### PR TITLE
typechecker: Ensure must allows throwsy expressions in non-throwsy contexts

### DIFF
--- a/bootstrap/stage0/codegen.cpp
+++ b/bootstrap/stage0/codegen.cpp
@@ -58,7 +58,7 @@ if (__jakt_enum_value == false) {
 return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 else if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_615; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_616; {
 JaktInternal::Tuple<ByteString,ByteString> const break_stmt_continue_stmt_ = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<ByteString,ByteString>,ErrorOr<ByteString>> {
 auto __jakt_enum_value = (((*this).directly_inside_match));
@@ -77,10 +77,10 @@ VERIFY_NOT_REACHED();
 ByteString const break_stmt = ((break_stmt_continue_stmt_).template get<0>());
 ByteString const continue_stmt = ((break_stmt_continue_stmt_).template get<1>());
 
-__jakt_var_615 = __jakt_format((StringView::from_string_literal("if (_jakt_value.is_loop_break())\n        {};\n    if (_jakt_value.is_loop_continue())\n        {};\n    "sv)),break_stmt,continue_stmt); goto __jakt_label_524;
+__jakt_var_616 = __jakt_format((StringView::from_string_literal("if (_jakt_value.is_loop_break())\n        {};\n    if (_jakt_value.is_loop_continue())\n        {};\n    "sv)),break_stmt,continue_stmt); goto __jakt_label_524;
 
 }
-__jakt_label_524:; __jakt_var_615.release_value(); }));
+__jakt_label_524:; __jakt_var_616.release_value(); }));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -1328,7 +1328,7 @@ return {};
 }
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function = ((*this).current_function);
 (((*this).current_function) = function);
-ScopeGuard __jakt_var_616([&] {
+ScopeGuard __jakt_var_617([&] {
 (((*this).current_function) = previous_function);
 });
 if ((((((((function)->linkage)).__jakt_init_index() == 1 /* External */) || ((((function)->type)).__jakt_init_index() == 2 /* ImplicitConstructor */)) || ((((function)->type)).__jakt_init_index() == 3 /* ImplicitEnumConstructor */)) || ((((function)->type)).__jakt_init_index() == 1 /* Destructor */))){
@@ -1900,7 +1900,7 @@ continue;
 }
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function = ((*this).current_function);
 (((*this).current_function) = function);
-ScopeGuard __jakt_var_617([&] {
+ScopeGuard __jakt_var_618([&] {
 (((*this).current_function) = previous_function);
 });
 if ((((((((function)->linkage)).__jakt_init_index() == 1 /* External */) || ((((function)->type)).__jakt_init_index() == 2 /* ImplicitConstructor */)) || ((((function)->type)).__jakt_init_index() == 3 /* ImplicitEnumConstructor */)) || ((((function)->type)).__jakt_init_index() == 1 /* Destructor */))){
@@ -1987,7 +1987,7 @@ continue;
 }
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function = ((*this).current_function);
 (((*this).current_function) = function);
-ScopeGuard __jakt_var_618([&] {
+ScopeGuard __jakt_var_619([&] {
 (((*this).current_function) = previous_function);
 });
 if ((((((((function)->linkage)).__jakt_init_index() == 1 /* External */) || ((((function)->type)).__jakt_init_index() == 2 /* ImplicitConstructor */)) || ((((function)->type)).__jakt_init_index() == 3 /* ImplicitEnumConstructor */)) || ((((function)->type)).__jakt_init_index() == 1 /* Destructor */))){
@@ -2060,7 +2060,7 @@ continue;
 }
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function = ((*this).current_function);
 (((*this).current_function) = function);
-ScopeGuard __jakt_var_619([&] {
+ScopeGuard __jakt_var_620([&] {
 (((*this).current_function) = previous_function);
 });
 if (((((function)->type)).__jakt_init_index() == 2 /* ImplicitConstructor */)){
@@ -2152,7 +2152,7 @@ ids::FunctionId function_id = (_magic_value.value());
 NonnullRefPtr<types::CheckedFunction> const function = ((((*this).program))->get_function(function_id));
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function = ((*this).current_function);
 (((*this).current_function) = function);
-ScopeGuard __jakt_var_620([&] {
+ScopeGuard __jakt_var_621([&] {
 (((*this).current_function) = previous_function);
 });
 if (((!(((((function)->type)).__jakt_init_index() == 2 /* ImplicitConstructor */))) && ((!(((((function)->type)).__jakt_init_index() == 3 /* ImplicitEnumConstructor */))) && ((!(((((function)->type)).__jakt_init_index() == 1 /* Destructor */))) && ((!(((function)->is_comptime))) && ((((((function)->generics))->params)).is_empty())))))){
@@ -2314,7 +2314,7 @@ continue;
 }
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function_id = ((*this).current_function);
 (((*this).current_function) = static_cast<JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>>>(function));
-ScopeGuard __jakt_var_621([&] {
+ScopeGuard __jakt_var_622([&] {
 (((*this).current_function) = previous_function_id);
 });
 if (((!(((((function)->type)).__jakt_init_index() == 2 /* ImplicitConstructor */))) && ((!(((((function)->type)).__jakt_init_index() == 1 /* Destructor */))) && ([](ByteString const& self, ByteString rhs) -> bool {{
@@ -2836,7 +2836,7 @@ JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_fun
 NonnullRefPtr<types::CheckedFunction> const function = ((((*this).program))->get_function(function_id));
 TRY((set_access_level(((function)->visibility))));
 (((*this).current_function) = static_cast<JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>>>(function));
-ScopeGuard __jakt_var_622([&] {
+ScopeGuard __jakt_var_623([&] {
 (((*this).current_function) = previous_function_id);
 });
 if (((((function)->type)).__jakt_init_index() == 1 /* Destructor */)){
@@ -3155,7 +3155,7 @@ ids::FunctionId function_id = (_magic_value.value());
 NonnullRefPtr<types::CheckedFunction> const function = ((((*this).program))->get_function(function_id));
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function_id = ((*this).current_function);
 (((*this).current_function) = static_cast<JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>>>(function));
-ScopeGuard __jakt_var_623([&] {
+ScopeGuard __jakt_var_624([&] {
 (((*this).current_function) = previous_function_id);
 });
 if ((!(((((function)->type)).__jakt_init_index() == 3 /* ImplicitEnumConstructor */)))){
@@ -3652,7 +3652,7 @@ return JaktInternal::ExplicitValue(DynamicArray<JaktInternal::Tuple<ByteString,B
 case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;ByteString const& name = __jakt_match_value.name;
 JaktInternal::DynamicArray<ids::VarId> const& own_fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>> __jakt_var_624; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>> __jakt_var_625; {
 JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> fields = DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>::create_with({});
 {
 JaktInternal::ArrayIterator<ids::VarId> _magic = ((own_fields).iterator());
@@ -3672,21 +3672,21 @@ if ((!(((common_field_names).contains(((variable)->name)))))){
 }
 }
 
-__jakt_var_624 = fields; goto __jakt_label_525;
+__jakt_var_625 = fields; goto __jakt_label_525;
 
 }
-__jakt_label_525:; __jakt_var_624.release_value(); }));
+__jakt_label_525:; __jakt_var_625.release_value(); }));
 };/*case end*/
 case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;ByteString const& name = __jakt_match_value.name;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>> __jakt_var_625; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>> __jakt_var_626; {
 JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> fields = DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>::create_with({});
 ((fields).push((Tuple{(ByteString::from_utf8_without_validation("value"sv)), TRY((((*this).codegen_type(type_id))))})));
-__jakt_var_625 = fields; goto __jakt_label_526;
+__jakt_var_626 = fields; goto __jakt_label_526;
 
 }
-__jakt_label_526:; __jakt_var_625.release_value(); }));
+__jakt_label_526:; __jakt_var_626.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -3725,29 +3725,6 @@ return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("By
 };/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_626; {
-types::CheckedStruct const struct_ = ((((*this).program))->get_struct(id));
-__jakt_var_626 = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,JaktInternal::Optional<ByteString>> {
-auto __jakt_enum_value = (((((struct_).record_type)).__jakt_init_index() == 1 /* Class */));
-if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("NonnullRefPtr"sv)));
-}
-else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(((((struct_).name_for_codegen())).as_name_for_use()));
-}
-VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}); goto __jakt_label_527;
-
-}
-__jakt_label_527:; __jakt_var_626.release_value(); }));
-};/*case end*/
-case 23 /* GenericResolvedType */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.GenericResolvedType;ids::StructId const& id = __jakt_match_value.id;
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_627; {
 types::CheckedStruct const struct_ = ((((*this).program))->get_struct(id));
 __jakt_var_627 = ({
@@ -3764,13 +3741,13 @@ VERIFY_NOT_REACHED();
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-}); goto __jakt_label_528;
+}); goto __jakt_label_527;
 
 }
-__jakt_label_528:; __jakt_var_627.release_value(); }));
+__jakt_label_527:; __jakt_var_627.release_value(); }));
 };/*case end*/
-case 24 /* Struct */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
+case 23 /* GenericResolvedType */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.GenericResolvedType;ids::StructId const& id = __jakt_match_value.id;
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_628; {
 types::CheckedStruct const struct_ = ((((*this).program))->get_struct(id));
 __jakt_var_628 = ({
@@ -3787,10 +3764,33 @@ VERIFY_NOT_REACHED();
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
+}); goto __jakt_label_528;
+
+}
+__jakt_label_528:; __jakt_var_628.release_value(); }));
+};/*case end*/
+case 24 /* Struct */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_629; {
+types::CheckedStruct const struct_ = ((((*this).program))->get_struct(id));
+__jakt_var_629 = ({
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,JaktInternal::Optional<ByteString>> {
+auto __jakt_enum_value = (((((struct_).record_type)).__jakt_init_index() == 1 /* Class */));
+if (__jakt_enum_value == true) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("NonnullRefPtr"sv)));
+}
+else if (__jakt_enum_value == false) {
+return JaktInternal::ExplicitValue(((((struct_).name_for_codegen())).as_name_for_use()));
+}
+VERIFY_NOT_REACHED();
+}());
+    if (_jakt_value.is_return())
+        return _jakt_value.release_return();
+    _jakt_value.release_value();
 }); goto __jakt_label_529;
 
 }
-__jakt_label_529:; __jakt_var_628.release_value(); }));
+__jakt_label_529:; __jakt_var_629.release_value(); }));
 };/*case end*/
 case 18 /* TypeVariable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeVariable;ByteString const& name = __jakt_match_value.name;
@@ -3798,29 +3798,6 @@ return JaktInternal::ExplicitValue(name);
 };/*case end*/
 case 25 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_629; {
-types::CheckedEnum const enum_ = ((((*this).program))->get_enum(id));
-__jakt_var_629 = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,JaktInternal::Optional<ByteString>> {
-auto __jakt_enum_value = (((enum_).is_boxed));
-if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("NonnullRefPtr"sv)));
-}
-else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(((enum_).name));
-}
-VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}); goto __jakt_label_530;
-
-}
-__jakt_label_530:; __jakt_var_629.release_value(); }));
-};/*case end*/
-case 21 /* GenericEnumInstance */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::EnumId const& id = __jakt_match_value.id;
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_630; {
 types::CheckedEnum const enum_ = ((((*this).program))->get_enum(id));
 __jakt_var_630 = ({
@@ -3837,10 +3814,33 @@ VERIFY_NOT_REACHED();
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
+}); goto __jakt_label_530;
+
+}
+__jakt_label_530:; __jakt_var_630.release_value(); }));
+};/*case end*/
+case 21 /* GenericEnumInstance */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::EnumId const& id = __jakt_match_value.id;
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_631; {
+types::CheckedEnum const enum_ = ((((*this).program))->get_enum(id));
+__jakt_var_631 = ({
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,JaktInternal::Optional<ByteString>> {
+auto __jakt_enum_value = (((enum_).is_boxed));
+if (__jakt_enum_value == true) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("NonnullRefPtr"sv)));
+}
+else if (__jakt_enum_value == false) {
+return JaktInternal::ExplicitValue(((enum_).name));
+}
+VERIFY_NOT_REACHED();
+}());
+    if (_jakt_value.is_return())
+        return _jakt_value.release_return();
+    _jakt_value.release_value();
 }); goto __jakt_label_531;
 
 }
-__jakt_label_531:; __jakt_var_630.release_value(); }));
+__jakt_label_531:; __jakt_var_631.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
@@ -4283,7 +4283,7 @@ return {};
 ErrorOr<void> codegen::CodeGenerator::codegen_expression(NonnullRefPtr<typename types::CheckedExpression> const expression,ByteStringBuilder& output) {
 {
 (((*this).generic_inferences) = ((expression)->common.init_common.generic_inferences).value_or_lazy_evaluated_optional([&] { return ((*this).generic_inferences); }));
-ScopeGuard __jakt_var_631([&] {
+ScopeGuard __jakt_var_632([&] {
 (((*this).generic_inferences) = JaktInternal::OptionalNone());
 });
 ({
@@ -4865,19 +4865,19 @@ return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("si
 };/*case end*/
 case 12 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_632; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_633; {
 ByteString const is_type = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<void>>{
 auto&& __jakt_match_variant = *((((*this).program))->get_type(type_id));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_633; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_634; {
 types::CheckedStruct const struct_ = ((((*this).program))->get_struct(id));
-__jakt_var_633 = ((TRY((((*this).codegen_namespace_qualifier(((struct_).scope_id),true,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()))))) + (((((struct_).name_for_codegen())).as_name_for_use()))); goto __jakt_label_533;
+__jakt_var_634 = ((TRY((((*this).codegen_namespace_qualifier(((struct_).scope_id),true,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()))))) + (((((struct_).name_for_codegen())).as_name_for_use()))); goto __jakt_label_533;
 
 }
-__jakt_label_533:; __jakt_var_633.release_value(); }));
+__jakt_label_533:; __jakt_var_634.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(TRY((((*this).codegen_type(type_id)))));
@@ -4889,17 +4889,17 @@ return JaktInternal::ExplicitValue(TRY((((*this).codegen_type(type_id)))));
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-__jakt_var_632 = (((((ByteString::from_utf8_without_validation("is<"sv))) + (is_type))) + ((ByteString::from_utf8_without_validation(">("sv)))); goto __jakt_label_532;
+__jakt_var_633 = (((((ByteString::from_utf8_without_validation("is<"sv))) + (is_type))) + ((ByteString::from_utf8_without_validation(">("sv)))); goto __jakt_label_532;
 
 }
-__jakt_label_532:; __jakt_var_632.release_value(); }));
+__jakt_label_532:; __jakt_var_633.release_value(); }));
 };/*case end*/
 case 15 /* IsNone */: {
 return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("!"sv)));
 };/*case end*/
 case 11 /* TypeCast */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeCast;types::CheckedTypeCast const& cast = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_634; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_635; {
 ids::TypeId final_type_id = ((cast).type_id());
 NonnullRefPtr<typename types::Type> const type = ((((*this).program))->get_type(final_type_id));
 ByteString const cast_type = ({
@@ -4907,7 +4907,7 @@ ByteString const cast_type = ({
 auto&& __jakt_match_variant = cast;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Fallible */: {
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_635; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_636; {
 ids::TypeId const type_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::TypeId, ErrorOr<void>>{
 auto&& __jakt_match_variant = *type;
@@ -4952,13 +4952,13 @@ else if (((((*this).program))->is_floating(type_id))){
 (final_type_id = type_id);
 (cast_type = (ByteString::from_utf8_without_validation("fallible_float_cast"sv)));
 }
-__jakt_var_635 = cast_type; goto __jakt_label_535;
+__jakt_var_636 = cast_type; goto __jakt_label_535;
 
 }
-__jakt_label_535:; __jakt_var_635.release_value(); }));
+__jakt_label_535:; __jakt_var_636.release_value(); }));
 };/*case end*/
 case 1 /* Infallible */: {
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_636; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_637; {
 ByteString cast_type = (ByteString::from_utf8_without_validation("verify_cast"sv));
 if (((((expr)->type())).equals(types::unknown_type_id()))){
 (cast_type = (ByteString::from_utf8_without_validation("assert_type"sv)));
@@ -4989,10 +4989,10 @@ ids::TypeId const inner = (type)->as.RawPtr.value;
 else if ((((((((*this).program))->is_integer(((expr)->type()))) && ((((*this).program))->is_floating(type_id))) || (((((*this).program))->is_floating(((expr)->type()))) && ((((*this).program))->is_integer(type_id)))) || (((((*this).program))->is_floating(((expr)->type()))) && ((((*this).program))->is_floating(type_id))))){
 (cast_type = (ByteString::from_utf8_without_validation("infallible_float_cast"sv)));
 }
-__jakt_var_636 = cast_type; goto __jakt_label_536;
+__jakt_var_637 = cast_type; goto __jakt_label_536;
 
 }
-__jakt_label_536:; __jakt_var_636.release_value(); }));
+__jakt_label_536:; __jakt_var_637.release_value(); }));
 };/*case end*/
 case 2 /* Identity */: {
 return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("static_cast"sv)));
@@ -5004,10 +5004,10 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-__jakt_var_634 = ((((((cast_type) + ((ByteString::from_utf8_without_validation("<"sv))))) + (TRY((((*this).codegen_type(final_type_id))))))) + ((ByteString::from_utf8_without_validation(">("sv)))); goto __jakt_label_534;
+__jakt_var_635 = ((((((cast_type) + ((ByteString::from_utf8_without_validation("<"sv))))) + (TRY((((*this).codegen_type(final_type_id))))))) + ((ByteString::from_utf8_without_validation(">("sv)))); goto __jakt_label_534;
 
 }
-__jakt_label_534:; __jakt_var_634.release_value(); }));
+__jakt_label_534:; __jakt_var_635.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
@@ -5641,7 +5641,7 @@ VERIFY_NOT_REACHED();
 });
 codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state);
 (((*this).control_flow_state) = ((last_control_flow).enter_function()));
-ScopeGuard __jakt_var_637([&] {
+ScopeGuard __jakt_var_638([&] {
 (((*this).control_flow_state) = last_control_flow);
 });
 ((((output))).append(__jakt_format((StringView::from_string_literal("[{}]({}) -> {} "sv)),utility::join(generated_captures,(ByteString::from_utf8_without_validation(", "sv))),utility::join(generated_params,(ByteString::from_utf8_without_validation(", "sv))),return_type)));
@@ -5649,7 +5649,7 @@ if (((pseudo_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const function = ((((*this).program))->get_function((pseudo_function_id.value())));
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function = ((*this).current_function);
 (((*this).current_function) = function);
-ScopeGuard __jakt_var_638([&] {
+ScopeGuard __jakt_var_639([&] {
 (((*this).current_function) = previous_function);
 });
 TRY((((*this).codegen_lambda_block(can_throw,block,return_type_id,((((output))))))));
@@ -5710,7 +5710,7 @@ codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state)
 (((((*this).control_flow_state)).directly_inside_match) = false);
 (((((*this).control_flow_state)).indirectly_inside_match) = false);
 (((((*this).control_flow_state)).passes_through_try) = true);
-ScopeGuard __jakt_var_639([&] {
+ScopeGuard __jakt_var_640([&] {
 {
 (((*this).control_flow_state) = last_control_flow);
 }
@@ -5790,7 +5790,7 @@ codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state)
 (((((*this).control_flow_state)).directly_inside_match) = false);
 (((((*this).control_flow_state)).indirectly_inside_match) = false);
 (((((*this).control_flow_state)).passes_through_try) = true);
-ScopeGuard __jakt_var_640([&] {
+ScopeGuard __jakt_var_641([&] {
 {
 (((*this).control_flow_state) = last_control_flow);
 }
@@ -8447,7 +8447,7 @@ return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("vo
 };/*case end*/
 case 32 /* Const */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Const;types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_641; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_642; {
 NonnullRefPtr<interpreter::Interpreter> interpreter = interpreter::Interpreter::create(((*this).compiler),((*this).program),types::TypecheckFunctions::__jakt_create([](parser::ParsedBlock parsed_block, ids::ScopeId parent_scope_id, types::SafetyMode safety_mode, JaktInternal::Optional<ids::TypeId> yield_type_hint, JaktInternal::Optional<ids::FunctionId> containing_function_id) -> ErrorOr<types::CheckedBlock> {{
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Cannot typecheck a const block"sv)));
 }
@@ -8460,10 +8460,10 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Canno
 NonnullRefPtr<typename types::CheckedExpression> const expr = TRY((interpreter::value_to_checked_expression(value,interpreter)));
 ByteStringBuilder builder = ByteStringBuilder::create();
 TRY((((*this).codegen_expression(expr,((builder))))));
-__jakt_var_641 = ((builder).to_string()); goto __jakt_label_537;
+__jakt_var_642 = ((builder).to_string()); goto __jakt_label_537;
 
 }
-__jakt_label_537:; __jakt_var_641.release_value(); }));
+__jakt_label_537:; __jakt_var_642.release_value(); }));
 };/*case end*/
 case 26 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;ids::TypeId const& type_id = __jakt_match_value.value;
@@ -8503,9 +8503,9 @@ return JaktInternal::ExplicitValue(TRY((((*this).codegen_generic_type_instance(i
 };/*case end*/
 case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_642; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_643; {
 JaktInternal::Optional<ids::TypeId> const implements_type = ((((((*this).program))->get_struct(id))).implements_type);
-__jakt_var_642 = ({
+__jakt_var_643 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
 auto __jakt_enum_value = (((implements_type).has_value()));
 if (__jakt_enum_value == true) {
@@ -8522,7 +8522,7 @@ VERIFY_NOT_REACHED();
 }); goto __jakt_label_538;
 
 }
-__jakt_label_538:; __jakt_var_642.release_value(); }));
+__jakt_label_538:; __jakt_var_643.release_value(); }));
 };/*case end*/
 case 25 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -8531,13 +8531,13 @@ return JaktInternal::ExplicitValue(TRY((((*this).codegen_enum_type(id,as_namespa
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::EnumId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_643; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_644; {
 ByteStringBuilder builder = ByteStringBuilder::create();
 TRY((((*this).codegen_generic_enum_instance(id,args,as_namespace,((builder))))));
-__jakt_var_643 = ((builder).to_string()); goto __jakt_label_539;
+__jakt_var_644 = ((builder).to_string()); goto __jakt_label_539;
 
 }
-__jakt_label_539:; __jakt_var_643.release_value(); }));
+__jakt_label_539:; __jakt_var_644.release_value(); }));
 };/*case end*/
 case 18 /* TypeVariable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeVariable;ByteString const& name = __jakt_match_value.name;
@@ -8547,7 +8547,7 @@ case 30 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<ids::TypeId> const& params = __jakt_match_value.params;
 bool const& can_throw = __jakt_match_value.can_throw;
 ids::TypeId const& return_type_id = __jakt_match_value.return_type_id;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_644; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_645; {
 ByteStringBuilder builder = ByteStringBuilder::create();
 ((builder).append((StringView::from_string_literal("Function<"sv))));
 if (can_throw){
@@ -8582,10 +8582,10 @@ else {
 }
 
 ((builder).append((StringView::from_string_literal(")>"sv))));
-__jakt_var_644 = ((builder).to_string()); goto __jakt_label_540;
+__jakt_var_645 = ((builder).to_string()); goto __jakt_label_540;
 
 }
-__jakt_label_540:; __jakt_var_644.release_value(); }));
+__jakt_label_540:; __jakt_var_645.release_value(); }));
 };/*case end*/
 case 22 /* GenericTraitInstance */: {
 {
@@ -8593,11 +8593,11 @@ utility::panic((ByteString::from_utf8_without_validation("Generic trait instance
 }
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_645; {
-__jakt_var_645 = (ByteString::from_utf8_without_validation("auto"sv)); goto __jakt_label_541;
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_646; {
+__jakt_var_646 = (ByteString::from_utf8_without_validation("auto"sv)); goto __jakt_label_541;
 
 }
-__jakt_label_541:; __jakt_var_645.release_value(); }));
+__jakt_label_541:; __jakt_var_646.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -8810,7 +8810,7 @@ while (((current_scope_id).has_value())){
 NonnullRefPtr<types::Scope> const scope = ((((*this).program))->get_scope((current_scope_id.value())));
 JaktInternal::Optional<ByteString> const name = ((((scope)->namespace_name_for_codegen())).map([&](auto& _value) { return _value.as_name_for_use(); }));
 bool const is_constructor_call = (first && ((possible_constructor_name) == (name)));
-ScopeGuard __jakt_var_646([&] {
+ScopeGuard __jakt_var_647([&] {
 {
 if (((name).has_value())){
 (first = false);
@@ -8830,7 +8830,7 @@ if (__jakt_enum_value == false) {
 return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 else if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_647; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_648; {
 JaktInternal::Optional<JaktInternal::DynamicArray<types::CheckedGenericParameter>> const parameters = ((((((*this).program))->get_type((((scope)->relevant_type_id).value()))))->generic_parameters(((*this).program)));
 ByteStringBuilder builder = ByteStringBuilder::create();
 if (((parameters).has_value())){
@@ -8870,10 +8870,10 @@ else {
 }
 }
 }
-__jakt_var_647 = ((builder).to_string()); goto __jakt_label_542;
+__jakt_var_648 = ((builder).to_string()); goto __jakt_label_542;
 
 }
-__jakt_label_542:; __jakt_var_647.release_value(); }));
+__jakt_label_542:; __jakt_var_648.release_value(); }));
 }
 VERIFY_NOT_REACHED();
 }());

--- a/bootstrap/stage0/formatter.cpp
+++ b/bootstrap/stage0/formatter.cpp
@@ -466,7 +466,7 @@ ErrorOr<formatter::Stage0> formatter::Stage0::create(NonnullRefPtr<compiler::Com
 {
 JaktInternal::DynamicArray<u8> const old_file_contents = ((compiler)->current_file_contents);
 (((compiler)->current_file_contents) = source);
-ScopeGuard __jakt_var_648([&] {
+ScopeGuard __jakt_var_649([&] {
 {
 (((compiler)->current_file_contents) = old_file_contents);
 }
@@ -622,36 +622,36 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 98 /* Struct */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_649; {
-TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 87 /* Namespace */))),false,static_cast<size_t>(0ULL),true)))));
-JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
-if ((((token).__jakt_init_index() == 87 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */))))){
-((trailing_trivia).push(static_cast<u8>(u8' ')));
-}
-__jakt_var_649 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_543;
-
-}
-__jakt_label_543:; __jakt_var_649.release_value(); }));
-};/*case end*/
-case 65 /* Class */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_650; {
 TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 87 /* Namespace */))),false,static_cast<size_t>(0ULL),true)))));
 JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
 if ((((token).__jakt_init_index() == 87 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */))))){
 ((trailing_trivia).push(static_cast<u8>(u8' ')));
 }
-__jakt_var_650 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_544;
+__jakt_var_650 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_543;
 
 }
-__jakt_label_544:; __jakt_var_650.release_value(); }));
+__jakt_label_543:; __jakt_var_650.release_value(); }));
+};/*case end*/
+case 65 /* Class */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_651; {
+TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 87 /* Namespace */))),false,static_cast<size_t>(0ULL),true)))));
+JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
+if ((((token).__jakt_init_index() == 87 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */))))){
+((trailing_trivia).push(static_cast<u8>(u8' ')));
+}
+__jakt_var_651 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_544;
+
+}
+__jakt_label_544:; __jakt_var_651.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_651; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_652; {
 ((*this).pop_state());
-__jakt_var_651 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_545;
+__jakt_var_652 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_545;
 
 }
-__jakt_label_545:; __jakt_var_651.release_value(); }));
+__jakt_label_545:; __jakt_var_652.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -670,7 +670,7 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 72 /* Extern */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_652; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_653; {
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
@@ -699,185 +699,185 @@ return JaktInternal::ExplicitValue<void>();
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-__jakt_var_652 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_546;
+__jakt_var_653 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_546;
 
 }
-__jakt_label_546:; __jakt_var_652.release_value(); }));
+__jakt_label_546:; __jakt_var_653.release_value(); }));
 };/*case end*/
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_653; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_654; {
 if ((((name) == ((ByteString::from_utf8_without_validation("type"sv)))) && ((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 3 /* Identifier */))){
 TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),true,false,static_cast<size_t>(0ULL),is_extern)))));
 return ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
 }
-__jakt_var_653 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_547;
+__jakt_var_654 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_547;
 
 }
-__jakt_label_547:; __jakt_var_653.release_value(); }));
+__jakt_label_547:; __jakt_var_654.release_value(); }));
 };/*case end*/
 case 71 /* Enum */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_654; {
-TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 87 /* Namespace */))),false,static_cast<size_t>(0ULL),is_extern)))));
-JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
-if ((((token).__jakt_init_index() == 87 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */))))){
-((trailing_trivia).push(static_cast<u8>(u8' ')));
-}
-__jakt_var_654 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_548;
-
-}
-__jakt_label_548:; __jakt_var_654.release_value(); }));
-};/*case end*/
-case 65 /* Class */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_655; {
 TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 87 /* Namespace */))),false,static_cast<size_t>(0ULL),is_extern)))));
 JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
 if ((((token).__jakt_init_index() == 87 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */))))){
 ((trailing_trivia).push(static_cast<u8>(u8' ')));
 }
-__jakt_var_655 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_549;
+__jakt_var_655 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_548;
 
 }
-__jakt_label_549:; __jakt_var_655.release_value(); }));
+__jakt_label_548:; __jakt_var_655.release_value(); }));
 };/*case end*/
-case 98 /* Struct */: {
+case 65 /* Class */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_656; {
 TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 87 /* Namespace */))),false,static_cast<size_t>(0ULL),is_extern)))));
 JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
 if ((((token).__jakt_init_index() == 87 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */))))){
 ((trailing_trivia).push(static_cast<u8>(u8' ')));
 }
-__jakt_var_656 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_550;
+__jakt_var_656 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_549;
 
 }
-__jakt_label_550:; __jakt_var_656.release_value(); }));
+__jakt_label_549:; __jakt_var_656.release_value(); }));
 };/*case end*/
-case 112 /* Trait */: {
+case 98 /* Struct */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_657; {
 TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 87 /* Namespace */))),false,static_cast<size_t>(0ULL),is_extern)))));
 JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
 if ((((token).__jakt_init_index() == 87 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */))))){
 ((trailing_trivia).push(static_cast<u8>(u8' ')));
 }
-__jakt_var_657 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_551;
+__jakt_var_657 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_550;
 
 }
-__jakt_label_551:; __jakt_var_657.release_value(); }));
+__jakt_label_550:; __jakt_var_657.release_value(); }));
 };/*case end*/
-case 75 /* Fn */: {
+case 112 /* Trait */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_658; {
 TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 87 /* Namespace */))),false,static_cast<size_t>(0ULL),is_extern)))));
 JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
 if ((((token).__jakt_init_index() == 87 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */))))){
 ((trailing_trivia).push(static_cast<u8>(u8' ')));
 }
-__jakt_var_658 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_552;
+__jakt_var_658 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_551;
 
 }
-__jakt_label_552:; __jakt_var_658.release_value(); }));
+__jakt_label_551:; __jakt_var_658.release_value(); }));
 };/*case end*/
-case 76 /* Comptime */: {
+case 75 /* Fn */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_659; {
 TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 87 /* Namespace */))),false,static_cast<size_t>(0ULL),is_extern)))));
 JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
 if ((((token).__jakt_init_index() == 87 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */))))){
 ((trailing_trivia).push(static_cast<u8>(u8' ')));
 }
-__jakt_var_659 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_553;
+__jakt_var_659 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_552;
 
 }
-__jakt_label_553:; __jakt_var_659.release_value(); }));
+__jakt_label_552:; __jakt_var_659.release_value(); }));
 };/*case end*/
-case 87 /* Namespace */: {
+case 76 /* Comptime */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_660; {
 TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 87 /* Namespace */))),false,static_cast<size_t>(0ULL),is_extern)))));
 JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
 if ((((token).__jakt_init_index() == 87 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */))))){
 ((trailing_trivia).push(static_cast<u8>(u8' ')));
 }
-__jakt_var_660 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_554;
+__jakt_var_660 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_553;
 
 }
-__jakt_label_554:; __jakt_var_660.release_value(); }));
+__jakt_label_553:; __jakt_var_660.release_value(); }));
+};/*case end*/
+case 87 /* Namespace */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_661; {
+TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 87 /* Namespace */))),false,static_cast<size_t>(0ULL),is_extern)))));
+JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
+if ((((token).__jakt_init_index() == 87 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */))))){
+((trailing_trivia).push(static_cast<u8>(u8' ')));
+}
+__jakt_var_661 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_554;
+
+}
+__jakt_label_554:; __jakt_var_661.release_value(); }));
 };/*case end*/
 case 11 /* LSquare */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_661; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_662; {
 TRY((((*this).replace_state(formatter::State::Toplevel(open_parens,open_curlies,JaktInternal::checked_add(open_squares,static_cast<size_t>(1ULL)),is_extern)))));
-__jakt_var_661 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_555;
+__jakt_var_662 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_555;
 
 }
-__jakt_label_555:; __jakt_var_661.release_value(); }));
+__jakt_label_555:; __jakt_var_662.release_value(); }));
 };/*case end*/
 case 12 /* RSquare */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_662; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_663; {
 if (((open_squares) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::Toplevel(open_parens,open_curlies,JaktInternal::checked_sub(open_squares,static_cast<size_t>(1ULL)),is_extern)))));
-__jakt_var_662 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_556;
+__jakt_var_663 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_556;
 
 }
-__jakt_label_556:; __jakt_var_662.release_value(); }));
+__jakt_label_556:; __jakt_var_663.release_value(); }));
 };/*case end*/
 case 7 /* LParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_663; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_664; {
 TRY((((*this).replace_state(formatter::State::Toplevel(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,is_extern)))));
-__jakt_var_663 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_557;
+__jakt_var_664 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_557;
 
 }
-__jakt_label_557:; __jakt_var_663.release_value(); }));
+__jakt_label_557:; __jakt_var_664.release_value(); }));
 };/*case end*/
 case 8 /* RParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_664; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_665; {
 if (((open_parens) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::Toplevel(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,is_extern)))));
-__jakt_var_664 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_558;
+__jakt_var_665 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_558;
 
 }
-__jakt_label_558:; __jakt_var_664.release_value(); }));
+__jakt_label_558:; __jakt_var_665.release_value(); }));
 };/*case end*/
 case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_665; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_666; {
 TRY((((*this).replace_state(formatter::State::Toplevel(open_parens,JaktInternal::checked_add(open_curlies,static_cast<size_t>(1ULL)),open_squares,is_extern)))));
-__jakt_var_665 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_559;
+__jakt_var_666 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_559;
 
 }
-__jakt_label_559:; __jakt_var_665.release_value(); }));
+__jakt_label_559:; __jakt_var_666.release_value(); }));
 };/*case end*/
 case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_666; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_667; {
 if (((open_curlies) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)) -= (static_cast<size_t>(1ULL)));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::Toplevel(open_parens,JaktInternal::checked_sub(open_curlies,static_cast<size_t>(1ULL)),open_squares,is_extern)))));
-__jakt_var_666 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_560;
+__jakt_var_667 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_560;
 
 }
-__jakt_label_560:; __jakt_var_666.release_value(); }));
+__jakt_label_560:; __jakt_var_667.release_value(); }));
 };/*case end*/
 case 5 /* Colon */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_667; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_668; {
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_667 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_561;
+__jakt_var_668 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_561;
 
 }
-__jakt_label_561:; __jakt_var_667.release_value(); }));
+__jakt_label_561:; __jakt_var_668.release_value(); }));
 };/*case end*/
 case 78 /* Import */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_668; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_669; {
 TRY((((*this).push_state(formatter::State::Import(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 72 /* Extern */))))));
-__jakt_var_668 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_562;
+__jakt_var_669 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_562;
 
 }
-__jakt_label_562:; __jakt_var_668.release_value(); }));
+__jakt_label_562:; __jakt_var_669.release_value(); }));
 };/*case end*/
 case 92 /* Public */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
@@ -898,23 +898,23 @@ case 104 /* Unsafe */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
 };/*case end*/
 case 96 /* Restricted */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_669; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_670; {
 TRY((((*this).push_state(formatter::State::RestrictionList()))));
-__jakt_var_669 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_563;
+__jakt_var_670 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_563;
 
 }
-__jakt_label_563:; __jakt_var_669.release_value(); }));
+__jakt_label_563:; __jakt_var_670.release_value(); }));
 };/*case end*/
 case 52 /* Comma */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
 };/*case end*/
 case 16 /* Equal */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_670; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_671; {
 TRY((((*this).push_state(formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false,formatter::ExpressionMode::AtExpressionStart(),static_cast<size_t>(0ULL))))));
-__jakt_var_670 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_564;
+__jakt_var_671 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_564;
 
 }
-__jakt_label_564:; __jakt_var_670.release_value(); }));
+__jakt_label_564:; __jakt_var_671.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))));
@@ -942,7 +942,7 @@ case 61 /* As */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
 };/*case end*/
 case 3 /* Identifier */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_671; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_672; {
 if (((!(is_extern)) && ((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 7 /* LParen */))){
 return ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
 }
@@ -952,16 +952,16 @@ return ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicA
 if (((!(is_extern)) && ((!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 9 /* LCurly */))) && (!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 61 /* As */)))))){
 ((*this).pop_state());
 }
-__jakt_var_671 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_565;
+__jakt_var_672 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_565;
 
 }
-__jakt_label_565:; __jakt_var_671.release_value(); }));
+__jakt_label_565:; __jakt_var_672.release_value(); }));
 };/*case end*/
 case 7 /* LParen */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))));
 };/*case end*/
 case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_672; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_673; {
 if (is_extern){
 TRY((((*this).push_state(formatter::State::Toplevel(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),is_extern)))));
 }
@@ -969,22 +969,22 @@ else {
 TRY((((*this).push_state(formatter::State::ImportList(true)))));
 }
 
-__jakt_var_672 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_566;
+__jakt_var_673 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_566;
 
 }
-__jakt_label_566:; __jakt_var_672.release_value(); }));
+__jakt_label_566:; __jakt_var_673.release_value(); }));
 };/*case end*/
 case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_673; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_674; {
 ((*this).pop_state());
-__jakt_var_673 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_567;
+__jakt_var_674 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_567;
 
 }
-__jakt_label_567:; __jakt_var_673.release_value(); }));
+__jakt_label_567:; __jakt_var_674.release_value(); }));
 };/*case end*/
 case 52 /* Comma */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_674; {
-__jakt_var_674 = ((*this).formatted_token(token,({
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_675; {
+__jakt_var_675 = ((*this).formatted_token(token,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -1003,7 +1003,7 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
 }),DynamicArray<u8>::create_with({}))); goto __jakt_label_568;
 
 }
-__jakt_label_568:; __jakt_var_674.release_value(); }));
+__jakt_label_568:; __jakt_var_675.release_value(); }));
 };/*case end*/
 case 6 /* ColonColon */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))));
@@ -1028,12 +1028,12 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* RParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_675; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_676; {
 ((*this).pop_state());
-__jakt_var_675 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_569;
+__jakt_var_676 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_569;
 
 }
-__jakt_label_569:; __jakt_var_675.release_value(); }));
+__jakt_label_569:; __jakt_var_676.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))));
@@ -1062,12 +1062,12 @@ return TRY((((*this).next_impl(true))));
 }
 };/*case end*/
 case 52 /* Comma */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_676; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_677; {
 TRY((((*this).replace_state(formatter::State::ImportList(true)))));
-__jakt_var_676 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_570;
+__jakt_var_677 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_570;
 
 }
-__jakt_label_570:; __jakt_var_676.release_value(); }));
+__jakt_label_570:; __jakt_var_677.release_value(); }));
 };/*case end*/
 case 55 /* Eol */: {
 {
@@ -1075,7 +1075,7 @@ return TRY((((*this).next())));
 }
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_677; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_678; {
 JaktInternal::DynamicArray<ByteString> collection = DynamicArray<ByteString>::create_with({});
 ByteString output = (ByteString::from_utf8_without_validation(""sv));
 utility::Span const span = ((token).span());
@@ -1189,10 +1189,10 @@ else {
 
 ((*this).pop_state());
 ((((*this).index)--));
-__jakt_var_677 = ((*this).formatted_token(lexer::Token::Identifier(output,span),DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_571;
+__jakt_var_678 = ((*this).formatted_token(lexer::Token::Identifier(output,span),DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_571;
 
 }
-__jakt_label_571:; __jakt_var_677.release_value(); }));
+__jakt_label_571:; __jakt_var_678.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -1211,17 +1211,17 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 28 /* LessThan */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_678; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_679; {
 if (accept_generics){
 TRY((((*this).replace_state(formatter::State::EntityDeclaration(entity,accept_generics,true,JaktInternal::checked_add(generic_nesting,static_cast<size_t>(1ULL)),is_extern)))));
 }
-__jakt_var_678 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_572;
+__jakt_var_679 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_572;
 
 }
-__jakt_label_572:; __jakt_var_678.release_value(); }));
+__jakt_label_572:; __jakt_var_679.release_value(); }));
 };/*case end*/
 case 26 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_679; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_680; {
 if (accept_generics){
 if ([](size_t const& self, size_t rhs) -> bool {{
 return (((infallible_integer_cast<u8>(([](size_t const& self, size_t rhs) -> jakt__prelude__operators::Ordering {{
@@ -1239,13 +1239,13 @@ TRY((((*this).replace_state(formatter::State::EntityDefinition(entity,is_extern)
 }
 
 }
-__jakt_var_679 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_573;
+__jakt_var_680 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_573;
 
 }
-__jakt_label_573:; __jakt_var_679.release_value(); }));
+__jakt_label_573:; __jakt_var_680.release_value(); }));
 };/*case end*/
 case 3 /* Identifier */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_680; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_681; {
 if ((((generic_nesting) == (static_cast<size_t>(0ULL))) && ((!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */))) && (!(has_generics))))){
 TRY((((*this).replace_state(formatter::State::EntityDefinition(entity,is_extern)))));
 }
@@ -1253,29 +1253,29 @@ if (((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 110 /* Imple
 TRY((((*this).push_state(formatter::State::Implements()))));
 return ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
 }
-__jakt_var_680 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_574;
+__jakt_var_681 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_574;
 
 }
-__jakt_label_574:; __jakt_var_680.release_value(); }));
+__jakt_label_574:; __jakt_var_681.release_value(); }));
 };/*case end*/
 case 52 /* Comma */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
 };/*case end*/
 case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_681; {
-((*this).pop_state());
-__jakt_var_681 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_575;
-
-}
-__jakt_label_575:; __jakt_var_681.release_value(); }));
-};/*case end*/
-case 55 /* Eol */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_682; {
 ((*this).pop_state());
-__jakt_var_682 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_576;
+__jakt_var_682 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_575;
 
 }
-__jakt_label_576:; __jakt_var_682.release_value(); }));
+__jakt_label_575:; __jakt_var_682.release_value(); }));
+};/*case end*/
+case 55 /* Eol */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_683; {
+((*this).pop_state());
+__jakt_var_683 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_576;
+
+}
+__jakt_label_576:; __jakt_var_683.release_value(); }));
 };/*case end*/
 case 92 /* Public */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
@@ -1290,12 +1290,12 @@ case 90 /* Override */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
 };/*case end*/
 case 96 /* Restricted */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_683; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_684; {
 TRY((((*this).push_state(formatter::State::RestrictionList()))));
-__jakt_var_683 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_577;
+__jakt_var_684 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_577;
 
 }
-__jakt_label_577:; __jakt_var_683.release_value(); }));
+__jakt_label_577:; __jakt_var_684.release_value(); }));
 };/*case end*/
 case 111 /* Requires */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))));
@@ -1325,9 +1325,9 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_684; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_685; {
 ((*this).pop_state());
-__jakt_var_684 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),({
+__jakt_var_685 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -1349,12 +1349,12 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
 }))); goto __jakt_label_578;
 
 }
-__jakt_label_578:; __jakt_var_684.release_value(); }));
+__jakt_label_578:; __jakt_var_685.release_value(); }));
 };/*case end*/
 case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_685; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_686; {
 TRY((((*this).push_state(formatter::State::Toplevel(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),is_extern)))));
-__jakt_var_685 = ((*this).formatted_token(token,({
+__jakt_var_686 = ((*this).formatted_token(token,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -1376,7 +1376,7 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
 }),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_579;
 
 }
-__jakt_label_579:; __jakt_var_685.release_value(); }));
+__jakt_label_579:; __jakt_var_686.release_value(); }));
 };/*case end*/
 case 5 /* Colon */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
@@ -1404,9 +1404,9 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_686; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_687; {
 ((*this).pop_state());
-__jakt_var_686 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),({
+__jakt_var_687 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -1428,12 +1428,12 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
 }))); goto __jakt_label_580;
 
 }
-__jakt_label_580:; __jakt_var_686.release_value(); }));
+__jakt_label_580:; __jakt_var_687.release_value(); }));
 };/*case end*/
 case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_687; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_688; {
 TRY((((*this).push_state(formatter::State::Toplevel(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),is_extern)))));
-__jakt_var_687 = ((*this).formatted_token(token,({
+__jakt_var_688 = ((*this).formatted_token(token,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -1455,7 +1455,7 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
 }),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_581;
 
 }
-__jakt_label_581:; __jakt_var_687.release_value(); }));
+__jakt_label_581:; __jakt_var_688.release_value(); }));
 };/*case end*/
 case 5 /* Colon */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
@@ -1483,9 +1483,9 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_688; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_689; {
 ((*this).pop_state());
-__jakt_var_688 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),({
+__jakt_var_689 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -1507,12 +1507,12 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
 }))); goto __jakt_label_582;
 
 }
-__jakt_label_582:; __jakt_var_688.release_value(); }));
+__jakt_label_582:; __jakt_var_689.release_value(); }));
 };/*case end*/
 case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_689; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_690; {
 TRY((((*this).push_state(formatter::State::Toplevel(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),is_extern)))));
-__jakt_var_689 = ((*this).formatted_token(token,({
+__jakt_var_690 = ((*this).formatted_token(token,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -1534,7 +1534,7 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
 }),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_583;
 
 }
-__jakt_label_583:; __jakt_var_689.release_value(); }));
+__jakt_label_583:; __jakt_var_690.release_value(); }));
 };/*case end*/
 case 5 /* Colon */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
@@ -1564,7 +1564,7 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 57 /* FatArrow */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_690; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_691; {
 bool const next_is_eol = ((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 55 /* Eol */);
 TRY((((*this).replace_state(formatter::State::EntityDefinition(formatter::Entity::Function(true,next_is_eol),is_extern)))));
 if (next_is_eol){
@@ -1580,26 +1580,26 @@ if (next_is_eol){
 (eols_allowed = static_cast<size_t>(1ULL));
 }
 TRY((((*this).push_state(formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),eols_allowed,false,formatter::ExpressionMode::BeforeExpressions(),static_cast<size_t>(0ULL))))));
-__jakt_var_690 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_584;
+__jakt_var_691 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_584;
 
 }
-__jakt_label_584:; __jakt_var_690.release_value(); }));
+__jakt_label_584:; __jakt_var_691.release_value(); }));
 };/*case end*/
 case 58 /* Arrow */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_691; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_692; {
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_691 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_585;
+__jakt_var_692 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_585;
 
 }
-__jakt_label_585:; __jakt_var_691.release_value(); }));
+__jakt_label_585:; __jakt_var_692.release_value(); }));
 };/*case end*/
 case 7 /* LParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_692; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_693; {
 TRY((((*this).push_state(formatter::State::ParameterList(static_cast<size_t>(0ULL))))));
-__jakt_var_692 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_586;
+__jakt_var_693 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_586;
 
 }
-__jakt_label_586:; __jakt_var_692.release_value(); }));
+__jakt_label_586:; __jakt_var_693.release_value(); }));
 };/*case end*/
 case 8 /* RParen */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,({
@@ -1621,23 +1621,23 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
 }),DynamicArray<u8>::create_with({}))));
 };/*case end*/
 case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_693; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_694; {
 TRY((((*this).push_state(formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),JaktInternal::OptionalNone(),false,formatter::ExpressionMode::OutsideExpression(),static_cast<size_t>(0ULL))))));
-__jakt_var_693 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_587;
+__jakt_var_694 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_587;
 
 }
-__jakt_label_587:; __jakt_var_693.release_value(); }));
+__jakt_label_587:; __jakt_var_694.release_value(); }));
 };/*case end*/
 case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_694; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_695; {
 ((*this).pop_state());
-__jakt_var_694 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_588;
+__jakt_var_695 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_588;
 
 }
-__jakt_label_588:; __jakt_var_694.release_value(); }));
+__jakt_label_588:; __jakt_var_695.release_value(); }));
 };/*case end*/
 case 55 /* Eol */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_695; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_696; {
 if ((!(arrow))){
 ((*this).pop_state());
 return ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
@@ -1670,10 +1670,10 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 ((((((*this).dedents_to_skip))[JaktInternal::checked_sub(((((*this).dedents_to_skip)).size()),static_cast<size_t>(1ULL))])) -= (static_cast<size_t>(1ULL)));
 }
 }
-__jakt_var_695 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_589;
+__jakt_var_696 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_589;
 
 }
-__jakt_label_589:; __jakt_var_695.release_value(); }));
+__jakt_label_589:; __jakt_var_696.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))));
@@ -1703,85 +1703,85 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 82 /* Let */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_696; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_697; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
 TRY((((*this).push_state(formatter::State::VariableDeclaration(static_cast<size_t>(0ULL))))));
-__jakt_var_696 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_590;
+__jakt_var_697 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_590;
 
 }
-__jakt_label_590:; __jakt_var_696.release_value(); }));
+__jakt_label_590:; __jakt_var_697.release_value(); }));
 };/*case end*/
 case 86 /* Mut */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_697; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_698; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 if (((expression_mode).__jakt_init_index() == 0 /* OutsideExpression */)){
 TRY((((*this).push_state(formatter::State::VariableDeclaration(static_cast<size_t>(0ULL))))));
 }
-__jakt_var_697 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_591;
+__jakt_var_698 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_591;
 
 }
-__jakt_label_591:; __jakt_var_697.release_value(); }));
+__jakt_label_591:; __jakt_var_698.release_value(); }));
 };/*case end*/
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_698; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_699; {
 size_t const added_indent = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_699; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_699 = indent; goto __jakt_label_593;
-
-}
-__jakt_label_593:; __jakt_var_699.release_value(); }));
-};/*case end*/
-case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_700; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_700 = indent; goto __jakt_label_594;
+__jakt_var_700 = indent; goto __jakt_label_593;
 
 }
-__jakt_label_594:; __jakt_var_700.release_value(); }));
+__jakt_label_593:; __jakt_var_700.release_value(); }));
 };/*case end*/
-case 107 /* While */: {
+case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_701; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_701 = indent; goto __jakt_label_595;
+__jakt_var_701 = indent; goto __jakt_label_594;
 
 }
-__jakt_label_595:; __jakt_var_701.release_value(); }));
+__jakt_label_594:; __jakt_var_701.release_value(); }));
 };/*case end*/
-case 77 /* If */: {
+case 107 /* While */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_702; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_702 = indent; goto __jakt_label_596;
+__jakt_var_702 = indent; goto __jakt_label_595;
 
 }
-__jakt_label_596:; __jakt_var_702.release_value(); }));
+__jakt_label_595:; __jakt_var_702.release_value(); }));
 };/*case end*/
-case 109 /* Guard */: {
+case 77 /* If */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_703; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_703 = indent; goto __jakt_label_597;
+__jakt_var_703 = indent; goto __jakt_label_596;
 
 }
-__jakt_label_597:; __jakt_var_703.release_value(); }));
+__jakt_label_596:; __jakt_var_703.release_value(); }));
+};/*case end*/
+case 109 /* Guard */: {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_704; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_704 = indent; goto __jakt_label_597;
+
+}
+__jakt_label_597:; __jakt_var_704.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
@@ -1795,71 +1795,71 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 });
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_add(dedents_on_open_curly,added_indent))))));
 ((((indent_change))) += ((infallible_integer_cast<i64>((added_indent)))));
-__jakt_var_698 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_592;
+__jakt_var_699 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_592;
 
 }
-__jakt_label_592:; __jakt_var_698.release_value(); }));
+__jakt_label_592:; __jakt_var_699.release_value(); }));
 };/*case end*/
 case 74 /* For */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_704; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_705; {
 size_t const added_indent = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_705; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_705 = indent; goto __jakt_label_599;
-
-}
-__jakt_label_599:; __jakt_var_705.release_value(); }));
-};/*case end*/
-case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_706; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_706 = indent; goto __jakt_label_600;
+__jakt_var_706 = indent; goto __jakt_label_599;
 
 }
-__jakt_label_600:; __jakt_var_706.release_value(); }));
+__jakt_label_599:; __jakt_var_706.release_value(); }));
 };/*case end*/
-case 107 /* While */: {
+case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_707; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_707 = indent; goto __jakt_label_601;
+__jakt_var_707 = indent; goto __jakt_label_600;
 
 }
-__jakt_label_601:; __jakt_var_707.release_value(); }));
+__jakt_label_600:; __jakt_var_707.release_value(); }));
 };/*case end*/
-case 77 /* If */: {
+case 107 /* While */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_708; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_708 = indent; goto __jakt_label_602;
+__jakt_var_708 = indent; goto __jakt_label_601;
 
 }
-__jakt_label_602:; __jakt_var_708.release_value(); }));
+__jakt_label_601:; __jakt_var_708.release_value(); }));
 };/*case end*/
-case 109 /* Guard */: {
+case 77 /* If */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_709; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_709 = indent; goto __jakt_label_603;
+__jakt_var_709 = indent; goto __jakt_label_602;
 
 }
-__jakt_label_603:; __jakt_var_709.release_value(); }));
+__jakt_label_602:; __jakt_var_709.release_value(); }));
+};/*case end*/
+case 109 /* Guard */: {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_710; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_710 = indent; goto __jakt_label_603;
+
+}
+__jakt_label_603:; __jakt_var_710.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
@@ -1873,71 +1873,71 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 });
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_add(dedents_on_open_curly,added_indent))))));
 ((((indent_change))) += ((infallible_integer_cast<i64>((added_indent)))));
-__jakt_var_704 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_598;
+__jakt_var_705 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_598;
 
 }
-__jakt_label_598:; __jakt_var_704.release_value(); }));
+__jakt_label_598:; __jakt_var_705.release_value(); }));
 };/*case end*/
 case 107 /* While */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_710; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_711; {
 size_t const added_indent = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_711; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_711 = indent; goto __jakt_label_605;
-
-}
-__jakt_label_605:; __jakt_var_711.release_value(); }));
-};/*case end*/
-case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_712; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_712 = indent; goto __jakt_label_606;
+__jakt_var_712 = indent; goto __jakt_label_605;
 
 }
-__jakt_label_606:; __jakt_var_712.release_value(); }));
+__jakt_label_605:; __jakt_var_712.release_value(); }));
 };/*case end*/
-case 107 /* While */: {
+case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_713; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_713 = indent; goto __jakt_label_607;
+__jakt_var_713 = indent; goto __jakt_label_606;
 
 }
-__jakt_label_607:; __jakt_var_713.release_value(); }));
+__jakt_label_606:; __jakt_var_713.release_value(); }));
 };/*case end*/
-case 77 /* If */: {
+case 107 /* While */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_714; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_714 = indent; goto __jakt_label_608;
+__jakt_var_714 = indent; goto __jakt_label_607;
 
 }
-__jakt_label_608:; __jakt_var_714.release_value(); }));
+__jakt_label_607:; __jakt_var_714.release_value(); }));
 };/*case end*/
-case 109 /* Guard */: {
+case 77 /* If */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_715; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_715 = indent; goto __jakt_label_609;
+__jakt_var_715 = indent; goto __jakt_label_608;
 
 }
-__jakt_label_609:; __jakt_var_715.release_value(); }));
+__jakt_label_608:; __jakt_var_715.release_value(); }));
+};/*case end*/
+case 109 /* Guard */: {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_716; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_716 = indent; goto __jakt_label_609;
+
+}
+__jakt_label_609:; __jakt_var_716.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
@@ -1951,71 +1951,71 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 });
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_add(dedents_on_open_curly,added_indent))))));
 ((((indent_change))) += ((infallible_integer_cast<i64>((added_indent)))));
-__jakt_var_710 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_604;
+__jakt_var_711 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_604;
 
 }
-__jakt_label_604:; __jakt_var_710.release_value(); }));
+__jakt_label_604:; __jakt_var_711.release_value(); }));
 };/*case end*/
 case 77 /* If */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_716; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_717; {
 size_t const added_indent = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_717; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_717 = indent; goto __jakt_label_611;
-
-}
-__jakt_label_611:; __jakt_var_717.release_value(); }));
-};/*case end*/
-case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_718; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_718 = indent; goto __jakt_label_612;
+__jakt_var_718 = indent; goto __jakt_label_611;
 
 }
-__jakt_label_612:; __jakt_var_718.release_value(); }));
+__jakt_label_611:; __jakt_var_718.release_value(); }));
 };/*case end*/
-case 107 /* While */: {
+case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_719; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_719 = indent; goto __jakt_label_613;
+__jakt_var_719 = indent; goto __jakt_label_612;
 
 }
-__jakt_label_613:; __jakt_var_719.release_value(); }));
+__jakt_label_612:; __jakt_var_719.release_value(); }));
 };/*case end*/
-case 77 /* If */: {
+case 107 /* While */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_720; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_720 = indent; goto __jakt_label_614;
+__jakt_var_720 = indent; goto __jakt_label_613;
 
 }
-__jakt_label_614:; __jakt_var_720.release_value(); }));
+__jakt_label_613:; __jakt_var_720.release_value(); }));
 };/*case end*/
-case 109 /* Guard */: {
+case 77 /* If */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_721; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_721 = indent; goto __jakt_label_615;
+__jakt_var_721 = indent; goto __jakt_label_614;
 
 }
-__jakt_label_615:; __jakt_var_721.release_value(); }));
+__jakt_label_614:; __jakt_var_721.release_value(); }));
+};/*case end*/
+case 109 /* Guard */: {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_722; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_722 = indent; goto __jakt_label_615;
+
+}
+__jakt_label_615:; __jakt_var_722.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
@@ -2029,71 +2029,71 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 });
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_add(dedents_on_open_curly,added_indent))))));
 ((((indent_change))) += ((infallible_integer_cast<i64>((added_indent)))));
-__jakt_var_716 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_610;
+__jakt_var_717 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_610;
 
 }
-__jakt_label_610:; __jakt_var_716.release_value(); }));
+__jakt_label_610:; __jakt_var_717.release_value(); }));
 };/*case end*/
 case 103 /* Try */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_722; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_723; {
 size_t const added_indent = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_723; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_723 = indent; goto __jakt_label_617;
-
-}
-__jakt_label_617:; __jakt_var_723.release_value(); }));
-};/*case end*/
-case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_724; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_724 = indent; goto __jakt_label_618;
+__jakt_var_724 = indent; goto __jakt_label_617;
 
 }
-__jakt_label_618:; __jakt_var_724.release_value(); }));
+__jakt_label_617:; __jakt_var_724.release_value(); }));
 };/*case end*/
-case 107 /* While */: {
+case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_725; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_725 = indent; goto __jakt_label_619;
+__jakt_var_725 = indent; goto __jakt_label_618;
 
 }
-__jakt_label_619:; __jakt_var_725.release_value(); }));
+__jakt_label_618:; __jakt_var_725.release_value(); }));
 };/*case end*/
-case 77 /* If */: {
+case 107 /* While */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_726; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_726 = indent; goto __jakt_label_620;
+__jakt_var_726 = indent; goto __jakt_label_619;
 
 }
-__jakt_label_620:; __jakt_var_726.release_value(); }));
+__jakt_label_619:; __jakt_var_726.release_value(); }));
 };/*case end*/
-case 109 /* Guard */: {
+case 77 /* If */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_727; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_727 = indent; goto __jakt_label_621;
+__jakt_var_727 = indent; goto __jakt_label_620;
 
 }
-__jakt_label_621:; __jakt_var_727.release_value(); }));
+__jakt_label_620:; __jakt_var_727.release_value(); }));
+};/*case end*/
+case 109 /* Guard */: {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_728; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_728 = indent; goto __jakt_label_621;
+
+}
+__jakt_label_621:; __jakt_var_728.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
@@ -2107,71 +2107,71 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 });
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_add(dedents_on_open_curly,added_indent))))));
 ((((indent_change))) += ((infallible_integer_cast<i64>((added_indent)))));
-__jakt_var_722 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_616;
+__jakt_var_723 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_616;
 
 }
-__jakt_label_616:; __jakt_var_722.release_value(); }));
+__jakt_label_616:; __jakt_var_723.release_value(); }));
 };/*case end*/
 case 83 /* Loop */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_728; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_729; {
 size_t const added_indent = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_729; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_729 = indent; goto __jakt_label_623;
-
-}
-__jakt_label_623:; __jakt_var_729.release_value(); }));
-};/*case end*/
-case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_730; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_730 = indent; goto __jakt_label_624;
+__jakt_var_730 = indent; goto __jakt_label_623;
 
 }
-__jakt_label_624:; __jakt_var_730.release_value(); }));
+__jakt_label_623:; __jakt_var_730.release_value(); }));
 };/*case end*/
-case 107 /* While */: {
+case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_731; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_731 = indent; goto __jakt_label_625;
+__jakt_var_731 = indent; goto __jakt_label_624;
 
 }
-__jakt_label_625:; __jakt_var_731.release_value(); }));
+__jakt_label_624:; __jakt_var_731.release_value(); }));
 };/*case end*/
-case 77 /* If */: {
+case 107 /* While */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_732; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_732 = indent; goto __jakt_label_626;
+__jakt_var_732 = indent; goto __jakt_label_625;
 
 }
-__jakt_label_626:; __jakt_var_732.release_value(); }));
+__jakt_label_625:; __jakt_var_732.release_value(); }));
 };/*case end*/
-case 109 /* Guard */: {
+case 77 /* If */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_733; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_733 = indent; goto __jakt_label_627;
+__jakt_var_733 = indent; goto __jakt_label_626;
 
 }
-__jakt_label_627:; __jakt_var_733.release_value(); }));
+__jakt_label_626:; __jakt_var_733.release_value(); }));
+};/*case end*/
+case 109 /* Guard */: {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_734; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_734 = indent; goto __jakt_label_627;
+
+}
+__jakt_label_627:; __jakt_var_734.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
@@ -2185,71 +2185,71 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 });
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_add(dedents_on_open_curly,added_indent))))));
 ((((indent_change))) += ((infallible_integer_cast<i64>((added_indent)))));
-__jakt_var_728 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_622;
+__jakt_var_729 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_622;
 
 }
-__jakt_label_622:; __jakt_var_728.release_value(); }));
+__jakt_label_622:; __jakt_var_729.release_value(); }));
 };/*case end*/
 case 109 /* Guard */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_734; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_735; {
 size_t const added_indent = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_735; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_735 = indent; goto __jakt_label_629;
-
-}
-__jakt_label_629:; __jakt_var_735.release_value(); }));
-};/*case end*/
-case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_736; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_736 = indent; goto __jakt_label_630;
+__jakt_var_736 = indent; goto __jakt_label_629;
 
 }
-__jakt_label_630:; __jakt_var_736.release_value(); }));
+__jakt_label_629:; __jakt_var_736.release_value(); }));
 };/*case end*/
-case 107 /* While */: {
+case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_737; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_737 = indent; goto __jakt_label_631;
+__jakt_var_737 = indent; goto __jakt_label_630;
 
 }
-__jakt_label_631:; __jakt_var_737.release_value(); }));
+__jakt_label_630:; __jakt_var_737.release_value(); }));
 };/*case end*/
-case 77 /* If */: {
+case 107 /* While */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_738; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_738 = indent; goto __jakt_label_632;
+__jakt_var_738 = indent; goto __jakt_label_631;
 
 }
-__jakt_label_632:; __jakt_var_738.release_value(); }));
+__jakt_label_631:; __jakt_var_738.release_value(); }));
 };/*case end*/
-case 109 /* Guard */: {
+case 77 /* If */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_739; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_739 = indent; goto __jakt_label_633;
+__jakt_var_739 = indent; goto __jakt_label_632;
 
 }
-__jakt_label_633:; __jakt_var_739.release_value(); }));
+__jakt_label_632:; __jakt_var_739.release_value(); }));
+};/*case end*/
+case 109 /* Guard */: {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_740; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_740 = indent; goto __jakt_label_633;
+
+}
+__jakt_label_633:; __jakt_var_740.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
@@ -2263,71 +2263,71 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 });
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_add(dedents_on_open_curly,added_indent))))));
 ((((indent_change))) += ((infallible_integer_cast<i64>((added_indent)))));
-__jakt_var_734 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_628;
+__jakt_var_735 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_628;
 
 }
-__jakt_label_628:; __jakt_var_734.release_value(); }));
+__jakt_label_628:; __jakt_var_735.release_value(); }));
 };/*case end*/
 case 68 /* Defer */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_740; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_741; {
 size_t const added_indent = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_741; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_741 = indent; goto __jakt_label_635;
-
-}
-__jakt_label_635:; __jakt_var_741.release_value(); }));
-};/*case end*/
-case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_742; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_742 = indent; goto __jakt_label_636;
+__jakt_var_742 = indent; goto __jakt_label_635;
 
 }
-__jakt_label_636:; __jakt_var_742.release_value(); }));
+__jakt_label_635:; __jakt_var_742.release_value(); }));
 };/*case end*/
-case 107 /* While */: {
+case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_743; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_743 = indent; goto __jakt_label_637;
+__jakt_var_743 = indent; goto __jakt_label_636;
 
 }
-__jakt_label_637:; __jakt_var_743.release_value(); }));
+__jakt_label_636:; __jakt_var_743.release_value(); }));
 };/*case end*/
-case 77 /* If */: {
+case 107 /* While */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_744; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_744 = indent; goto __jakt_label_638;
+__jakt_var_744 = indent; goto __jakt_label_637;
 
 }
-__jakt_label_638:; __jakt_var_744.release_value(); }));
+__jakt_label_637:; __jakt_var_744.release_value(); }));
 };/*case end*/
-case 109 /* Guard */: {
+case 77 /* If */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_745; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_745 = indent; goto __jakt_label_639;
+__jakt_var_745 = indent; goto __jakt_label_638;
 
 }
-__jakt_label_639:; __jakt_var_745.release_value(); }));
+__jakt_label_638:; __jakt_var_745.release_value(); }));
+};/*case end*/
+case 109 /* Guard */: {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_746; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_746 = indent; goto __jakt_label_639;
+
+}
+__jakt_label_639:; __jakt_var_746.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
@@ -2341,61 +2341,12 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 });
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_add(dedents_on_open_curly,added_indent))))));
 ((((indent_change))) += ((infallible_integer_cast<i64>((added_indent)))));
-__jakt_var_740 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_634;
+__jakt_var_741 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_634;
 
 }
-__jakt_label_634:; __jakt_var_740.release_value(); }));
+__jakt_label_634:; __jakt_var_741.release_value(); }));
 };/*case end*/
 case 64 /* Catch */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_746; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
-__jakt_var_746 = ((*this).formatted_token(token,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
-switch(__jakt_match_variant.__jakt_init_index()) {
-case 55 /* Eol */: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-};/*case end*/
-case 57 /* FatArrow */: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-};/*case end*/
-case 7 /* LParen */: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-};/*case end*/
-default: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-};/*case end*/
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
-switch(__jakt_match_variant.__jakt_init_index()) {
-case 55 /* Eol */: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-};/*case end*/
-case 40 /* Pipe */: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-};/*case end*/
-default: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-};/*case end*/
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}))); goto __jakt_label_640;
-
-}
-__jakt_label_640:; __jakt_var_746.release_value(); }));
-};/*case end*/
-case 70 /* Else */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_747; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
 __jakt_var_747 = ((*this).formatted_token(token,({
@@ -2439,13 +2390,62 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
+}))); goto __jakt_label_640;
+
+}
+__jakt_label_640:; __jakt_var_747.release_value(); }));
+};/*case end*/
+case 70 /* Else */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_748; {
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
+__jakt_var_748 = ((*this).formatted_token(token,({
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 55 /* Eol */: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
+};/*case end*/
+case 57 /* FatArrow */: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
+};/*case end*/
+case 7 /* LParen */: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
+};/*case end*/
+}/*switch end*/
+}()
+);
+    if (_jakt_value.is_return())
+        return _jakt_value.release_return();
+    _jakt_value.release_value();
+}),({
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 55 /* Eol */: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
+};/*case end*/
+case 40 /* Pipe */: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
+};/*case end*/
+}/*switch end*/
+}()
+);
+    if (_jakt_value.is_return())
+        return _jakt_value.release_return();
+    _jakt_value.release_value();
 }))); goto __jakt_label_641;
 
 }
-__jakt_label_641:; __jakt_var_747.release_value(); }));
+__jakt_label_641:; __jakt_var_748.release_value(); }));
 };/*case end*/
 case 55 /* Eol */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_748; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_749; {
 if ((((expression_mode).__jakt_init_index() == 1 /* BeforeExpressions */) && ((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 55 /* Eol */))){
 return TRY((((*this).next())));
 }
@@ -2511,23 +2511,23 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,new_arrow_indents,new_allow_eol,inserted_comma,new_expression_mode,dedents_on_open_curly)))));
-__jakt_var_748 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_642;
+__jakt_var_749 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_642;
 
 }
-__jakt_label_642:; __jakt_var_748.release_value(); }));
+__jakt_label_642:; __jakt_var_749.release_value(); }));
 };/*case end*/
 case 75 /* Fn */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_749; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_750; {
 TRY((((*this).push_state(formatter::State::FunctionTypeContext(false)))));
-__jakt_var_749 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_643;
+__jakt_var_750 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_643;
 
 }
-__jakt_label_643:; __jakt_var_749.release_value(); }));
+__jakt_label_643:; __jakt_var_750.release_value(); }));
 };/*case end*/
 case 52 /* Comma */: {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<formatter::FormattedToken>> __jakt_var_750; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<formatter::FormattedToken>> __jakt_var_751; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_750 = ({
+__jakt_var_751 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -2546,7 +2546,7 @@ return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u
 }); goto __jakt_label_644;
 
 }
-__jakt_label_644:; __jakt_var_750.release_value(); }));
+__jakt_label_644:; __jakt_var_751.release_value(); }));
 };/*case end*/
 case 95 /* Return */: {
 return JaktInternal::ExplicitValue(({
@@ -2554,28 +2554,28 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* Semicolon */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_751; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
-__jakt_var_751 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_645;
-
-}
-__jakt_label_645:; __jakt_var_751.release_value(); }));
-};/*case end*/
-case 55 /* Eol */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_752; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
-__jakt_var_752 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_646;
+__jakt_var_752 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_645;
 
 }
-__jakt_label_646:; __jakt_var_752.release_value(); }));
+__jakt_label_645:; __jakt_var_752.release_value(); }));
+};/*case end*/
+case 55 /* Eol */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_753; {
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
+__jakt_var_753 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_646;
+
+}
+__jakt_label_646:; __jakt_var_753.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_753; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_754; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_753 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_647;
+__jakt_var_754 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_647;
 
 }
-__jakt_label_647:; __jakt_var_753.release_value(); }));
+__jakt_label_647:; __jakt_var_754.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -2591,28 +2591,28 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* Semicolon */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_754; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
-__jakt_var_754 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_648;
-
-}
-__jakt_label_648:; __jakt_var_754.release_value(); }));
-};/*case end*/
-case 55 /* Eol */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_755; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
-__jakt_var_755 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_649;
+__jakt_var_755 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_648;
 
 }
-__jakt_label_649:; __jakt_var_755.release_value(); }));
+__jakt_label_648:; __jakt_var_755.release_value(); }));
+};/*case end*/
+case 55 /* Eol */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_756; {
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
+__jakt_var_756 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_649;
+
+}
+__jakt_label_649:; __jakt_var_756.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_756; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_757; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_756 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_650;
+__jakt_var_757 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_650;
 
 }
-__jakt_label_650:; __jakt_var_756.release_value(); }));
+__jakt_label_650:; __jakt_var_757.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -2628,28 +2628,28 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* Semicolon */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_757; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
-__jakt_var_757 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_651;
-
-}
-__jakt_label_651:; __jakt_var_757.release_value(); }));
-};/*case end*/
-case 55 /* Eol */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_758; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
-__jakt_var_758 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_652;
+__jakt_var_758 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_651;
 
 }
-__jakt_label_652:; __jakt_var_758.release_value(); }));
+__jakt_label_651:; __jakt_var_758.release_value(); }));
+};/*case end*/
+case 55 /* Eol */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_759; {
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
+__jakt_var_759 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_652;
+
+}
+__jakt_label_652:; __jakt_var_759.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_759; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_760; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_759 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_653;
+__jakt_var_760 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_653;
 
 }
-__jakt_label_653:; __jakt_var_759.release_value(); }));
+__jakt_label_653:; __jakt_var_760.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -2660,7 +2660,7 @@ __jakt_label_653:; __jakt_var_759.release_value(); }));
 }));
 };/*case end*/
 case 57 /* FatArrow */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_760; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_761; {
 bool const next_is_eol = ((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 55 /* Eol */);
 size_t new_arrow_indents = arrow_indents;
 if (next_is_eol){
@@ -2689,55 +2689,55 @@ return JaktInternal::ExplicitValue(formatter::ExpressionMode::BeforeExpressions(
         return _jakt_value.release_return();
     _jakt_value.release_value();
 }),dedents_on_open_curly)))));
-__jakt_var_760 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_654;
+__jakt_var_761 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_654;
 
 }
-__jakt_label_654:; __jakt_var_760.release_value(); }));
+__jakt_label_654:; __jakt_var_761.release_value(); }));
 };/*case end*/
 case 11 /* LSquare */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_761; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_762; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,JaktInternal::checked_add(open_squares,static_cast<size_t>(1ULL)),arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_761 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_655;
+__jakt_var_762 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_655;
 
 }
-__jakt_label_655:; __jakt_var_761.release_value(); }));
+__jakt_label_655:; __jakt_var_762.release_value(); }));
 };/*case end*/
 case 12 /* RSquare */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_762; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_763; {
 if (((open_squares) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,JaktInternal::checked_sub(open_squares,static_cast<size_t>(1ULL)),arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_762 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_656;
+__jakt_var_763 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_656;
 
 }
-__jakt_label_656:; __jakt_var_762.release_value(); }));
+__jakt_label_656:; __jakt_var_763.release_value(); }));
 };/*case end*/
 case 7 /* LParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_763; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_764; {
 TRY((((*this).replace_state(formatter::State::StatementContext(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_763 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_657;
+__jakt_var_764 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_657;
 
 }
-__jakt_label_657:; __jakt_var_763.release_value(); }));
+__jakt_label_657:; __jakt_var_764.release_value(); }));
 };/*case end*/
 case 8 /* RParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_764; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_765; {
 if (((open_parens) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::StatementContext(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::InExpression(),dedents_on_open_curly)))));
-__jakt_var_764 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_658;
+__jakt_var_765 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_658;
 
 }
-__jakt_label_658:; __jakt_var_764.release_value(); }));
+__jakt_label_658:; __jakt_var_765.release_value(); }));
 };/*case end*/
 case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_765; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_766; {
 size_t dedented = static_cast<size_t>(0ULL);
 if ([](size_t const& self, size_t rhs) -> bool {{
 return (((infallible_integer_cast<u8>(([](size_t const& self, size_t rhs) -> jakt__prelude__operators::Ordering {{
@@ -2752,7 +2752,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 (dedented = static_cast<size_t>(1ULL));
 }
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,JaktInternal::checked_add(open_curlies,static_cast<size_t>(1ULL)),open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_sub(dedents_on_open_curly,dedented))))));
-__jakt_var_765 = ((*this).formatted_token(token,({
+__jakt_var_766 = ((*this).formatted_token(token,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = expression_mode;
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -2827,17 +2827,17 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
 }))); goto __jakt_label_659;
 
 }
-__jakt_label_659:; __jakt_var_765.release_value(); }));
+__jakt_label_659:; __jakt_var_766.release_value(); }));
 };/*case end*/
 case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_766; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_767; {
 if (((open_curlies) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)) -= (static_cast<size_t>(1ULL)));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,JaktInternal::checked_sub(open_curlies,static_cast<size_t>(1ULL)),open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::InExpression(),dedents_on_open_curly)))));
-__jakt_var_766 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),({
+__jakt_var_767 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -2859,27 +2859,27 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
 }))); goto __jakt_label_660;
 
 }
-__jakt_label_660:; __jakt_var_766.release_value(); }));
+__jakt_label_660:; __jakt_var_767.release_value(); }));
 };/*case end*/
 case 88 /* Not */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_767; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_768; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_767 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_661;
+__jakt_var_768 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_661;
 
 }
-__jakt_label_661:; __jakt_var_767.release_value(); }));
+__jakt_label_661:; __jakt_var_768.release_value(); }));
 };/*case end*/
 case 97 /* Sizeof */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_768; {
-__jakt_var_768 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_662;
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_769; {
+__jakt_var_769 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_662;
 
 }
-__jakt_label_662:; __jakt_var_768.release_value(); }));
+__jakt_label_662:; __jakt_var_769.release_value(); }));
 };/*case end*/
 case 5 /* Colon */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_769; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_770; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_769 = ((*this).formatted_token(token,({
+__jakt_var_770 = ((*this).formatted_token(token,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -2898,34 +2898,9 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
 }),DynamicArray<u8>::create_with({}))); goto __jakt_label_663;
 
 }
-__jakt_label_663:; __jakt_var_769.release_value(); }));
+__jakt_label_663:; __jakt_var_770.release_value(); }));
 };/*case end*/
 case 15 /* Minus */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_770; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-JaktInternal::DynamicArray<u8> const trivia = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = expression_mode;
-switch(__jakt_match_variant.__jakt_init_index()) {
-case 3 /* InExpression */: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-};/*case end*/
-default: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-};/*case end*/
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-__jakt_var_770 = ((*this).formatted_token(token,trivia,trivia)); goto __jakt_label_664;
-
-}
-__jakt_label_664:; __jakt_var_770.release_value(); }));
-};/*case end*/
-case 36 /* Asterisk */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_771; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 JaktInternal::DynamicArray<u8> const trivia = ({
@@ -2945,12 +2920,12 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-__jakt_var_771 = ((*this).formatted_token(token,trivia,trivia)); goto __jakt_label_665;
+__jakt_var_771 = ((*this).formatted_token(token,trivia,trivia)); goto __jakt_label_664;
 
 }
-__jakt_label_665:; __jakt_var_771.release_value(); }));
+__jakt_label_664:; __jakt_var_771.release_value(); }));
 };/*case end*/
-case 37 /* Ampersand */: {
+case 36 /* Asterisk */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_772; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 JaktInternal::DynamicArray<u8> const trivia = ({
@@ -2970,266 +2945,291 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-__jakt_var_772 = ((*this).formatted_token(token,trivia,trivia)); goto __jakt_label_666;
+__jakt_var_772 = ((*this).formatted_token(token,trivia,trivia)); goto __jakt_label_665;
 
 }
-__jakt_label_666:; __jakt_var_772.release_value(); }));
+__jakt_label_665:; __jakt_var_772.release_value(); }));
 };/*case end*/
-case 13 /* PercentSign */: {
+case 37 /* Ampersand */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_773; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_773 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_667;
+JaktInternal::DynamicArray<u8> const trivia = ({
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+auto&& __jakt_match_variant = expression_mode;
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 3 /* InExpression */: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
+};/*case end*/
+}/*switch end*/
+}()
+);
+    if (_jakt_value.is_return())
+        return _jakt_value.release_return();
+    _jakt_value.release_value();
+});
+__jakt_var_773 = ((*this).formatted_token(token,trivia,trivia)); goto __jakt_label_666;
 
 }
-__jakt_label_667:; __jakt_var_773.release_value(); }));
+__jakt_label_666:; __jakt_var_773.release_value(); }));
 };/*case end*/
-case 14 /* Plus */: {
+case 13 /* PercentSign */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_774; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_774 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_668;
+__jakt_var_774 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_667;
 
 }
-__jakt_label_668:; __jakt_var_774.release_value(); }));
+__jakt_label_667:; __jakt_var_774.release_value(); }));
 };/*case end*/
-case 16 /* Equal */: {
+case 14 /* Plus */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_775; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_775 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_669;
+__jakt_var_775 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_668;
 
 }
-__jakt_label_669:; __jakt_var_775.release_value(); }));
+__jakt_label_668:; __jakt_var_775.release_value(); }));
 };/*case end*/
-case 40 /* Pipe */: {
+case 16 /* Equal */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_776; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_776 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_670;
+__jakt_var_776 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_669;
 
 }
-__jakt_label_670:; __jakt_var_776.release_value(); }));
+__jakt_label_669:; __jakt_var_776.release_value(); }));
 };/*case end*/
-case 17 /* PlusEqual */: {
+case 40 /* Pipe */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_777; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_777 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_671;
+__jakt_var_777 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_670;
 
 }
-__jakt_label_671:; __jakt_var_777.release_value(); }));
+__jakt_label_670:; __jakt_var_777.release_value(); }));
 };/*case end*/
-case 19 /* MinusEqual */: {
+case 17 /* PlusEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_778; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_778 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_672;
+__jakt_var_778 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_671;
 
 }
-__jakt_label_672:; __jakt_var_778.release_value(); }));
+__jakt_label_671:; __jakt_var_778.release_value(); }));
 };/*case end*/
-case 21 /* AsteriskEqual */: {
+case 19 /* MinusEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_779; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_779 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_673;
+__jakt_var_779 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_672;
 
 }
-__jakt_label_673:; __jakt_var_779.release_value(); }));
+__jakt_label_672:; __jakt_var_779.release_value(); }));
 };/*case end*/
-case 22 /* ForwardSlashEqual */: {
+case 21 /* AsteriskEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_780; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_780 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_674;
+__jakt_var_780 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_673;
 
 }
-__jakt_label_674:; __jakt_var_780.release_value(); }));
+__jakt_label_673:; __jakt_var_780.release_value(); }));
 };/*case end*/
-case 23 /* PercentSignEqual */: {
+case 22 /* ForwardSlashEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_781; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_781 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_675;
+__jakt_var_781 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_674;
 
 }
-__jakt_label_675:; __jakt_var_781.release_value(); }));
+__jakt_label_674:; __jakt_var_781.release_value(); }));
 };/*case end*/
-case 24 /* NotEqual */: {
+case 23 /* PercentSignEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_782; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_782 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_676;
+__jakt_var_782 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_675;
 
 }
-__jakt_label_676:; __jakt_var_782.release_value(); }));
+__jakt_label_675:; __jakt_var_782.release_value(); }));
 };/*case end*/
-case 25 /* DoubleEqual */: {
+case 24 /* NotEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_783; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_783 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_677;
+__jakt_var_783 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_676;
 
 }
-__jakt_label_677:; __jakt_var_783.release_value(); }));
+__jakt_label_676:; __jakt_var_783.release_value(); }));
 };/*case end*/
-case 26 /* GreaterThan */: {
+case 25 /* DoubleEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_784; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_784 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_678;
+__jakt_var_784 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_677;
 
 }
-__jakt_label_678:; __jakt_var_784.release_value(); }));
+__jakt_label_677:; __jakt_var_784.release_value(); }));
 };/*case end*/
-case 27 /* GreaterThanOrEqual */: {
+case 26 /* GreaterThan */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_785; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_785 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_679;
+__jakt_var_785 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_678;
 
 }
-__jakt_label_679:; __jakt_var_785.release_value(); }));
+__jakt_label_678:; __jakt_var_785.release_value(); }));
 };/*case end*/
-case 28 /* LessThan */: {
+case 27 /* GreaterThanOrEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_786; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_786 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_680;
+__jakt_var_786 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_679;
 
 }
-__jakt_label_680:; __jakt_var_786.release_value(); }));
+__jakt_label_679:; __jakt_var_786.release_value(); }));
 };/*case end*/
-case 29 /* LessThanOrEqual */: {
+case 28 /* LessThan */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_787; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_787 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_681;
+__jakt_var_787 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_680;
 
 }
-__jakt_label_681:; __jakt_var_787.release_value(); }));
+__jakt_label_680:; __jakt_var_787.release_value(); }));
 };/*case end*/
-case 30 /* LeftArithmeticShift */: {
+case 29 /* LessThanOrEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_788; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_788 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_682;
+__jakt_var_788 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_681;
 
 }
-__jakt_label_682:; __jakt_var_788.release_value(); }));
+__jakt_label_681:; __jakt_var_788.release_value(); }));
 };/*case end*/
-case 31 /* LeftShift */: {
+case 30 /* LeftArithmeticShift */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_789; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_789 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_683;
+__jakt_var_789 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_682;
 
 }
-__jakt_label_683:; __jakt_var_789.release_value(); }));
+__jakt_label_682:; __jakt_var_789.release_value(); }));
 };/*case end*/
-case 33 /* RightShift */: {
+case 31 /* LeftShift */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_790; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_790 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_684;
+__jakt_var_790 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_683;
 
 }
-__jakt_label_684:; __jakt_var_790.release_value(); }));
+__jakt_label_683:; __jakt_var_790.release_value(); }));
 };/*case end*/
-case 32 /* LeftShiftEqual */: {
+case 33 /* RightShift */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_791; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_791 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_685;
+__jakt_var_791 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_684;
 
 }
-__jakt_label_685:; __jakt_var_791.release_value(); }));
+__jakt_label_684:; __jakt_var_791.release_value(); }));
 };/*case end*/
-case 34 /* RightArithmeticShift */: {
+case 32 /* LeftShiftEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_792; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_792 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_686;
+__jakt_var_792 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_685;
 
 }
-__jakt_label_686:; __jakt_var_792.release_value(); }));
+__jakt_label_685:; __jakt_var_792.release_value(); }));
 };/*case end*/
-case 35 /* RightShiftEqual */: {
+case 34 /* RightArithmeticShift */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_793; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_793 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_687;
+__jakt_var_793 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_686;
 
 }
-__jakt_label_687:; __jakt_var_793.release_value(); }));
+__jakt_label_686:; __jakt_var_793.release_value(); }));
 };/*case end*/
-case 38 /* AmpersandEqual */: {
+case 35 /* RightShiftEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_794; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_794 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_688;
+__jakt_var_794 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_687;
 
 }
-__jakt_label_688:; __jakt_var_794.release_value(); }));
+__jakt_label_687:; __jakt_var_794.release_value(); }));
 };/*case end*/
-case 41 /* PipeEqual */: {
+case 38 /* AmpersandEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_795; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_795 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_689;
+__jakt_var_795 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_688;
 
 }
-__jakt_label_689:; __jakt_var_795.release_value(); }));
+__jakt_label_688:; __jakt_var_795.release_value(); }));
 };/*case end*/
-case 43 /* Caret */: {
+case 41 /* PipeEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_796; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_796 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_690;
+__jakt_var_796 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_689;
 
 }
-__jakt_label_690:; __jakt_var_796.release_value(); }));
+__jakt_label_689:; __jakt_var_796.release_value(); }));
 };/*case end*/
-case 44 /* CaretEqual */: {
+case 43 /* Caret */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_797; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_797 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_691;
+__jakt_var_797 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_690;
 
 }
-__jakt_label_691:; __jakt_var_797.release_value(); }));
+__jakt_label_690:; __jakt_var_797.release_value(); }));
 };/*case end*/
-case 47 /* ForwardSlash */: {
+case 44 /* CaretEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_798; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_798 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_692;
+__jakt_var_798 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_691;
 
 }
-__jakt_label_692:; __jakt_var_798.release_value(); }));
+__jakt_label_691:; __jakt_var_798.release_value(); }));
 };/*case end*/
-case 50 /* QuestionMarkQuestionMark */: {
+case 47 /* ForwardSlash */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_799; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_799 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_693;
+__jakt_var_799 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_692;
 
 }
-__jakt_label_693:; __jakt_var_799.release_value(); }));
+__jakt_label_692:; __jakt_var_799.release_value(); }));
 };/*case end*/
-case 51 /* QuestionMarkQuestionMarkEqual */: {
+case 50 /* QuestionMarkQuestionMark */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_800; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_800 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_694;
+__jakt_var_800 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_693;
 
 }
-__jakt_label_694:; __jakt_var_800.release_value(); }));
+__jakt_label_693:; __jakt_var_800.release_value(); }));
 };/*case end*/
-case 59 /* And */: {
+case 51 /* QuestionMarkQuestionMarkEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_801; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_801 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_695;
+__jakt_var_801 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_694;
 
 }
-__jakt_label_695:; __jakt_var_801.release_value(); }));
+__jakt_label_694:; __jakt_var_801.release_value(); }));
 };/*case end*/
-case 80 /* In */: {
+case 59 /* And */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_802; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_802 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_696;
+__jakt_var_802 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_695;
 
 }
-__jakt_label_696:; __jakt_var_802.release_value(); }));
+__jakt_label_695:; __jakt_var_802.release_value(); }));
 };/*case end*/
-case 89 /* Or */: {
+case 80 /* In */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_803; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_803 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_697;
+__jakt_var_803 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_696;
 
 }
-__jakt_label_697:; __jakt_var_803.release_value(); }));
+__jakt_label_696:; __jakt_var_803.release_value(); }));
+};/*case end*/
+case 89 /* Or */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_804; {
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
+__jakt_var_804 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_697;
+
+}
+__jakt_label_697:; __jakt_var_804.release_value(); }));
 };/*case end*/
 case 81 /* Is */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_804; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_805; {
 TRY((((*this).push_state(formatter::State::MatchPattern(static_cast<size_t>(0ULL),false)))));
-__jakt_var_804 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_698;
+__jakt_var_805 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_698;
 
 }
-__jakt_label_698:; __jakt_var_804.release_value(); }));
+__jakt_label_698:; __jakt_var_805.release_value(); }));
 };/*case end*/
 case 61 /* As */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,({
@@ -3292,270 +3292,6 @@ return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u
 }));
 };/*case end*/
 case 3 /* Identifier */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_805; {
-if ((((((*this).peek((-(static_cast<i64>(1LL)))))).__jakt_init_index() == 3 /* Identifier */) && (!(inserted_comma)))){
-((((*this).index)--));
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,true,formatter::ExpressionMode::InExpression(),dedents_on_open_curly)))));
-return ((*this).formatted_token(lexer::Token::Comma(((token).span())),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
-}
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,false,formatter::ExpressionMode::InExpression(),dedents_on_open_curly)))));
-if (((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 7 /* LParen */)){
-return ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-}
-if ((!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */)))){
-return ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-}
-i64 open_angles = static_cast<i64>(1LL);
-i64 lookahead_index = static_cast<i64>(2LL);
-while ([](i64 const& self, i64 rhs) -> bool {{
-return (((infallible_integer_cast<u8>(([](i64 const& self, i64 rhs) -> jakt__prelude__operators::Ordering {{
-return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::compare(self,rhs))));
-}
-}
-(self,rhs))))) == (static_cast<u8>(2)));
-}
-}
-(open_angles,static_cast<i64>(0LL))){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = ((*this).peek(((lookahead_index++))));
-switch(__jakt_match_variant.__jakt_init_index()) {
-case 28 /* LessThan */: {
-{
-((open_angles) += (static_cast<i64>(1LL)));
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 26 /* GreaterThan */: {
-{
-((open_angles) -= (static_cast<i64>(1LL)));
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 55 /* Eol */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 13 /* PercentSign */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 14 /* Plus */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 15 /* Minus */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 16 /* Equal */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 17 /* PlusEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 19 /* MinusEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 21 /* AsteriskEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 22 /* ForwardSlashEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 23 /* PercentSignEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 24 /* NotEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 25 /* DoubleEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 27 /* GreaterThanOrEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 29 /* LessThanOrEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 30 /* LeftArithmeticShift */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 31 /* LeftShift */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 33 /* RightShift */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 32 /* LeftShiftEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 34 /* RightArithmeticShift */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 35 /* RightShiftEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 36 /* Asterisk */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 38 /* AmpersandEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 40 /* Pipe */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 41 /* PipeEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 43 /* Caret */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 44 /* CaretEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 47 /* ForwardSlash */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 50 /* QuestionMarkQuestionMark */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 51 /* QuestionMarkQuestionMarkEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 59 /* And */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 80 /* In */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 81 /* Is */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 89 /* Or */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-default: {
-{
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
-}
-if ((((open_angles) == (static_cast<i64>(0LL))) && ((((*this).peek(lookahead_index))).__jakt_init_index() == 7 /* LParen */))){
-TRY((((*this).push_state(formatter::State::GenericCallTypeParams(static_cast<size_t>(0ULL))))));
-}
-__jakt_var_805 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_699;
-
-}
-__jakt_label_699:; __jakt_var_805.release_value(); }));
-};/*case end*/
-case 2 /* Number */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_806; {
 if ((((((*this).peek((-(static_cast<i64>(1LL)))))).__jakt_init_index() == 3 /* Identifier */) && (!(inserted_comma)))){
 ((((*this).index)--));
@@ -3814,13 +3550,277 @@ return JaktInternal::ExplicitValue<void>();
 if ((((open_angles) == (static_cast<i64>(0LL))) && ((((*this).peek(lookahead_index))).__jakt_init_index() == 7 /* LParen */))){
 TRY((((*this).push_state(formatter::State::GenericCallTypeParams(static_cast<size_t>(0ULL))))));
 }
-__jakt_var_806 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_700;
+__jakt_var_806 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_699;
 
 }
-__jakt_label_700:; __jakt_var_806.release_value(); }));
+__jakt_label_699:; __jakt_var_806.release_value(); }));
+};/*case end*/
+case 2 /* Number */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_807; {
+if ((((((*this).peek((-(static_cast<i64>(1LL)))))).__jakt_init_index() == 3 /* Identifier */) && (!(inserted_comma)))){
+((((*this).index)--));
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,true,formatter::ExpressionMode::InExpression(),dedents_on_open_curly)))));
+return ((*this).formatted_token(lexer::Token::Comma(((token).span())),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+}
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,false,formatter::ExpressionMode::InExpression(),dedents_on_open_curly)))));
+if (((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 7 /* LParen */)){
+return ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+}
+if ((!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */)))){
+return ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+}
+i64 open_angles = static_cast<i64>(1LL);
+i64 lookahead_index = static_cast<i64>(2LL);
+while ([](i64 const& self, i64 rhs) -> bool {{
+return (((infallible_integer_cast<u8>(([](i64 const& self, i64 rhs) -> jakt__prelude__operators::Ordering {{
+return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::compare(self,rhs))));
+}
+}
+(self,rhs))))) == (static_cast<u8>(2)));
+}
+}
+(open_angles,static_cast<i64>(0LL))){
+({
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+auto&& __jakt_match_variant = ((*this).peek(((lookahead_index++))));
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 28 /* LessThan */: {
+{
+((open_angles) += (static_cast<i64>(1LL)));
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 26 /* GreaterThan */: {
+{
+((open_angles) -= (static_cast<i64>(1LL)));
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 55 /* Eol */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 13 /* PercentSign */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 14 /* Plus */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 15 /* Minus */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 16 /* Equal */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 17 /* PlusEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 19 /* MinusEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 21 /* AsteriskEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 22 /* ForwardSlashEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 23 /* PercentSignEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 24 /* NotEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 25 /* DoubleEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 27 /* GreaterThanOrEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 29 /* LessThanOrEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 30 /* LeftArithmeticShift */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 31 /* LeftShift */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 33 /* RightShift */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 32 /* LeftShiftEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 34 /* RightArithmeticShift */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 35 /* RightShiftEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 36 /* Asterisk */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 38 /* AmpersandEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 40 /* Pipe */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 41 /* PipeEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 43 /* Caret */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 44 /* CaretEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 47 /* ForwardSlash */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 50 /* QuestionMarkQuestionMark */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 51 /* QuestionMarkQuestionMarkEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 59 /* And */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 80 /* In */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 81 /* Is */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 89 /* Or */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+default: {
+{
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+}/*switch end*/
+}()
+);
+    if (_jakt_value.is_return())
+        return _jakt_value.release_return();
+    if (_jakt_value.is_loop_break())
+        break;
+    if (_jakt_value.is_loop_continue())
+        continue;
+    _jakt_value.release_value();
+});
+}
+if ((((open_angles) == (static_cast<i64>(0LL))) && ((((*this).peek(lookahead_index))).__jakt_init_index() == 7 /* LParen */))){
+TRY((((*this).push_state(formatter::State::GenericCallTypeParams(static_cast<size_t>(0ULL))))));
+}
+__jakt_var_807 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_700;
+
+}
+__jakt_label_700:; __jakt_var_807.release_value(); }));
 };/*case end*/
 case 4 /* Semicolon */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_807; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_808; {
 if (((open_squares) == (static_cast<size_t>(0ULL)))){
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
@@ -3840,34 +3840,34 @@ return JaktInternal::ExplicitValue(((*this).formatted_token(lexer::Token::Eol(Ja
     _jakt_value.release_value();
 });
 }
-__jakt_var_807 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_701;
+__jakt_var_808 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_701;
 
 }
-__jakt_label_701:; __jakt_var_807.release_value(); }));
+__jakt_label_701:; __jakt_var_808.release_value(); }));
 };/*case end*/
 case 93 /* Raw */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_808; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_809; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_808 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_702;
+__jakt_var_809 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_702;
 
 }
-__jakt_label_702:; __jakt_var_808.release_value(); }));
+__jakt_label_702:; __jakt_var_809.release_value(); }));
 };/*case end*/
 case 94 /* Reflect */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_809; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_810; {
 TRY((((*this).replace_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_809 = formatter::FormattedToken(token,((*this).indent),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})); goto __jakt_label_703;
+__jakt_var_810 = formatter::FormattedToken(token,((*this).indent),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})); goto __jakt_label_703;
 
 }
-__jakt_label_703:; __jakt_var_809.release_value(); }));
+__jakt_label_703:; __jakt_var_810.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_810; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_811; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::InExpression(),dedents_on_open_curly)))));
-__jakt_var_810 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_704;
+__jakt_var_811 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_704;
 
 }
-__jakt_label_704:; __jakt_var_810.release_value(); }));
+__jakt_label_704:; __jakt_var_811.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -3886,15 +3886,15 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 28 /* LessThan */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_811; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_812; {
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_811 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_705;
+__jakt_var_812 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_705;
 
 }
-__jakt_label_705:; __jakt_var_811.release_value(); }));
+__jakt_label_705:; __jakt_var_812.release_value(); }));
 };/*case end*/
 case 26 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_812; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_813; {
 if ([](size_t const& self, size_t rhs) -> bool {{
 return (((infallible_integer_cast<u8>(([](size_t const& self, size_t rhs) -> jakt__prelude__operators::Ordering {{
 return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::compare(self,rhs))));
@@ -3910,18 +3910,18 @@ else {
 TRY((((*this).replace_state(formatter::State::GenericCallTypeParams(JaktInternal::checked_sub(open_angles,static_cast<size_t>(1ULL)))))));
 }
 
-__jakt_var_812 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_706;
+__jakt_var_813 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_706;
 
 }
-__jakt_label_706:; __jakt_var_812.release_value(); }));
+__jakt_label_706:; __jakt_var_813.release_value(); }));
 };/*case end*/
 case 52 /* Comma */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_813; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_814; {
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_813 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_707;
+__jakt_var_814 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_707;
 
 }
-__jakt_label_707:; __jakt_var_813.release_value(); }));
+__jakt_label_707:; __jakt_var_814.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))));
@@ -3943,41 +3943,41 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* Colon */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_814; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_815; {
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_814 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_708;
+__jakt_var_815 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_708;
 
 }
-__jakt_label_708:; __jakt_var_814.release_value(); }));
+__jakt_label_708:; __jakt_var_815.release_value(); }));
 };/*case end*/
 case 7 /* LParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_815; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_816; {
 TRY((((*this).replace_state(formatter::State::VariableDeclaration(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)))))));
-__jakt_var_815 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_709;
+__jakt_var_816 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_709;
 
 }
-__jakt_label_709:; __jakt_var_815.release_value(); }));
+__jakt_label_709:; __jakt_var_816.release_value(); }));
 };/*case end*/
 case 8 /* RParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_816; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_817; {
 if (((open_parens) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::VariableDeclaration(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL)))))));
-__jakt_var_816 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_710;
+__jakt_var_817 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_710;
 
 }
-__jakt_label_710:; __jakt_var_816.release_value(); }));
+__jakt_label_710:; __jakt_var_817.release_value(); }));
 };/*case end*/
 case 16 /* Equal */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_817; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_818; {
 ((*this).pop_state());
-__jakt_var_817 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_711;
+__jakt_var_818 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_711;
 
 }
-__jakt_label_711:; __jakt_var_817.release_value(); }));
+__jakt_label_711:; __jakt_var_818.release_value(); }));
 };/*case end*/
 case 52 /* Comma */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
@@ -4002,20 +4002,20 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 52 /* Comma */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_818; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_819; {
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_818 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_712;
+__jakt_var_819 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_712;
 
 }
-__jakt_label_712:; __jakt_var_818.release_value(); }));
+__jakt_label_712:; __jakt_var_819.release_value(); }));
 };/*case end*/
 case 8 /* RParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_819; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_820; {
 ((*this).pop_state());
-__jakt_var_819 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_713;
+__jakt_var_820 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_713;
 
 }
-__jakt_label_713:; __jakt_var_819.release_value(); }));
+__jakt_label_713:; __jakt_var_820.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))));
@@ -4043,44 +4043,44 @@ case 86 /* Mut */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
 };/*case end*/
 case 5 /* Colon */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_820; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_821; {
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_820 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_714;
+__jakt_var_821 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_714;
 
 }
-__jakt_label_714:; __jakt_var_820.release_value(); }));
+__jakt_label_714:; __jakt_var_821.release_value(); }));
 };/*case end*/
 case 52 /* Comma */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
 };/*case end*/
 case 16 /* Equal */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_821; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_822; {
 TRY((((*this).push_state(formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false,formatter::ExpressionMode::AtExpressionStart(),static_cast<size_t>(0ULL))))));
-__jakt_var_821 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_715;
+__jakt_var_822 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_715;
 
 }
-__jakt_label_715:; __jakt_var_821.release_value(); }));
+__jakt_label_715:; __jakt_var_822.release_value(); }));
 };/*case end*/
 case 7 /* LParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_822; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_823; {
 TRY((((*this).replace_state(formatter::State::ParameterList(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)))))));
-__jakt_var_822 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_716;
+__jakt_var_823 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_716;
 
 }
-__jakt_label_716:; __jakt_var_822.release_value(); }));
+__jakt_label_716:; __jakt_var_823.release_value(); }));
 };/*case end*/
 case 8 /* RParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_823; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_824; {
 if (((open_parens) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::ParameterList(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL)))))));
-__jakt_var_823 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_717;
+__jakt_var_824 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_717;
 
 }
-__jakt_label_717:; __jakt_var_823.release_value(); }));
+__jakt_label_717:; __jakt_var_824.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))));
@@ -4102,48 +4102,48 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* Colon */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_824; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_825; {
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_824 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_718;
+__jakt_var_825 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_718;
 
 }
-__jakt_label_718:; __jakt_var_824.release_value(); }));
+__jakt_label_718:; __jakt_var_825.release_value(); }));
 };/*case end*/
 case 28 /* LessThan */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_825; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_826; {
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,JaktInternal::checked_add(open_angles,static_cast<size_t>(1ULL)),seen_start)))));
-__jakt_var_825 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_719;
+__jakt_var_826 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_719;
 
 }
-__jakt_label_719:; __jakt_var_825.release_value(); }));
+__jakt_label_719:; __jakt_var_826.release_value(); }));
 };/*case end*/
 case 26 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_826; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_827; {
 if (((open_angles) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,JaktInternal::checked_sub(open_angles,static_cast<size_t>(1ULL)),seen_start)))));
-__jakt_var_826 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_720;
+__jakt_var_827 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_720;
 
 }
-__jakt_label_720:; __jakt_var_826.release_value(); }));
+__jakt_label_720:; __jakt_var_827.release_value(); }));
 };/*case end*/
 case 55 /* Eol */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_827; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_828; {
 if (((JaktInternal::checked_add(JaktInternal::checked_add(JaktInternal::checked_add(open_parens,open_curlies),open_squares),open_angles)) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
-__jakt_var_827 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_721;
+__jakt_var_828 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_721;
 
 }
-__jakt_label_721:; __jakt_var_827.release_value(); }));
+__jakt_label_721:; __jakt_var_828.release_value(); }));
 };/*case end*/
 case 11 /* LSquare */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_828; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_829; {
 if (seen_start){
 ((((*this).index)--));
 ((*this).pop_state());
@@ -4151,26 +4151,26 @@ return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,JaktInternal::checked_add(open_squares,static_cast<size_t>(1ULL)),open_angles,true)))));
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_828 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_722;
+__jakt_var_829 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_722;
 
 }
-__jakt_label_722:; __jakt_var_828.release_value(); }));
+__jakt_label_722:; __jakt_var_829.release_value(); }));
 };/*case end*/
 case 12 /* RSquare */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_829; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_830; {
 if (((open_squares) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,JaktInternal::checked_sub(open_squares,static_cast<size_t>(1ULL)),open_angles,seen_start)))));
-__jakt_var_829 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_723;
+__jakt_var_830 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_723;
 
 }
-__jakt_label_723:; __jakt_var_829.release_value(); }));
+__jakt_label_723:; __jakt_var_830.release_value(); }));
 };/*case end*/
 case 7 /* LParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_830; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_831; {
 if (seen_start){
 ((((*this).index)--));
 ((*this).pop_state());
@@ -4178,26 +4178,26 @@ return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::TypeContext(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,open_angles,true)))));
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_830 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_724;
+__jakt_var_831 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_724;
 
 }
-__jakt_label_724:; __jakt_var_830.release_value(); }));
+__jakt_label_724:; __jakt_var_831.release_value(); }));
 };/*case end*/
 case 8 /* RParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_831; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_832; {
 if (((open_parens) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::TypeContext(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,open_angles,seen_start)))));
-__jakt_var_831 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_725;
+__jakt_var_832 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_725;
 
 }
-__jakt_label_725:; __jakt_var_831.release_value(); }));
+__jakt_label_725:; __jakt_var_832.release_value(); }));
 };/*case end*/
 case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_832; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_833; {
 if (seen_start){
 ((((*this).index)--));
 ((*this).pop_state());
@@ -4205,77 +4205,77 @@ return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,JaktInternal::checked_add(open_curlies,static_cast<size_t>(1ULL)),open_squares,open_angles,true)))));
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_832 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_726;
+__jakt_var_833 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_726;
 
 }
-__jakt_label_726:; __jakt_var_832.release_value(); }));
+__jakt_label_726:; __jakt_var_833.release_value(); }));
 };/*case end*/
 case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_833; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_834; {
 if (((open_curlies) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)) -= (static_cast<size_t>(1ULL)));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,JaktInternal::checked_sub(open_curlies,static_cast<size_t>(1ULL)),open_squares,open_angles,seen_start)))));
-__jakt_var_833 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_727;
+__jakt_var_834 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_727;
 
 }
-__jakt_label_727:; __jakt_var_833.release_value(); }));
+__jakt_label_727:; __jakt_var_834.release_value(); }));
 };/*case end*/
 case 93 /* Raw */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_834; {
-TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true)))));
-__jakt_var_834 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_728;
-
-}
-__jakt_label_728:; __jakt_var_834.release_value(); }));
-};/*case end*/
-case 86 /* Mut */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_835; {
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true)))));
-__jakt_var_835 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_729;
+__jakt_var_835 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_728;
 
 }
-__jakt_label_729:; __jakt_var_835.release_value(); }));
+__jakt_label_728:; __jakt_var_835.release_value(); }));
 };/*case end*/
-case 37 /* Ampersand */: {
+case 86 /* Mut */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_836; {
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true)))));
-__jakt_var_836 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_730;
+__jakt_var_836 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_729;
 
 }
-__jakt_label_730:; __jakt_var_836.release_value(); }));
+__jakt_label_729:; __jakt_var_836.release_value(); }));
 };/*case end*/
-case 75 /* Fn */: {
+case 37 /* Ampersand */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_837; {
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true)))));
-TRY((((*this).push_state(formatter::State::FunctionTypeContext(false)))));
-__jakt_var_837 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_731;
+__jakt_var_837 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_730;
 
 }
-__jakt_label_731:; __jakt_var_837.release_value(); }));
+__jakt_label_730:; __jakt_var_837.release_value(); }));
+};/*case end*/
+case 75 /* Fn */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_838; {
+TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true)))));
+TRY((((*this).push_state(formatter::State::FunctionTypeContext(false)))));
+__jakt_var_838 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_731;
+
+}
+__jakt_label_731:; __jakt_var_838.release_value(); }));
 };/*case end*/
 case 52 /* Comma */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_838; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_839; {
 if (((JaktInternal::checked_add(open_angles,open_parens)) == (static_cast<size_t>(0ULL)))){
 ((((*this).index)--));
 ((*this).pop_state());
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_838 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_732;
+__jakt_var_839 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_732;
 
 }
-__jakt_label_732:; __jakt_var_838.release_value(); }));
+__jakt_label_732:; __jakt_var_839.release_value(); }));
 };/*case end*/
 case 3 /* Identifier */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_839; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_840; {
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true)))));
-__jakt_var_839 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_733;
+__jakt_var_840 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_733;
 
 }
-__jakt_label_733:; __jakt_var_839.release_value(); }));
+__jakt_label_733:; __jakt_var_840.release_value(); }));
 };/*case end*/
 case 106 /* Weak */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
@@ -4321,33 +4321,33 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* RSquare */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_840; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_841; {
 ((*this).pop_state());
-__jakt_var_840 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_734;
+__jakt_var_841 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_734;
 
 }
-__jakt_label_734:; __jakt_var_840.release_value(); }));
+__jakt_label_734:; __jakt_var_841.release_value(); }));
 };/*case end*/
 case 52 /* Comma */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_841; {
-__jakt_var_841 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_735;
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_842; {
+__jakt_var_842 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_735;
 
 }
-__jakt_label_735:; __jakt_var_841.release_value(); }));
+__jakt_label_735:; __jakt_var_842.release_value(); }));
 };/*case end*/
 case 86 /* Mut */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_842; {
-__jakt_var_842 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_736;
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_843; {
+__jakt_var_843 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_736;
 
 }
-__jakt_label_736:; __jakt_var_842.release_value(); }));
+__jakt_label_736:; __jakt_var_843.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_843; {
-__jakt_var_843 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_737;
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_844; {
+__jakt_var_844 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_737;
 
 }
-__jakt_label_737:; __jakt_var_843.release_value(); }));
+__jakt_label_737:; __jakt_var_844.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -4380,7 +4380,7 @@ return TRY((((*this).next_impl(true))));
 }
 };/*case end*/
 case 58 /* Arrow */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_844; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_845; {
 if (seen_final_type){
 ((*this).pop_state());
 ((((*this).index)--));
@@ -4388,40 +4388,40 @@ return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::FunctionTypeContext(true)))));
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_844 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_738;
+__jakt_var_845 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_738;
 
 }
-__jakt_label_738:; __jakt_var_844.release_value(); }));
+__jakt_label_738:; __jakt_var_845.release_value(); }));
 };/*case end*/
 case 11 /* LSquare */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_845; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_846; {
 TRY((((*this).push_state(formatter::State::CaptureList()))));
-__jakt_var_845 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_739;
+__jakt_var_846 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_739;
 
 }
-__jakt_label_739:; __jakt_var_845.release_value(); }));
+__jakt_label_739:; __jakt_var_846.release_value(); }));
 };/*case end*/
 case 7 /* LParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_846; {
-if (seen_final_type){
-((*this).pop_state());
-((((*this).index)--));
-return TRY((((*this).next_impl(true))));
-}
-TRY((((*this).push_state(formatter::State::ParameterList(static_cast<size_t>(0ULL))))));
-__jakt_var_846 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_740;
-
-}
-__jakt_label_740:; __jakt_var_846.release_value(); }));
-};/*case end*/
-case 8 /* RParen */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_847; {
 if (seen_final_type){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
-__jakt_var_847 = ((*this).formatted_token(token,({
+TRY((((*this).push_state(formatter::State::ParameterList(static_cast<size_t>(0ULL))))));
+__jakt_var_847 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_740;
+
+}
+__jakt_label_740:; __jakt_var_847.release_value(); }));
+};/*case end*/
+case 8 /* RParen */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_848; {
+if (seen_final_type){
+((*this).pop_state());
+((((*this).index)--));
+return TRY((((*this).next_impl(true))));
+}
+__jakt_var_848 = ((*this).formatted_token(token,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -4440,22 +4440,22 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
 }),DynamicArray<u8>::create_with({}))); goto __jakt_label_741;
 
 }
-__jakt_label_741:; __jakt_var_847.release_value(); }));
+__jakt_label_741:; __jakt_var_848.release_value(); }));
 };/*case end*/
 case 101 /* Throws */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_848; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_849; {
 if (seen_final_type){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
-__jakt_var_848 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_742;
+__jakt_var_849 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_742;
 
 }
-__jakt_label_742:; __jakt_var_848.release_value(); }));
+__jakt_label_742:; __jakt_var_849.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -4474,53 +4474,53 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* LParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_849; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_850; {
 TRY((((*this).replace_state(formatter::State::MatchPattern(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)),allow_multiple)))));
 TRY((((*this).push_state(formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false,formatter::ExpressionMode::OutsideExpression(),static_cast<size_t>(0ULL))))));
-__jakt_var_849 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_743;
+__jakt_var_850 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_743;
 
 }
-__jakt_label_743:; __jakt_var_849.release_value(); }));
+__jakt_label_743:; __jakt_var_850.release_value(); }));
 };/*case end*/
 case 8 /* RParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_850; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_851; {
 if (((open_parens) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)) -= (static_cast<size_t>(1ULL)));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::MatchPattern(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL)),allow_multiple)))));
-__jakt_var_850 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_744;
+__jakt_var_851 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_744;
 
 }
-__jakt_label_744:; __jakt_var_850.release_value(); }));
+__jakt_label_744:; __jakt_var_851.release_value(); }));
 };/*case end*/
 case 55 /* Eol */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_851; {
-if ((!(allow_multiple))){
-((*this).pop_state());
-((((*this).index)) -= (static_cast<size_t>(1ULL)));
-return TRY((((*this).next_impl(true))));
-}
-__jakt_var_851 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_745;
-
-}
-__jakt_label_745:; __jakt_var_851.release_value(); }));
-};/*case end*/
-case 3 /* Identifier */: {
-return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))));
-};/*case end*/
-case 40 /* Pipe */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_852; {
 if ((!(allow_multiple))){
 ((*this).pop_state());
 ((((*this).index)) -= (static_cast<size_t>(1ULL)));
 return TRY((((*this).next_impl(true))));
 }
-__jakt_var_852 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_746;
+__jakt_var_852 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))); goto __jakt_label_745;
 
 }
-__jakt_label_746:; __jakt_var_852.release_value(); }));
+__jakt_label_745:; __jakt_var_852.release_value(); }));
+};/*case end*/
+case 3 /* Identifier */: {
+return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}))));
+};/*case end*/
+case 40 /* Pipe */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_853; {
+if ((!(allow_multiple))){
+((*this).pop_state());
+((((*this).index)) -= (static_cast<size_t>(1ULL)));
+return TRY((((*this).next_impl(true))));
+}
+__jakt_var_853 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_746;
+
+}
+__jakt_label_746:; __jakt_var_853.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -4606,7 +4606,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 }
-ScopeGuard __jakt_var_853([&] {
+ScopeGuard __jakt_var_854([&] {
 {
 if ([](i64 const& self, i64 rhs) -> bool {{
 return (((infallible_integer_cast<u8>(([](i64 const& self, i64 rhs) -> jakt__prelude__operators::Ordering {{

--- a/bootstrap/stage0/git.cpp
+++ b/bootstrap/stage0/git.cpp
@@ -3,7 +3,7 @@ namespace Jakt {
 namespace git {
 ErrorOr<ByteString> commit_hash() {
 {
-ByteString const hash = (ByteString::from_utf8_without_validation("HEAD"sv));
+ByteString const hash = (ByteString::from_utf8_without_validation("b7a77b58846ef58182319c9b8b3aee354b14073f"sv));
 return hash;
 }
 }

--- a/bootstrap/stage0/ide.cpp
+++ b/bootstrap/stage0/ide.cpp
@@ -85,29 +85,6 @@ auto&& __jakt_match_variant = ((record).record_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<parser::ParsedField> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_854; {
-{
-JaktInternal::ArrayIterator<parser::ParsedField> _magic = ((fields).iterator());
-for (;;){
-JaktInternal::Optional<parser::ParsedField> const _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-parser::ParsedField field = (_magic_value.value());
-{
-((children).push(ide::JaktSymbol(((((field).var_decl)).name),JaktInternal::OptionalNone(),(ByteString::from_utf8_without_validation("field"sv)),((((field).var_decl)).span),((((field).var_decl)).span),DynamicArray<ide::JaktSymbol>::create_with({}))));
-}
-
-}
-}
-
-__jakt_var_854 = (ByteString::from_utf8_without_validation("struct"sv)); goto __jakt_label_747;
-
-}
-__jakt_label_747:; __jakt_var_854.release_value(); }));
-};/*case end*/
-case 1 /* Class */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.Class;JaktInternal::DynamicArray<parser::ParsedField> const& fields = __jakt_match_value.fields;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_855; {
 {
 JaktInternal::ArrayIterator<parser::ParsedField> _magic = ((fields).iterator());
@@ -124,14 +101,37 @@ parser::ParsedField field = (_magic_value.value());
 }
 }
 
-__jakt_var_855 = (ByteString::from_utf8_without_validation("class"sv)); goto __jakt_label_748;
+__jakt_var_855 = (ByteString::from_utf8_without_validation("struct"sv)); goto __jakt_label_747;
 
 }
-__jakt_label_748:; __jakt_var_855.release_value(); }));
+__jakt_label_747:; __jakt_var_855.release_value(); }));
+};/*case end*/
+case 1 /* Class */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Class;JaktInternal::DynamicArray<parser::ParsedField> const& fields = __jakt_match_value.fields;
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_856; {
+{
+JaktInternal::ArrayIterator<parser::ParsedField> _magic = ((fields).iterator());
+for (;;){
+JaktInternal::Optional<parser::ParsedField> const _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+parser::ParsedField field = (_magic_value.value());
+{
+((children).push(ide::JaktSymbol(((((field).var_decl)).name),JaktInternal::OptionalNone(),(ByteString::from_utf8_without_validation("field"sv)),((((field).var_decl)).span),((((field).var_decl)).span),DynamicArray<ide::JaktSymbol>::create_with({}))));
+}
+
+}
+}
+
+__jakt_var_856 = (ByteString::from_utf8_without_validation("class"sv)); goto __jakt_label_748;
+
+}
+__jakt_label_748:; __jakt_var_856.release_value(); }));
 };/*case end*/
 case 2 /* ValueEnum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ValueEnum;JaktInternal::DynamicArray<parser::ValueEnumVariant> const& variants = __jakt_match_value.variants;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_856; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_857; {
 {
 JaktInternal::ArrayIterator<parser::ValueEnumVariant> _magic = ((variants).iterator());
 for (;;){
@@ -147,14 +147,14 @@ parser::ValueEnumVariant variant = (_magic_value.value());
 }
 }
 
-__jakt_var_856 = (ByteString::from_utf8_without_validation("enum"sv)); goto __jakt_label_749;
+__jakt_var_857 = (ByteString::from_utf8_without_validation("enum"sv)); goto __jakt_label_749;
 
 }
-__jakt_label_749:; __jakt_var_856.release_value(); }));
+__jakt_label_749:; __jakt_var_857.release_value(); }));
 };/*case end*/
 case 3 /* SumEnum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SumEnum;JaktInternal::DynamicArray<parser::SumEnumVariant> const& variants = __jakt_match_value.variants;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_857; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_858; {
 {
 JaktInternal::ArrayIterator<parser::SumEnumVariant> _magic = ((variants).iterator());
 for (;;){
@@ -194,10 +194,10 @@ return (!(((self) == (rhs))));
 }
 }
 
-__jakt_var_857 = (ByteString::from_utf8_without_validation("enum"sv)); goto __jakt_label_750;
+__jakt_var_858 = (ByteString::from_utf8_without_validation("enum"sv)); goto __jakt_label_750;
 
 }
-__jakt_label_750:; __jakt_var_857.release_value(); }));
+__jakt_label_750:; __jakt_var_858.release_value(); }));
 };/*case end*/
 case 4 /* Garbage */: {
 return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("garbage"sv)));
@@ -381,7 +381,7 @@ return JaktInternal::ExplicitValue(((value).span));
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& struct_id = __jakt_match_value.id;
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_858; {
+return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_859; {
 utility::Span output = span;
 if ((((((((struct_id).equals(array_struct_id)) || ((struct_id).equals(optional_struct_id))) || ((struct_id).equals(range_struct_id))) || ((struct_id).equals(set_struct_id))) || ((struct_id).equals(tuple_struct_id))) || ((struct_id).equals(weak_ptr_struct_id)))){
 (output = TRY((ide::find_type_definition_for_type_id(program,((args)[static_cast<i64>(0LL)]),span))));
@@ -393,10 +393,10 @@ else {
 (output = ((((program)->get_struct(struct_id))).name_span));
 }
 
-__jakt_var_858 = output; goto __jakt_label_751;
+__jakt_var_859 = output; goto __jakt_label_751;
 
 }
-__jakt_label_751:; __jakt_var_858.release_value(); }));
+__jakt_label_751:; __jakt_var_859.release_value(); }));
 };/*case end*/
 case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& struct_id = __jakt_match_value.value;
@@ -454,27 +454,27 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Variable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Variable;utility::Span const& span = __jakt_match_value.span;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_859; {
-__jakt_var_859 = TRY((ide::find_type_definition_for_type_id(program,type_id,span))); goto __jakt_label_752;
+return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_860; {
+__jakt_var_860 = TRY((ide::find_type_definition_for_type_id(program,type_id,span))); goto __jakt_label_752;
 
 }
-__jakt_label_752:; __jakt_var_859.release_value(); }));
+__jakt_label_752:; __jakt_var_860.release_value(); }));
 };/*case end*/
 case 1 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;ids::FunctionId const& function_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_860; {
-__jakt_var_860 = ((((program)->get_function(function_id)))->name_span); goto __jakt_label_753;
+return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_861; {
+__jakt_var_861 = ((((program)->get_function(function_id)))->name_span); goto __jakt_label_753;
 
 }
-__jakt_label_753:; __jakt_var_860.release_value(); }));
+__jakt_label_753:; __jakt_var_861.release_value(); }));
 };/*case end*/
 case 2 /* Typename */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typename;ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_861; {
-__jakt_var_861 = TRY((ide::find_type_definition_for_type_id(program,type_id,span))); goto __jakt_label_754;
+return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_862; {
+__jakt_var_862 = TRY((ide::find_type_definition_for_type_id(program,type_id,span))); goto __jakt_label_754;
 
 }
-__jakt_label_754:; __jakt_var_861.release_value(); }));
+__jakt_label_754:; __jakt_var_862.release_value(); }));
 };/*case end*/
 case 3 /* NameSet */: {
 return JaktInternal::ExplicitValue(span);
@@ -513,34 +513,34 @@ ide::Mutability const& mutability = __jakt_match_value.mutability;
 ide::VarType const& var_type = __jakt_match_value.var_type;
 ide::VarVisibility const& visibility = __jakt_match_value.visibility;
 JaktInternal::Optional<ids::TypeId> const& struct_type_id = __jakt_match_value.struct_type_id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_862; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_863; {
 ByteString const result = TRY((ide::get_var_signature(program,name,type_id,mutability,var_type,visibility,struct_type_id)));
-__jakt_var_862 = static_cast<JaktInternal::Optional<ByteString>>(result); goto __jakt_label_755;
+__jakt_var_863 = static_cast<JaktInternal::Optional<ByteString>>(result); goto __jakt_label_755;
 
 }
-__jakt_label_755:; __jakt_var_862.release_value(); }));
+__jakt_label_755:; __jakt_var_863.release_value(); }));
 };/*case end*/
 case 1 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;ids::FunctionId const& function_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_863; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_864; {
 ByteString const result = TRY((ide::get_function_signature(program,function_id)));
-__jakt_var_863 = static_cast<JaktInternal::Optional<ByteString>>(result); goto __jakt_label_756;
+__jakt_var_864 = static_cast<JaktInternal::Optional<ByteString>>(result); goto __jakt_label_756;
 
 }
-__jakt_label_756:; __jakt_var_863.release_value(); }));
+__jakt_label_756:; __jakt_var_864.release_value(); }));
 };/*case end*/
 case 2 /* Typename */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typename;ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_864; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_865; {
 ByteString const result = TRY((ide::get_type_signature(program,type_id)));
-__jakt_var_864 = static_cast<JaktInternal::Optional<ByteString>>(result); goto __jakt_label_757;
+__jakt_var_865 = static_cast<JaktInternal::Optional<ByteString>>(result); goto __jakt_label_757;
 
 }
-__jakt_label_757:; __jakt_var_864.release_value(); }));
+__jakt_label_757:; __jakt_var_865.release_value(); }));
 };/*case end*/
 case 3 /* NameSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NameSet;JaktInternal::DynamicArray<ByteString> const& names = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_865; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_866; {
 ByteString output = (ByteString::from_utf8_without_validation(""sv));
 bool first = true;
 {
@@ -573,22 +573,22 @@ else {
 }
 }
 
-__jakt_var_865 = static_cast<JaktInternal::Optional<ByteString>>(output); goto __jakt_label_758;
+__jakt_var_866 = static_cast<JaktInternal::Optional<ByteString>>(output); goto __jakt_label_758;
 
 }
-__jakt_label_758:; __jakt_var_865.release_value(); }));
+__jakt_label_758:; __jakt_var_866.release_value(); }));
 };/*case end*/
 case 4 /* EnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;ByteString const& name = __jakt_match_value.name;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
 JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>> const& variants = __jakt_match_value.variants;
 JaktInternal::Optional<types::NumberConstant> const& number_constant = __jakt_match_value.number_constant;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_866; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_867; {
 ByteString const result = TRY((ide::get_enum_variant_signature(program,name,type_id,variants,number_constant)));
-__jakt_var_866 = static_cast<JaktInternal::Optional<ByteString>>(result); goto __jakt_label_759;
+__jakt_var_867 = static_cast<JaktInternal::Optional<ByteString>>(result); goto __jakt_label_759;
 
 }
-__jakt_label_759:; __jakt_var_866.release_value(); }));
+__jakt_label_759:; __jakt_var_867.release_value(); }));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -789,20 +789,20 @@ auto&& __jakt_match_variant = (result.value());
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Variable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Variable;ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<ByteString>> __jakt_var_867; {
-__jakt_var_867 = TRY((ide::completions_for_type_id(program,type_id))); goto __jakt_label_760;
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<ByteString>> __jakt_var_868; {
+__jakt_var_868 = TRY((ide::completions_for_type_id(program,type_id))); goto __jakt_label_760;
 
 }
-__jakt_label_760:; __jakt_var_867.release_value(); }));
+__jakt_label_760:; __jakt_var_868.release_value(); }));
 };/*case end*/
 case 1 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;ids::FunctionId const& function_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<ByteString>> __jakt_var_868; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<ByteString>> __jakt_var_869; {
 ids::TypeId const result_type_id = ((((program)->get_function(function_id)))->return_type_id);
-__jakt_var_868 = TRY((ide::completions_for_type_id(program,result_type_id))); goto __jakt_label_761;
+__jakt_var_869 = TRY((ide::completions_for_type_id(program,result_type_id))); goto __jakt_label_761;
 
 }
-__jakt_label_761:; __jakt_var_868.release_value(); }));
+__jakt_label_761:; __jakt_var_869.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({}));
@@ -1162,7 +1162,7 @@ case 4 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;NonnullRefPtr<typename types::CheckedExpression> const& condition = __jakt_match_value.condition;
 types::CheckedBlock const& then_block = __jakt_match_value.then_block;
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedStatement>> const& else_statement = __jakt_match_value.else_statement;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_869; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_870; {
 JaktInternal::Optional<ide::Usage> found = TRY((ide::find_span_in_expression(program,condition,span)));
 if (((found).has_value())){
 return found;
@@ -1174,18 +1174,18 @@ return found;
 if (((else_statement).has_value())){
 return TRY((ide::find_span_in_statement(program,(else_statement.value()),span)));
 }
-__jakt_var_869 = none; goto __jakt_label_762;
+__jakt_var_870 = none; goto __jakt_label_762;
 
 }
-__jakt_label_762:; __jakt_var_869.release_value(); }));
+__jakt_label_762:; __jakt_var_870.release_value(); }));
 };/*case end*/
 case 13 /* InlineCpp */: {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_870; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_871; {
 JaktInternal::Optional<ide::Usage> const output = JaktInternal::OptionalNone();
-__jakt_var_870 = output; goto __jakt_label_763;
+__jakt_var_871 = output; goto __jakt_label_763;
 
 }
-__jakt_label_763:; __jakt_var_870.release_value(); }));
+__jakt_label_763:; __jakt_var_871.release_value(); }));
 };/*case end*/
 case 6 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;types::CheckedBlock const& block = __jakt_match_value.block;
@@ -1215,7 +1215,7 @@ return JaktInternal::ExplicitValue(TRY((ide::find_span_in_expression(program,exp
 case 3 /* VarDecl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.VarDecl;ids::VarId const& var_id = __jakt_match_value.var_id;
 NonnullRefPtr<typename types::CheckedExpression> const& init = __jakt_match_value.init;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_871; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_872; {
 NonnullRefPtr<types::CheckedVariable> const checked_var = ((program)->get_variable(var_id));
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,init,span)));
 if (((found).has_value())){
@@ -1245,28 +1245,28 @@ VERIFY_NOT_REACHED();
 });
 return static_cast<JaktInternal::Optional<ide::Usage>>(ide::Usage::Variable(((checked_var)->definition_span),((checked_var)->name),((checked_var)->type_id),mutability,ide::VarType::Variable(),ide::VarVisibility::DoesNotApply(),JaktInternal::OptionalNone()));
 }
-__jakt_var_871 = none; goto __jakt_label_764;
+__jakt_var_872 = none; goto __jakt_label_764;
 
 }
-__jakt_label_764:; __jakt_var_871.release_value(); }));
+__jakt_label_764:; __jakt_var_872.release_value(); }));
 };/*case end*/
 case 7 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;NonnullRefPtr<typename types::CheckedExpression> const& condition = __jakt_match_value.condition;
 types::CheckedBlock const& block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_872; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_873; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,condition,span)));
 if (((found).has_value())){
 return found;
 }
-__jakt_var_872 = TRY((ide::find_span_in_block(program,block,span))); goto __jakt_label_765;
+__jakt_var_873 = TRY((ide::find_span_in_block(program,block,span))); goto __jakt_label_765;
 
 }
-__jakt_label_765:; __jakt_var_872.release_value(); }));
+__jakt_label_765:; __jakt_var_873.release_value(); }));
 };/*case end*/
 case 2 /* DestructuringAssignment */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DestructuringAssignment;JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedStatement>> const& vars = __jakt_match_value.vars;
 NonnullRefPtr<typename types::CheckedStatement> const& var_decl = __jakt_match_value.var_decl;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_873; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_874; {
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename types::CheckedStatement>> _magic = ((vars).iterator());
 for (;;){
@@ -1285,10 +1285,10 @@ return found;
 }
 }
 
-__jakt_var_873 = TRY((ide::find_span_in_statement(program,var_decl,span))); goto __jakt_label_766;
+__jakt_var_874 = TRY((ide::find_span_in_statement(program,var_decl,span))); goto __jakt_label_766;
 
 }
-__jakt_label_766:; __jakt_var_873.release_value(); }));
+__jakt_label_766:; __jakt_var_874.release_value(); }));
 };/*case end*/
 case 12 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
@@ -1324,20 +1324,20 @@ case 7 /* BinaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.BinaryOp;NonnullRefPtr<typename types::CheckedExpression> const& lhs = __jakt_match_value.lhs;
 types::CheckedBinaryOperator const& op = __jakt_match_value.op;
 NonnullRefPtr<typename types::CheckedExpression> const& rhs = __jakt_match_value.rhs;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_874; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_875; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,lhs,span)));
 if (((found).has_value())){
 return found;
 }
-__jakt_var_874 = TRY((ide::find_span_in_expression(program,rhs,span))); goto __jakt_label_767;
+__jakt_var_875 = TRY((ide::find_span_in_expression(program,rhs,span))); goto __jakt_label_767;
 
 }
-__jakt_label_767:; __jakt_var_874.release_value(); }));
+__jakt_label_767:; __jakt_var_875.release_value(); }));
 };/*case end*/
 case 10 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> const& vals = __jakt_match_value.vals;
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const& repeat = __jakt_match_value.repeat;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_875; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_876; {
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename types::CheckedExpression>> _magic = ((vals).iterator());
 for (;;){
@@ -1359,10 +1359,10 @@ return found;
 if (((repeat).has_value())){
 return TRY((ide::find_span_in_expression(program,(repeat.value()),span)));
 }
-__jakt_var_875 = none; goto __jakt_label_768;
+__jakt_var_876 = none; goto __jakt_label_768;
 
 }
-__jakt_label_768:; __jakt_var_875.release_value(); }));
+__jakt_label_768:; __jakt_var_876.release_value(); }));
 };/*case end*/
 case 28 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;types::CheckedBlock const& block = __jakt_match_value.block;
@@ -1371,7 +1371,7 @@ return JaktInternal::ExplicitValue(TRY((ide::find_span_in_block(program,block,sp
 case 21 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;types::CheckedCall const& call = __jakt_match_value.call;
 utility::Span const& call_span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_876; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_877; {
 {
 JaktInternal::ArrayIterator<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>> _magic = ((((call).args)).iterator());
 for (;;){
@@ -1397,14 +1397,14 @@ return found;
 if ((((((call).function_id)).has_value()) && ((call_span).contains(span)))){
 return static_cast<JaktInternal::Optional<ide::Usage>>(ide::Usage::Call((((call).function_id).value())));
 }
-__jakt_var_876 = none; goto __jakt_label_769;
+__jakt_var_877 = none; goto __jakt_label_769;
 
 }
-__jakt_label_769:; __jakt_var_876.release_value(); }));
+__jakt_label_769:; __jakt_var_877.release_value(); }));
 };/*case end*/
 case 12 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename types::CheckedExpression>,NonnullRefPtr<typename types::CheckedExpression>>> const& vals = __jakt_match_value.vals;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_877; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_878; {
 {
 JaktInternal::ArrayIterator<JaktInternal::Tuple<NonnullRefPtr<typename types::CheckedExpression>,NonnullRefPtr<typename types::CheckedExpression>>> _magic = ((vals).iterator());
 for (;;){
@@ -1431,15 +1431,15 @@ return found;
 }
 }
 
-__jakt_var_877 = none; goto __jakt_label_770;
+__jakt_var_878 = none; goto __jakt_label_770;
 
 }
-__jakt_label_770:; __jakt_var_877.release_value(); }));
+__jakt_label_770:; __jakt_var_878.release_value(); }));
 };/*case end*/
 case 13 /* IndexedExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedExpression;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 NonnullRefPtr<typename types::CheckedExpression> const& index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_878; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_879; {
 JaktInternal::Optional<ide::Usage> found = TRY((ide::find_span_in_expression(program,expr,span)));
 if (((found).has_value())){
 return found;
@@ -1448,17 +1448,17 @@ return found;
 if (((found).has_value())){
 return found;
 }
-__jakt_var_878 = none; goto __jakt_label_771;
+__jakt_var_879 = none; goto __jakt_label_771;
 
 }
-__jakt_label_771:; __jakt_var_878.release_value(); }));
+__jakt_label_771:; __jakt_var_879.release_value(); }));
 };/*case end*/
 case 16 /* IndexedStruct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedStruct;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 ByteString const& name = __jakt_match_value.name;
 utility::Span const& index_span = __jakt_match_value.span;
 ids::TypeId const& known_type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_879; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_880; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,expr,span)));
 if (((found).has_value())){
 return found;
@@ -1519,30 +1519,30 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 
 }
 }
-__jakt_var_879 = none; goto __jakt_label_772;
+__jakt_var_880 = none; goto __jakt_label_772;
 
 }
-__jakt_label_772:; __jakt_var_879.release_value(); }));
+__jakt_label_772:; __jakt_var_880.release_value(); }));
 };/*case end*/
 case 14 /* IndexedDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedDictionary;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 NonnullRefPtr<typename types::CheckedExpression> const& index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_880; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_881; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,expr,span)));
 if (((found).has_value())){
 return found;
 }
-__jakt_var_880 = TRY((ide::find_span_in_expression(program,index,span))); goto __jakt_label_773;
+__jakt_var_881 = TRY((ide::find_span_in_expression(program,index,span))); goto __jakt_label_773;
 
 }
-__jakt_label_773:; __jakt_var_880.release_value(); }));
+__jakt_label_773:; __jakt_var_881.release_value(); }));
 };/*case end*/
 case 19 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 JaktInternal::DynamicArray<types::CheckedMatchCase> const& match_cases = __jakt_match_value.match_cases;
 utility::Span const& match_span = __jakt_match_value.span;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_881; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_882; {
 {
 JaktInternal::ArrayIterator<types::CheckedMatchCase> _magic = ((match_cases).iterator());
 for (;;){
@@ -1564,11 +1564,11 @@ size_t const& index = __jakt_match_value.index;
 ids::ScopeId const& scope_id = __jakt_match_value.scope_id;
 types::CheckedMatchBody const& body = __jakt_match_value.body;
 utility::Span const& marker_span = __jakt_match_value.marker_span;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_882; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_883; {
 if (((marker_span).contains(span))){
 return static_cast<JaktInternal::Optional<ide::Usage>>(ide::get_enum_variant_usage_from_type_id_and_name(program,subject_type_id,name));
 }
-__jakt_var_882 = ({
+__jakt_var_883 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>, ErrorOr<JaktInternal::Optional<ide::Usage>>>{
 auto&& __jakt_match_variant = body;
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -1593,17 +1593,17 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 }); goto __jakt_label_775;
 
 }
-__jakt_label_775:; __jakt_var_882.release_value(); }));
+__jakt_label_775:; __jakt_var_883.release_value(); }));
 };/*case end*/
 case 1 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expression;
 types::CheckedMatchBody const& body = __jakt_match_value.body;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_883; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_884; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,expr,span)));
 if (((found).has_value())){
 return found;
 }
-__jakt_var_883 = ({
+__jakt_var_884 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>, ErrorOr<JaktInternal::Optional<ide::Usage>>>{
 auto&& __jakt_match_variant = body;
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -1628,7 +1628,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 }); goto __jakt_label_776;
 
 }
-__jakt_label_776:; __jakt_var_883.release_value(); }));
+__jakt_label_776:; __jakt_var_884.release_value(); }));
 };/*case end*/
 case 3 /* CatchAll */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;types::CheckedMatchBody const& body = __jakt_match_value.body;
@@ -1637,38 +1637,13 @@ return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>,ErrorOr<JaktInternal::Optional<ide::Usage>>> {
 auto __jakt_enum_value = (((marker_span).contains(span)));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_884; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_885; {
 JaktInternal::Set<ByteString> const all_cases = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Set<ByteString>, ErrorOr<JaktInternal::Optional<ide::Usage>>>{
 auto&& __jakt_match_variant = *((program)->get_type(type_id));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 25 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& enum_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Set<ByteString>> __jakt_var_885; {
-JaktInternal::Set<ByteString> names = Set<ByteString>::create_with_values({});
-types::CheckedEnum const enum_ = ((program)->get_enum(enum_id));
-{
-JaktInternal::ArrayIterator<types::CheckedEnumVariant> _magic = ((((enum_).variants)).iterator());
-for (;;){
-JaktInternal::Optional<types::CheckedEnumVariant> const _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-types::CheckedEnumVariant variant = (_magic_value.value());
-{
-((names).add(((variant).name())));
-}
-
-}
-}
-
-__jakt_var_885 = names; goto __jakt_label_778;
-
-}
-__jakt_label_778:; __jakt_var_885.release_value(); }));
-};/*case end*/
-case 21 /* GenericEnumInstance */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::EnumId const& enum_id = __jakt_match_value.id;
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Set<ByteString>> __jakt_var_886; {
 JaktInternal::Set<ByteString> names = Set<ByteString>::create_with_values({});
 types::CheckedEnum const enum_ = ((program)->get_enum(enum_id));
@@ -1687,17 +1662,42 @@ types::CheckedEnumVariant variant = (_magic_value.value());
 }
 }
 
-__jakt_var_886 = names; goto __jakt_label_779;
+__jakt_var_886 = names; goto __jakt_label_778;
 
 }
-__jakt_label_779:; __jakt_var_886.release_value(); }));
+__jakt_label_778:; __jakt_var_886.release_value(); }));
+};/*case end*/
+case 21 /* GenericEnumInstance */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::EnumId const& enum_id = __jakt_match_value.id;
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Set<ByteString>> __jakt_var_887; {
+JaktInternal::Set<ByteString> names = Set<ByteString>::create_with_values({});
+types::CheckedEnum const enum_ = ((program)->get_enum(enum_id));
+{
+JaktInternal::ArrayIterator<types::CheckedEnumVariant> _magic = ((((enum_).variants)).iterator());
+for (;;){
+JaktInternal::Optional<types::CheckedEnumVariant> const _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::CheckedEnumVariant variant = (_magic_value.value());
+{
+((names).add(((variant).name())));
+}
+
+}
+}
+
+__jakt_var_887 = names; goto __jakt_label_779;
+
+}
+__jakt_label_779:; __jakt_var_887.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Set<ByteString>> __jakt_var_887; {
-__jakt_var_887 = Set<ByteString>::create_with_values({__jakt_format((StringView::from_string_literal("else ({})"sv)),TRY((((program)->type_name(type_id,false)))))}); goto __jakt_label_780;
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Set<ByteString>> __jakt_var_888; {
+__jakt_var_888 = Set<ByteString>::create_with_values({__jakt_format((StringView::from_string_literal("else ({})"sv)),TRY((((program)->type_name(type_id,false)))))}); goto __jakt_label_780;
 
 }
-__jakt_label_780:; __jakt_var_887.release_value(); }));
+__jakt_label_780:; __jakt_var_888.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -1729,11 +1729,11 @@ ByteString const name = (other_case).as.EnumVariant.name;
 }
 }
 
-__jakt_var_884 = ({
+__jakt_var_885 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>,ErrorOr<JaktInternal::Optional<ide::Usage>>> {
 auto __jakt_enum_value = (((remaining_cases).is_empty()));
 if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_888; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_889; {
 JaktInternal::DynamicArray<ByteString> cases_array = DynamicArray<ByteString>::create_with({});
 ((cases_array).ensure_capacity(((remaining_cases).size())));
 {
@@ -1751,10 +1751,10 @@ ByteString name = (_magic_value.value());
 }
 }
 
-__jakt_var_888 = static_cast<JaktInternal::Optional<ide::Usage>>(ide::Usage::NameSet(cases_array)); goto __jakt_label_781;
+__jakt_var_889 = static_cast<JaktInternal::Optional<ide::Usage>>(ide::Usage::NameSet(cases_array)); goto __jakt_label_781;
 
 }
-__jakt_label_781:; __jakt_var_888.release_value(); }));
+__jakt_label_781:; __jakt_var_889.release_value(); }));
 }
 else if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
@@ -1771,7 +1771,7 @@ VERIFY_NOT_REACHED();
 }); goto __jakt_label_777;
 
 }
-__jakt_label_777:; __jakt_var_884.release_value(); }));
+__jakt_label_777:; __jakt_var_885.release_value(); }));
 }
 else {
 return JaktInternal::ExplicitValue(({
@@ -1871,10 +1871,10 @@ return found;
 }
 }
 
-__jakt_var_881 = TRY((ide::find_span_in_expression(program,expr,span))); goto __jakt_label_774;
+__jakt_var_882 = TRY((ide::find_span_in_expression(program,expr,span))); goto __jakt_label_774;
 
 }
-__jakt_label_774:; __jakt_var_881.release_value(); }));
+__jakt_label_774:; __jakt_var_882.release_value(); }));
 };/*case end*/
 case 27 /* ForcedUnwrap */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForcedUnwrap;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
@@ -1951,7 +1951,7 @@ case 23 /* NamespacedVar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedVar;JaktInternal::DynamicArray<types::CheckedNamespace> const& namespaces = __jakt_match_value.namespaces;
 NonnullRefPtr<types::CheckedVariable> const& var = __jakt_match_value.var;
 utility::Span const& var_span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_889; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_890; {
 if ((((var_span).contains(span)) && (!(((namespaces).is_empty()))))){
 types::CheckedNamespace const last_ns = (((namespaces).last()).value());
 if (((((((program)->get_scope(((last_ns).scope))))->namespace_name)).has_value())){
@@ -1962,34 +1962,34 @@ return static_cast<JaktInternal::Optional<ide::Usage>>(ide::get_enum_variant_usa
 }
 }
 }
-__jakt_var_889 = none; goto __jakt_label_782;
+__jakt_var_890 = none; goto __jakt_label_782;
 
 }
-__jakt_label_782:; __jakt_var_889.release_value(); }));
+__jakt_label_782:; __jakt_var_890.release_value(); }));
 };/*case end*/
 case 33 /* TryBlock */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TryBlock;NonnullRefPtr<typename types::CheckedStatement> const& stmt = __jakt_match_value.stmt;
 ByteString const& error_name = __jakt_match_value.error_name;
 types::CheckedBlock const& catch_block = __jakt_match_value.catch_block;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_890; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_891; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_statement(program,stmt,span)));
 if (((found).has_value())){
 return found;
 }
-__jakt_var_890 = TRY((ide::find_span_in_block(program,catch_block,span))); goto __jakt_label_783;
+__jakt_var_891 = TRY((ide::find_span_in_block(program,catch_block,span))); goto __jakt_label_783;
 
 }
-__jakt_label_783:; __jakt_var_890.release_value(); }));
+__jakt_label_783:; __jakt_var_891.release_value(); }));
 };/*case end*/
 case 32 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 JaktInternal::Optional<types::CheckedBlock> const& catch_block = __jakt_match_value.catch_block;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_891; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_892; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,expr,span)));
 if (((found).has_value())){
 return found;
 }
-__jakt_var_891 = ({
+__jakt_var_892 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>,ErrorOr<JaktInternal::Optional<ide::Usage>>> {
 auto __jakt_enum_value = (((catch_block).has_value()));
 if (__jakt_enum_value == true) {
@@ -2006,12 +2006,12 @@ VERIFY_NOT_REACHED();
 }); goto __jakt_label_784;
 
 }
-__jakt_label_784:; __jakt_var_891.release_value(); }));
+__jakt_label_784:; __jakt_var_892.release_value(); }));
 };/*case end*/
 case 9 /* Range */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Range;JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const& from = __jakt_match_value.from;
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const& to = __jakt_match_value.to;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_892; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_893; {
 if (((from).has_value())){
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,(from.value()),span)));
 if (((found).has_value())){
@@ -2021,10 +2021,10 @@ return found;
 if (((to).has_value())){
 return TRY((ide::find_span_in_expression(program,(to.value()),span)));
 }
-__jakt_var_892 = none; goto __jakt_label_785;
+__jakt_var_893 = none; goto __jakt_label_785;
 
 }
-__jakt_label_785:; __jakt_var_892.release_value(); }));
+__jakt_label_785:; __jakt_var_893.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(none);
@@ -2272,7 +2272,7 @@ return ({
 auto&& __jakt_match_variant = var_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Variable */: {
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_893; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_894; {
 ByteString const mut_string = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = mutability;
@@ -2294,10 +2294,10 @@ return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""s
     _jakt_value.release_value();
 });
 ByteString const type_name = TRY((ide::get_type_signature(program,var_type_id)));
-__jakt_var_893 = __jakt_format((StringView::from_string_literal("{} {}: {}"sv)),mut_string,name,type_name); goto __jakt_label_786;
+__jakt_var_894 = __jakt_format((StringView::from_string_literal("{} {}: {}"sv)),mut_string,name,type_name); goto __jakt_label_786;
 
 }
-__jakt_label_786:; __jakt_var_893.release_value(); }));
+__jakt_label_786:; __jakt_var_894.release_value(); }));
 };/*case end*/
 case 1 /* Field */: {
 {
@@ -2440,7 +2440,7 @@ return JaktInternal::ExplicitValue(TRY((types::comptime_format_impl((ByteString:
 case 30 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<ids::TypeId> const& params = __jakt_match_value.params;
 ids::TypeId const& return_type_id = __jakt_match_value.return_type_id;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_894; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_895; {
 JaktInternal::DynamicArray<ByteString> param_names = DynamicArray<ByteString>::create_with({});
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((params).iterator());
@@ -2458,10 +2458,10 @@ ids::TypeId x = (_magic_value.value());
 }
 
 ByteString const return_type = TRY((((program)->type_name(return_type_id,false))));
-__jakt_var_894 = __jakt_format((StringView::from_string_literal("fn({}) -> {}"sv)),utility::join(param_names,(ByteString::from_utf8_without_validation(", "sv))),return_type); goto __jakt_label_787;
+__jakt_var_895 = __jakt_format((StringView::from_string_literal("fn({}) -> {}"sv)),utility::join(param_names,(ByteString::from_utf8_without_validation(", "sv))),return_type); goto __jakt_label_787;
 
 }
-__jakt_label_787:; __jakt_var_894.release_value(); }));
+__jakt_label_787:; __jakt_var_895.release_value(); }));
 };/*case end*/
 case 26 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;ids::TypeId const& type_id = __jakt_match_value.value;
@@ -2469,9 +2469,9 @@ return JaktInternal::ExplicitValue((((ByteString::from_utf8_without_validation("
 };/*case end*/
 case 25 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_895; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_896; {
 types::CheckedEnum const enum_ = ((program)->get_enum(id));
-__jakt_var_895 = ((((({
+__jakt_var_896 = ((((({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
 auto __jakt_enum_value = (((enum_).is_boxed));
 if (__jakt_enum_value == true) {
@@ -2487,13 +2487,13 @@ return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""s
 })) + ((ByteString::from_utf8_without_validation("enum "sv))))) + (((enum_).name))); goto __jakt_label_788;
 
 }
-__jakt_label_788:; __jakt_var_895.release_value(); }));
+__jakt_label_788:; __jakt_var_896.release_value(); }));
 };/*case end*/
 case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_896; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_897; {
 types::CheckedStruct const struct_ = ((program)->get_struct(id));
-__jakt_var_896 = ((({
+__jakt_var_897 = ((({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = ((struct_).record_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -2517,12 +2517,12 @@ utility::panic((ByteString::from_utf8_without_validation("unreachable: should've
 })) + (((struct_).name))); goto __jakt_label_789;
 
 }
-__jakt_label_789:; __jakt_var_896.release_value(); }));
+__jakt_label_789:; __jakt_var_897.release_value(); }));
 };/*case end*/
 case 23 /* GenericResolvedType */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericResolvedType;ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_897; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_898; {
 types::CheckedStruct const record = ((program)->get_struct(id));
 ByteString output = ((record).name);
 [](ByteString& self, ByteString rhs) -> void {{
@@ -2561,15 +2561,15 @@ size_t i = (_magic_value.value());
 }
 
 }
-__jakt_var_897 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_790;
+__jakt_var_898 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_790;
 
 }
-__jakt_label_790:; __jakt_var_897.release_value(); }));
+__jakt_label_790:; __jakt_var_898.release_value(); }));
 };/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::EnumId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_898; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_899; {
 types::CheckedEnum const enum_ = ((program)->get_enum(id));
 ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((enum_).is_boxed)){
@@ -2625,15 +2625,15 @@ size_t i = (_magic_value.value());
 }
 
 }
-__jakt_var_898 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_791;
+__jakt_var_899 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_791;
 
 }
-__jakt_label_791:; __jakt_var_898.release_value(); }));
+__jakt_label_791:; __jakt_var_899.release_value(); }));
 };/*case end*/
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;ids::TraitId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_899; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_900; {
 NonnullRefPtr<types::CheckedTrait> const trait_ = ((program)->get_trait(id));
 ByteString output = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {{
@@ -2682,15 +2682,15 @@ size_t i = (_magic_value.value());
 }
 
 }
-__jakt_var_899 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_792;
+__jakt_var_900 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_792;
 
 }
-__jakt_label_792:; __jakt_var_899.release_value(); }));
+__jakt_label_792:; __jakt_var_900.release_value(); }));
 };/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_900; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_901; {
 if (((id).equals(array_struct_id))){
 if (((args).is_empty())){
 return (ByteString::from_utf8_without_validation("[]"sv));
@@ -2842,10 +2842,10 @@ size_t i = (_magic_value.value());
 }
 
 }
-__jakt_var_900 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_793;
+__jakt_var_901 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_793;
 
 }
-__jakt_label_793:; __jakt_var_900.release_value(); }));
+__jakt_label_793:; __jakt_var_901.release_value(); }));
 };/*case end*/
 case 28 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;ids::TypeId const& type_id = __jakt_match_value.value;
@@ -3051,19 +3051,19 @@ auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* WithValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.WithValue;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::NumberConstant>> __jakt_var_901; {
-__jakt_var_901 = ((expr)->to_number_constant(program)); goto __jakt_label_794;
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::NumberConstant>> __jakt_var_902; {
+__jakt_var_902 = ((expr)->to_number_constant(program)); goto __jakt_label_794;
 
 }
-__jakt_label_794:; __jakt_var_901.release_value(); }));
+__jakt_label_794:; __jakt_var_902.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::NumberConstant>> __jakt_var_902; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::NumberConstant>> __jakt_var_903; {
 JaktInternal::Optional<types::NumberConstant> const none = JaktInternal::OptionalNone();
-__jakt_var_902 = none; goto __jakt_label_795;
+__jakt_var_903 = none; goto __jakt_label_795;
 
 }
-__jakt_label_795:; __jakt_var_902.release_value(); }));
+__jakt_label_795:; __jakt_var_903.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -3192,7 +3192,7 @@ auto&& __jakt_match_variant = checked_enum_variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;JaktInternal::DynamicArray<ids::VarId> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>>> __jakt_var_903; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>>> __jakt_var_904; {
 JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>> output = DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>>::create_with({});
 {
 JaktInternal::ArrayIterator<ids::VarId> _magic = ((fields).iterator());
@@ -3212,19 +3212,19 @@ JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId> const o = (T
 }
 }
 
-__jakt_var_903 = output; goto __jakt_label_796;
+__jakt_var_904 = output; goto __jakt_label_796;
 
 }
-__jakt_label_796:; __jakt_var_903.release_value(); }));
+__jakt_label_796:; __jakt_var_904.release_value(); }));
 };/*case end*/
 case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>>> __jakt_var_904; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>>> __jakt_var_905; {
 JaktInternal::Optional<ByteString> const string_none = JaktInternal::OptionalNone();
-__jakt_var_904 = DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>>::create_with({(Tuple{string_none, type_id})}); goto __jakt_label_797;
+__jakt_var_905 = DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>>::create_with({(Tuple{string_none, type_id})}); goto __jakt_label_797;
 
 }
-__jakt_label_797:; __jakt_var_904.release_value(); }));
+__jakt_label_797:; __jakt_var_905.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>>::create_with({}));

--- a/bootstrap/stage0/interpreter.cpp
+++ b/bootstrap/stage0/interpreter.cpp
@@ -2818,7 +2818,7 @@ return TRY((interpreter::Interpreter::invoke_typecheck_block(((((((*this).typech
 
 ErrorOr<types::CheckedBlock> interpreter::Interpreter::invoke_typecheck_block(Function<ErrorOr<types::CheckedBlock>(parser::ParsedBlock, ids::ScopeId, types::SafetyMode, JaktInternal::Optional<ids::TypeId>, JaktInternal::Optional<ids::FunctionId>)> const& function,parser::ParsedBlock const block,ids::ScopeId const parent_scope_id,JaktInternal::Optional<ids::FunctionId> const function_id) {
 {
-return TRY((function(block,parent_scope_id,types::SafetyMode::Safe(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
+return TRY((function(block,parent_scope_id,types::SafetyMode::Safe(),JaktInternal::OptionalNone(),function_id)));
 }
 }
 

--- a/bootstrap/stage0/main.cpp
+++ b/bootstrap/stage0/main.cpp
@@ -397,15 +397,15 @@ if (__jakt_enum_value == static_cast<size_t>(1ULL)) {
 return JaktInternal::ExplicitValue(input_file_length);
 }
 else if (__jakt_enum_value == static_cast<size_t>(2ULL)) {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_934; {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_935; {
 JaktInternal::Optional<u32> const end_input = ((((parts)[static_cast<i64>(1LL)])).template to_number<u32>());
 if ((!(((end_input).has_value())))){
 return JaktInternal::OptionalNone();
 }
-__jakt_var_934 = (infallible_integer_cast<size_t>(((end_input.value())))); goto __jakt_label_805;
+__jakt_var_935 = (infallible_integer_cast<size_t>(((end_input.value())))); goto __jakt_label_805;
 
 }
-__jakt_label_805:; __jakt_var_934.release_value(); }));
+__jakt_label_805:; __jakt_var_935.release_value(); }));
 }
 else {
 {
@@ -475,12 +475,12 @@ bool const is_directory = ((jakt__entry__is_directory__).template get<1>());
 jakt__path::Path const path = ((directory).join(entry));
 jakt__path::Path const path_relative_to_target = ((relative_dir).join(entry));
 if (is_directory){
-auto __jakt_var_936 = [&]() -> ErrorOr<void> { return TRY((jakt__platform__unknown_fs::make_directory(((((to).join(((path_relative_to_target).to_string())))).to_string())))), ErrorOr<void>{}; }();
+auto __jakt_var_937 = [&]() -> ErrorOr<void> { return TRY((jakt__platform__unknown_fs::make_directory(((((to).join(((path_relative_to_target).to_string())))).to_string())))), ErrorOr<void>{}; }();
 ;
 ((directories_to_copy).enqueue((Tuple{path, path_relative_to_target})));
 continue;
 }
-auto __jakt_var_938 = [&]() -> ErrorOr<void> { return TRY((mkdir_p(((((to).join(((path_relative_to_target).to_string())))).parent())))), ErrorOr<void>{}; }();
+auto __jakt_var_939 = [&]() -> ErrorOr<void> { return TRY((mkdir_p(((((to).join(((path_relative_to_target).to_string())))).parent())))), ErrorOr<void>{}; }();
 ;
 jakt__path::Path const target_path = ((to).join(((path_relative_to_target).to_string())));
 NonnullRefPtr<File> input_file = TRY((File::open_for_reading(((path).to_string()))));
@@ -1011,15 +1011,15 @@ bool const format_debug = TRY((((args_parser).flag(DynamicArray<ByteString>::cre
 ByteString const input_format_range = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-fr"sv)), (ByteString::from_utf8_without_validation("--format-range"sv))}))))).value_or_lazy_evaluated([&] { return (ByteString::from_utf8_without_validation(""sv)); });
 bool const ak_stdlib = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--ak-is-my-only-stdlib"sv))})))));
 bool const discover_only = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--discover"sv))})))));
-size_t const max_concurrent = (infallible_integer_cast<size_t>((({ Optional<u32> __jakt_var_939;
-auto __jakt_var_940 = [&]() -> ErrorOr<u32> { return TRY((value_or_throw<u32>(((compiler_job_count).template to_number<u32>())))); }();
-if (__jakt_var_940.is_error()) {{
+size_t const max_concurrent = (infallible_integer_cast<size_t>((({ Optional<u32> __jakt_var_940;
+auto __jakt_var_941 = [&]() -> ErrorOr<u32> { return TRY((value_or_throw<u32>(((compiler_job_count).template to_number<u32>())))); }();
+if (__jakt_var_941.is_error()) {{
 warnln((StringView::from_string_literal("error: invalid value for --jobs: {}"sv)),compiler_job_count);
 return static_cast<int>(1);
 }
-} else {__jakt_var_939 = __jakt_var_940.release_value();
+} else {__jakt_var_940 = __jakt_var_941.release_value();
 }
-__jakt_var_939.release_value(); }))));
+__jakt_var_940.release_value(); }))));
 if (TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--repl"sv))})))))){
 repl::REPL repl = TRY((repl::REPL::create(jakt__path::Path::from_parts(DynamicArray<ByteString>::create_with({runtime_path, (ByteString::from_utf8_without_validation("jaktlib"sv))})),target_triple,user_configuration)));
 TRY((((repl).run())));
@@ -1246,7 +1246,7 @@ JaktInternal::DynamicArray<types::Value> const arguments = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<types::Value>,ErrorOr<int>> {
 auto __jakt_enum_value = (((first_main_param).has_value()));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<types::Value>> __jakt_var_941; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<types::Value>> __jakt_var_942; {
 JaktInternal::DynamicArray<types::Value> passed_arguments = DynamicArray<types::Value>::create_with({types::Value(types::ValueImpl::JaktString((file_name.value())),call_span)});
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((interpreted_main_arguments).iterator());
@@ -1263,10 +1263,10 @@ ByteString argument = (_magic_value.value());
 }
 }
 
-__jakt_var_941 = DynamicArray<types::Value>::create_with({types::Value(types::ValueImpl::JaktArray(passed_arguments,(((((first_main_param.value())).variable))->type_id)),call_span)}); goto __jakt_label_806;
+__jakt_var_942 = DynamicArray<types::Value>::create_with({types::Value(types::ValueImpl::JaktArray(passed_arguments,(((((first_main_param.value())).variable))->type_id)),call_span)}); goto __jakt_label_806;
 
 }
-__jakt_label_806:; __jakt_var_941.release_value(); }));
+__jakt_label_806:; __jakt_var_942.release_value(); }));
 }
 else if (__jakt_enum_value == false) {
 return JaktInternal::ExplicitValue(DynamicArray<types::Value>::create_with({}));
@@ -1535,8 +1535,8 @@ ByteString const contents = ((contents_module_file_path_).template get<0>());
 ByteString const module_file_path = ((contents_module_file_path_).template get<1>());
 
 jakt__path::Path const path = ((binary_dir).join(file));
-auto __jakt_var_943 = [&]() -> ErrorOr<void> { return TRY((write_only_if_updated(contents,((path).to_string())))), ErrorOr<void>{}; }();
-if (__jakt_var_943.is_error()) {auto error = __jakt_var_943.release_error();
+auto __jakt_var_944 = [&]() -> ErrorOr<void> { return TRY((write_only_if_updated(contents,((path).to_string())))), ErrorOr<void>{}; }();
+if (__jakt_var_944.is_error()) {auto error = __jakt_var_944.release_error();
 {
 warnln((StringView::from_string_literal("Error: Could not write to file: {} ({})"sv)),file,error);
 return static_cast<int>(1);
@@ -1549,12 +1549,12 @@ return static_cast<int>(1);
 }
 
 if (((generate_depfile).has_value())){
-auto __jakt_var_944 = [&]() -> ErrorOr<void> {{
+auto __jakt_var_945 = [&]() -> ErrorOr<void> {{
 TRY((write_only_if_updated(((depfile_builder).to_string()),(generate_depfile.value()))));
 }
 
 ;return {};}();
-if (__jakt_var_944.is_error()) {auto error = __jakt_var_944.release_error();{
+if (__jakt_var_945.is_error()) {auto error = __jakt_var_945.release_error();{
 warnln((StringView::from_string_literal("Error: Could not write to file list ({})"sv)),error);
 return static_cast<int>(1);
 }
@@ -1660,12 +1660,12 @@ ByteString flag = (_magic_value.value());
 }
 }
 
-auto __jakt_var_946 = [&]() -> ErrorOr<void> { return TRY((((builder).build_all(binary_dir,(([use_ccache, cxx_compiler_path, runtime_path, extra_include_paths, optimize, extra_compiler_flags](ByteString input_filename, ByteString output_filename) -> ErrorOr<JaktInternal::DynamicArray<ByteString>> {{
+auto __jakt_var_947 = [&]() -> ErrorOr<void> { return TRY((((builder).build_all(binary_dir,(([use_ccache, cxx_compiler_path, runtime_path, extra_include_paths, optimize, extra_compiler_flags](ByteString input_filename, ByteString output_filename) -> ErrorOr<JaktInternal::DynamicArray<ByteString>> {{
 return TRY((platform__unknown_compiler::run_compiler(cxx_compiler_path,input_filename,output_filename,runtime_path,extra_include_paths,DynamicArray<ByteString>::create_with({}),DynamicArray<ByteString>::create_with({}),optimize,extra_compiler_flags,use_ccache)));
 }
 }
 )))))), ErrorOr<void>{}; }();
-if (__jakt_var_946.is_error()) {{
+if (__jakt_var_947.is_error()) {{
 return static_cast<int>(1);
 }
 }
@@ -1692,8 +1692,8 @@ if (archive_link_support_libs){
 ((extra_arguments).push(((((runtime_lib_path).join(TRY((platform::library_name_for_target((ByteString::from_utf8_without_validation("main"sv)),target)))))).to_string())));
 ((extra_arguments).push(((((runtime_lib_path).join(TRY((platform::library_name_for_target((ByteString::from_utf8_without_validation("runtime"sv)),target)))))).to_string())));
 }
-auto __jakt_var_948 = [&]() -> ErrorOr<void> { return TRY((((builder).link_into_archive(archiver_path.value_or_lazy_evaluated([&] { return (ByteString::from_utf8_without_validation("ar"sv)); }),((((binary_dir).join((link_archive.value())))).to_string()),extra_arguments)))), ErrorOr<void>{}; }();
-if (__jakt_var_948.is_error()) {{
+auto __jakt_var_949 = [&]() -> ErrorOr<void> { return TRY((((builder).link_into_archive(archiver_path.value_or_lazy_evaluated([&] { return (ByteString::from_utf8_without_validation("ar"sv)); }),((((binary_dir).join((link_archive.value())))).to_string()),extra_arguments)))), ErrorOr<void>{}; }();
+if (__jakt_var_949.is_error()) {{
 return static_cast<int>(1);
 }
 }
@@ -1779,8 +1779,8 @@ ByteString arg = (_magic_value.value());
 }
 }
 
-auto __jakt_var_950 = [&]() -> ErrorOr<void> { return TRY((((builder).link_into_executable(cxx_compiler_path,output_filename,extra_arguments)))), ErrorOr<void>{}; }();
-if (__jakt_var_950.is_error()) {{
+auto __jakt_var_951 = [&]() -> ErrorOr<void> { return TRY((((builder).link_into_executable(cxx_compiler_path,output_filename,extra_arguments)))), ErrorOr<void>{}; }();
+if (__jakt_var_951.is_error()) {{
 return static_cast<int>(1);
 }
 }
@@ -1975,15 +1975,15 @@ return {};
 
 bool file_needs_updating(ByteString const path,ByteString const new_contents) {
 {
-JaktInternal::Optional<NonnullRefPtr<File>> maybe_file = ({ Optional<NonnullRefPtr<File>> __jakt_var_951;
-auto __jakt_var_952 = [&]() -> ErrorOr<NonnullRefPtr<File>> { return TRY((File::open_for_reading(path))); }();
-if (!__jakt_var_952.is_error()) __jakt_var_951 = __jakt_var_952.release_value();
-__jakt_var_951; });
+JaktInternal::Optional<NonnullRefPtr<File>> maybe_file = ({ Optional<NonnullRefPtr<File>> __jakt_var_952;
+auto __jakt_var_953 = [&]() -> ErrorOr<NonnullRefPtr<File>> { return TRY((File::open_for_reading(path))); }();
+if (!__jakt_var_953.is_error()) __jakt_var_952 = __jakt_var_953.release_value();
+__jakt_var_952; });
 if (((maybe_file).has_value())){
-JaktInternal::Optional<JaktInternal::DynamicArray<u8>> const contents = ({ Optional<JaktInternal::DynamicArray<u8>> __jakt_var_953;
-auto __jakt_var_954 = [&]() -> ErrorOr<JaktInternal::DynamicArray<u8>> { return TRY(((((maybe_file.value()))->read_all()))); }();
-if (!__jakt_var_954.is_error()) __jakt_var_953 = __jakt_var_954.release_value();
-__jakt_var_953; });
+JaktInternal::Optional<JaktInternal::DynamicArray<u8>> const contents = ({ Optional<JaktInternal::DynamicArray<u8>> __jakt_var_954;
+auto __jakt_var_955 = [&]() -> ErrorOr<JaktInternal::DynamicArray<u8>> { return TRY(((((maybe_file.value()))->read_all()))); }();
+if (!__jakt_var_955.is_error()) __jakt_var_954 = __jakt_var_955.release_value();
+__jakt_var_954; });
 if (((contents).has_value())){
 return [](ByteString const& self, ByteString rhs) -> bool {{
 return (!(((self) == (rhs))));

--- a/bootstrap/stage0/repl.cpp
+++ b/bootstrap/stage0/repl.cpp
@@ -157,7 +157,7 @@ return JaktInternal::ExplicitValue(TRY((repl::serialize_unary_operation(op,TRY((
 };/*case end*/
 case 8 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> const& vals = __jakt_match_value.vals;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_905; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_906; {
 ByteStringBuilder builder = ByteStringBuilder::create();
 ((builder).append((StringView::from_string_literal("("sv))));
 {
@@ -179,15 +179,15 @@ if (((i) != (static_cast<size_t>(0ULL)))){
 }
 
 ((builder).append((StringView::from_string_literal(")"sv))));
-__jakt_var_905 = ((builder).to_string()); goto __jakt_label_798;
+__jakt_var_906 = ((builder).to_string()); goto __jakt_label_798;
 
 }
-__jakt_label_798:; __jakt_var_905.release_value(); }));
+__jakt_label_798:; __jakt_var_906.release_value(); }));
 };/*case end*/
 case 9 /* Range */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Range;JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const& from = __jakt_match_value.from;
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const& to = __jakt_match_value.to;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_906; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_907; {
 ByteString from_output = (ByteString::from_utf8_without_validation(""sv));
 if (((from).has_value())){
 (from_output = TRY((repl::serialize_ast_node((from.value())))));
@@ -196,14 +196,14 @@ ByteString to_output = (ByteString::from_utf8_without_validation(""sv));
 if (((to).has_value())){
 (to_output = TRY((repl::serialize_ast_node((to.value())))));
 }
-__jakt_var_906 = __jakt_format((StringView::from_string_literal("{}..{}"sv)),from_output,to_output); goto __jakt_label_799;
+__jakt_var_907 = __jakt_format((StringView::from_string_literal("{}..{}"sv)),from_output,to_output); goto __jakt_label_799;
 
 }
-__jakt_label_799:; __jakt_var_906.release_value(); }));
+__jakt_label_799:; __jakt_var_907.release_value(); }));
 };/*case end*/
 case 10 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> const& vals = __jakt_match_value.vals;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_907; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_908; {
 ByteStringBuilder builder = ByteStringBuilder::create();
 ((builder).append((StringView::from_string_literal("["sv))));
 {
@@ -225,14 +225,14 @@ if (((i) != (static_cast<size_t>(0ULL)))){
 }
 
 ((builder).append((StringView::from_string_literal("]"sv))));
-__jakt_var_907 = ((builder).to_string()); goto __jakt_label_800;
+__jakt_var_908 = ((builder).to_string()); goto __jakt_label_800;
 
 }
-__jakt_label_800:; __jakt_var_907.release_value(); }));
+__jakt_label_800:; __jakt_var_908.release_value(); }));
 };/*case end*/
 case 11 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> const& vals = __jakt_match_value.vals;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_908; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_909; {
 ByteStringBuilder builder = ByteStringBuilder::create();
 ((builder).append((StringView::from_string_literal("{"sv))));
 {
@@ -254,14 +254,14 @@ if (((i) != (static_cast<size_t>(0ULL)))){
 }
 
 ((builder).append((StringView::from_string_literal("}"sv))));
-__jakt_var_908 = ((builder).to_string()); goto __jakt_label_801;
+__jakt_var_909 = ((builder).to_string()); goto __jakt_label_801;
 
 }
-__jakt_label_801:; __jakt_var_908.release_value(); }));
+__jakt_label_801:; __jakt_var_909.release_value(); }));
 };/*case end*/
 case 12 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename types::CheckedExpression>,NonnullRefPtr<typename types::CheckedExpression>>> const& vals = __jakt_match_value.vals;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_909; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_910; {
 ByteStringBuilder builder = ByteStringBuilder::create();
 ((builder).append((StringView::from_string_literal("["sv))));
 {
@@ -286,10 +286,10 @@ JaktInternal::Tuple<NonnullRefPtr<typename types::CheckedExpression>,NonnullRefP
 }
 
 ((builder).append((StringView::from_string_literal("]"sv))));
-__jakt_var_909 = ((builder).to_string()); goto __jakt_label_802;
+__jakt_var_910 = ((builder).to_string()); goto __jakt_label_802;
 
 }
-__jakt_label_802:; __jakt_var_909.release_value(); }));
+__jakt_label_802:; __jakt_var_910.release_value(); }));
 };/*case end*/
 case 13 /* IndexedExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedExpression;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
@@ -314,7 +314,7 @@ return JaktInternal::ExplicitValue(__jakt_format((StringView::from_string_litera
 case 23 /* NamespacedVar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedVar;JaktInternal::DynamicArray<types::CheckedNamespace> const& namespaces = __jakt_match_value.namespaces;
 NonnullRefPtr<types::CheckedVariable> const& var = __jakt_match_value.var;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_910; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_911; {
 ByteStringBuilder builder = ByteStringBuilder::create();
 {
 JaktInternal::ArrayIterator<types::CheckedNamespace> _magic = ((namespaces).iterator());
@@ -333,10 +333,10 @@ types::CheckedNamespace namespace_ = (_magic_value.value());
 }
 
 ((builder).append(((var)->name)));
-__jakt_var_910 = ((builder).to_string()); goto __jakt_label_803;
+__jakt_var_911 = ((builder).to_string()); goto __jakt_label_803;
 
 }
-__jakt_label_803:; __jakt_var_910.release_value(); }));
+__jakt_label_803:; __jakt_var_911.release_value(); }));
 };/*case end*/
 case 24 /* Var */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Var;NonnullRefPtr<types::CheckedVariable> const& var = __jakt_match_value.var;
@@ -355,7 +355,7 @@ return JaktInternal::ExplicitValue(__jakt_format((StringView::from_string_litera
 };/*case end*/
 case 21 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;types::CheckedCall const& call = __jakt_match_value.call;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_911; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_912; {
 ByteStringBuilder builder = ByteStringBuilder::create();
 {
 JaktInternal::ArrayIterator<types::ResolvedNamespace> _magic = ((((call).namespace_)).iterator());
@@ -399,10 +399,10 @@ if ((!(((((arg).template get<0>())).is_empty())))){
 }
 
 ((builder).append((StringView::from_string_literal(")"sv))));
-__jakt_var_911 = ((builder).to_string()); goto __jakt_label_804;
+__jakt_var_912 = ((builder).to_string()); goto __jakt_label_804;
 
 }
-__jakt_label_804:; __jakt_var_911.release_value(); }));
+__jakt_label_804:; __jakt_var_912.release_value(); }));
 };/*case end*/
 case 35 /* Garbage */: {
 return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("<Garbage>"sv)));
@@ -594,7 +594,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 (((((*this).compiler))->current_file) = ((*this).file_id));
 (((((*this).compiler))->current_file_contents) = bytes_);
-ScopeGuard __jakt_var_912([&] {
+ScopeGuard __jakt_var_913([&] {
 {
 JaktInternal::DynamicArray<error::JaktError> const arr = DynamicArray<error::JaktError>::create_with({});
 (((((*this).compiler))->errors) = arr);
@@ -602,14 +602,14 @@ JaktInternal::DynamicArray<error::JaktError> const arr = DynamicArray<error::Jak
 
 });
 {
-JaktInternal::ArrayIterator<lexer::Token> _magic = ((({ Optional<JaktInternal::DynamicArray<lexer::Token>> __jakt_var_913;
-auto __jakt_var_914 = [&]() -> ErrorOr<JaktInternal::DynamicArray<lexer::Token>> { return lexer::Lexer::lex(((*this).compiler)); }();
-if (__jakt_var_914.is_error()) {{
+JaktInternal::ArrayIterator<lexer::Token> _magic = ((({ Optional<JaktInternal::DynamicArray<lexer::Token>> __jakt_var_914;
+auto __jakt_var_915 = [&]() -> ErrorOr<JaktInternal::DynamicArray<lexer::Token>> { return lexer::Lexer::lex(((*this).compiler)); }();
+if (__jakt_var_915.is_error()) {{
 return {};
 }
-} else {__jakt_var_913 = __jakt_var_914.release_value();
+} else {__jakt_var_914 = __jakt_var_915.release_value();
 }
-__jakt_var_913.release_value(); })).iterator());
+__jakt_var_914.release_value(); })).iterator());
 for (;;){
 JaktInternal::Optional<lexer::Token> const _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
@@ -885,7 +885,7 @@ return {};
 }
 ;
 repl_backend__default::Editor editor = TRY((repl_backend__default::Editor::create((ByteString::from_utf8_without_validation("> "sv)),((syntax_highlight_handler)))));
-ScopeGuard __jakt_var_915([&] {
+ScopeGuard __jakt_var_916([&] {
 ((editor).destroy());
 });
 for (;;){
@@ -894,15 +894,15 @@ TRY((((((*this).compiler))->print_errors())));
 JaktInternal::DynamicArray<error::JaktError> const arr = DynamicArray<error::JaktError>::create_with({});
 (((((*this).compiler))->errors) = arr);
 }
-repl_backend__common::LineResult const line_result = ({ Optional<repl_backend__common::LineResult> __jakt_var_916;
-auto __jakt_var_917 = [&]() -> ErrorOr<repl_backend__common::LineResult> { return TRY((((editor).get_line(JaktInternal::OptionalNone())))); }();
-if (__jakt_var_917.is_error()) {auto error = __jakt_var_917.release_error();
+repl_backend__common::LineResult const line_result = ({ Optional<repl_backend__common::LineResult> __jakt_var_917;
+auto __jakt_var_918 = [&]() -> ErrorOr<repl_backend__common::LineResult> { return TRY((((editor).get_line(JaktInternal::OptionalNone())))); }();
+if (__jakt_var_918.is_error()) {auto error = __jakt_var_918.release_error();
 {
 return {};
 }
-} else {__jakt_var_916 = __jakt_var_917.release_value();
+} else {__jakt_var_917 = __jakt_var_918.release_value();
 }
-__jakt_var_916.release_value(); });
+__jakt_var_917.release_value(); });
 if (((line_result).__jakt_init_index() == 0 /* Line */)){
 ByteString const line = (line_result).as.Line.value;
 if (((line) == ((ByteString::from_utf8_without_validation("\n"sv))))){
@@ -913,14 +913,14 @@ break;
 }
 (((((*this).compiler))->current_file) = ((*this).file_id));
 (((((*this).compiler))->current_file_contents) = repl::REPL::line_to_bytes(line));
-JaktInternal::DynamicArray<lexer::Token> tokens = ({ Optional<JaktInternal::DynamicArray<lexer::Token>> __jakt_var_918;
-auto __jakt_var_919 = [&]() -> ErrorOr<JaktInternal::DynamicArray<lexer::Token>> { return lexer::Lexer::lex(((*this).compiler)); }();
-if (__jakt_var_919.is_error()) {{
+JaktInternal::DynamicArray<lexer::Token> tokens = ({ Optional<JaktInternal::DynamicArray<lexer::Token>> __jakt_var_919;
+auto __jakt_var_920 = [&]() -> ErrorOr<JaktInternal::DynamicArray<lexer::Token>> { return lexer::Lexer::lex(((*this).compiler)); }();
+if (__jakt_var_920.is_error()) {{
 continue;
 }
-} else {__jakt_var_918 = __jakt_var_919.release_value();
+} else {__jakt_var_919 = __jakt_var_920.release_value();
 }
-__jakt_var_918.release_value(); });
+__jakt_var_919.release_value(); });
 if (((tokens).is_empty())){
 continue;
 }
@@ -928,28 +928,28 @@ if ((!(repl::REPL::check_parens(tokens)))){
 ByteStringBuilder builder = ByteStringBuilder::create();
 ((builder).append(line));
 while ((!(repl::REPL::check_parens(tokens)))){
-repl_backend__common::LineResult const line_result = ({ Optional<repl_backend__common::LineResult> __jakt_var_920;
-auto __jakt_var_921 = [&]() -> ErrorOr<repl_backend__common::LineResult> { return TRY((((editor).get_line((ByteString::from_utf8_without_validation(".."sv)))))); }();
-if (__jakt_var_921.is_error()) {auto error = __jakt_var_921.release_error();
+repl_backend__common::LineResult const line_result = ({ Optional<repl_backend__common::LineResult> __jakt_var_921;
+auto __jakt_var_922 = [&]() -> ErrorOr<repl_backend__common::LineResult> { return TRY((((editor).get_line((ByteString::from_utf8_without_validation(".."sv)))))); }();
+if (__jakt_var_922.is_error()) {auto error = __jakt_var_922.release_error();
 {
 return {};
 }
-} else {__jakt_var_920 = __jakt_var_921.release_value();
+} else {__jakt_var_921 = __jakt_var_922.release_value();
 }
-__jakt_var_920.release_value(); });
+__jakt_var_921.release_value(); });
 if (((line_result).__jakt_init_index() == 0 /* Line */)){
 ByteString const line = (line_result).as.Line.value;
 ((builder).append(line));
 (((((*this).compiler))->current_file) = ((*this).file_id));
 (((((*this).compiler))->current_file_contents) = repl::REPL::line_to_bytes(((builder).to_string())));
-(tokens = ({ Optional<JaktInternal::DynamicArray<lexer::Token>> __jakt_var_922;
-auto __jakt_var_923 = [&]() -> ErrorOr<JaktInternal::DynamicArray<lexer::Token>> { return lexer::Lexer::lex(((*this).compiler)); }();
-if (__jakt_var_923.is_error()) {{
+(tokens = ({ Optional<JaktInternal::DynamicArray<lexer::Token>> __jakt_var_923;
+auto __jakt_var_924 = [&]() -> ErrorOr<JaktInternal::DynamicArray<lexer::Token>> { return lexer::Lexer::lex(((*this).compiler)); }();
+if (__jakt_var_924.is_error()) {{
 continue;
 }
-} else {__jakt_var_922 = __jakt_var_923.release_value();
+} else {__jakt_var_923 = __jakt_var_924.release_value();
 }
-__jakt_var_922.release_value(); }));
+__jakt_var_923.release_value(); }));
 }
 else {
 return {};
@@ -960,20 +960,20 @@ return {};
 parser::Parser parser = parser::Parser(static_cast<size_t>(0ULL),tokens,((*this).compiler),true,static_cast<size_t>(0ULL));
 lexer::Token const first_token = (((tokens).first()).value());
 if (((((((((((first_token).__jakt_init_index() == 75 /* Fn */) || ((first_token).__jakt_init_index() == 76 /* Comptime */)) || ((first_token).__jakt_init_index() == 98 /* Struct */)) || ((first_token).__jakt_init_index() == 65 /* Class */)) || ((first_token).__jakt_init_index() == 71 /* Enum */)) || ((first_token).__jakt_init_index() == 62 /* Boxed */)) || ((first_token).__jakt_init_index() == 87 /* Namespace */)) || ((first_token).__jakt_init_index() == 78 /* Import */)) || ((first_token).__jakt_init_index() == 112 /* Trait */))){
-parser::ParsedNamespace const parsed_namespace = ({ Optional<parser::ParsedNamespace> __jakt_var_924;
-auto __jakt_var_925 = [&]() -> ErrorOr<parser::ParsedNamespace> { return ((parser).parse_namespace(false)); }();
-if (__jakt_var_925.is_error()) {{
+parser::ParsedNamespace const parsed_namespace = ({ Optional<parser::ParsedNamespace> __jakt_var_925;
+auto __jakt_var_926 = [&]() -> ErrorOr<parser::ParsedNamespace> { return ((parser).parse_namespace(false)); }();
+if (__jakt_var_926.is_error()) {{
 TRY((((*this).handle_possible_error())));
 continue;
 }
-} else {__jakt_var_924 = __jakt_var_925.release_value();
+} else {__jakt_var_925 = __jakt_var_926.release_value();
 }
-__jakt_var_924.release_value(); });
+__jakt_var_925.release_value(); });
 if (TRY((((*this).handle_possible_error())))){
 continue;
 }
-auto __jakt_var_927 = [&]() -> ErrorOr<void> { return TRY((((((*this).typechecker)).typecheck_module(parsed_namespace,((*this).root_scope_id))))), ErrorOr<void>{}; }();
-if (__jakt_var_927.is_error()) {{
+auto __jakt_var_928 = [&]() -> ErrorOr<void> { return TRY((((((*this).typechecker)).typecheck_module(parsed_namespace,((*this).root_scope_id))))), ErrorOr<void>{}; }();
+if (__jakt_var_928.is_error()) {{
 TRY((((*this).handle_possible_error())));
 continue;
 }
@@ -982,40 +982,40 @@ continue;
 TRY((((*this).handle_possible_error())));
 continue;
 }
-NonnullRefPtr<typename parser::ParsedStatement> const parsed_statement = ({ Optional<NonnullRefPtr<typename parser::ParsedStatement>> __jakt_var_928;
-auto __jakt_var_929 = [&]() -> ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> { return ((parser).parse_statement(true)); }();
-if (__jakt_var_929.is_error()) {{
+NonnullRefPtr<typename parser::ParsedStatement> const parsed_statement = ({ Optional<NonnullRefPtr<typename parser::ParsedStatement>> __jakt_var_929;
+auto __jakt_var_930 = [&]() -> ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> { return ((parser).parse_statement(true)); }();
+if (__jakt_var_930.is_error()) {{
 TRY((((*this).handle_possible_error())));
 continue;
 }
-} else {__jakt_var_928 = __jakt_var_929.release_value();
+} else {__jakt_var_929 = __jakt_var_930.release_value();
 }
-__jakt_var_928.release_value(); });
+__jakt_var_929.release_value(); });
 if (TRY((((*this).handle_possible_error())))){
 continue;
 }
-NonnullRefPtr<typename types::CheckedStatement> const checked_statement = ({ Optional<NonnullRefPtr<typename types::CheckedStatement>> __jakt_var_930;
-auto __jakt_var_931 = [&]() -> ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> { return TRY((((((*this).typechecker)).typecheck_statement(parsed_statement,((*this).root_scope_id),types::SafetyMode::Safe(),JaktInternal::OptionalNone())))); }();
-if (__jakt_var_931.is_error()) {{
+NonnullRefPtr<typename types::CheckedStatement> const checked_statement = ({ Optional<NonnullRefPtr<typename types::CheckedStatement>> __jakt_var_931;
+auto __jakt_var_932 = [&]() -> ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> { return TRY((((((*this).typechecker)).typecheck_statement(parsed_statement,((*this).root_scope_id),types::SafetyMode::Safe(),JaktInternal::OptionalNone())))); }();
+if (__jakt_var_932.is_error()) {{
 TRY((((*this).handle_possible_error())));
 continue;
 }
-} else {__jakt_var_930 = __jakt_var_931.release_value();
+} else {__jakt_var_931 = __jakt_var_932.release_value();
 }
-__jakt_var_930.release_value(); });
+__jakt_var_931.release_value(); });
 if (TRY((((*this).handle_possible_error())))){
 continue;
 }
 NonnullRefPtr<interpreter::Interpreter> interpreter = ((((*this).typechecker)).interpreter());
-interpreter::StatementResult const result = ({ Optional<interpreter::StatementResult> __jakt_var_932;
-auto __jakt_var_933 = [&]() -> ErrorOr<interpreter::StatementResult> { return TRY((((interpreter)->execute_statement(checked_statement,((*this).root_interpreter_scope),utility::Span(((*this).file_id),static_cast<size_t>(0ULL),((line).length())))))); }();
-if (__jakt_var_933.is_error()) {{
+interpreter::StatementResult const result = ({ Optional<interpreter::StatementResult> __jakt_var_933;
+auto __jakt_var_934 = [&]() -> ErrorOr<interpreter::StatementResult> { return TRY((((interpreter)->execute_statement(checked_statement,((*this).root_interpreter_scope),utility::Span(((*this).file_id),static_cast<size_t>(0ULL),((line).length())))))); }();
+if (__jakt_var_934.is_error()) {{
 TRY((((*this).handle_possible_error())));
 continue;
 }
-} else {__jakt_var_932 = __jakt_var_933.release_value();
+} else {__jakt_var_933 = __jakt_var_934.release_value();
 }
-__jakt_var_932.release_value(); });
+__jakt_var_933.release_value(); });
 if (TRY((((*this).handle_possible_error())))){
 continue;
 }

--- a/samples/control_flow/must.jakt
+++ b/samples/control_flow/must.jakt
@@ -1,11 +1,16 @@
 /// Expect:
-/// - output: "magic number: 42\n"
+/// - output: "magic number: 42 42\n"
 
 fn magic_number() throws -> i32 {
     return 42
 }
 
+fn ensure_magic_number() -> i32 {
+    return must magic_number()
+}
+
 fn main() {
-    let magic = must magic_number()
-    println("magic number: {}", magic)
+    let magic1 = must magic_number()
+    let magic2 = ensure_magic_number()
+    println("magic number: {} {}", magic1, magic2)
 }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -8587,7 +8587,8 @@ struct Typechecker {
     }
 
     fn typecheck_must(mut this, expr: ParsedExpression, span: Span, scope_id: ScopeId, safety_mode: SafetyMode, type_hint: TypeId?) throws -> CheckedExpression {
-        let checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint)
+        let must_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: true, debug_name: "must")
+        let checked_expr = .typecheck_expression(expr, scope_id: must_scope_id, safety_mode, type_hint)
         if not checked_expr.can_throw() {
             .error(format("‘must’ operator used on non-throwing expression"), span)
         }

--- a/tests/typechecker/must_cancels_throwsy.jakt
+++ b/tests/typechecker/must_cancels_throwsy.jakt
@@ -1,0 +1,17 @@
+/// Expect:
+/// - output: "PASS\n"
+
+fn may_throw(magic_number: i32) throws {
+    if magic_number != 1 {
+        throw Error::from_string_literal("Bad magic number!")
+    }
+}
+
+fn does_not_throw() {
+    must may_throw(magic_number: 1)
+}
+
+fn main() {
+    does_not_throw()
+    println("PASS")
+}


### PR DESCRIPTION
Code generation forwards it correctly, but typechecker did not ensure
the inner expression's typecheck knew that the expression could throw.
