### PR TITLE
codegen: Keep previous control flow state when compiling catch block

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -3244,6 +3244,7 @@ struct CodeGenerator {
                         output.append(".release_error();\n")
                     }
 
+                    .control_flow_state = last_control_flow
                     if catch_block!.yielded_type.has_value() {
                         output.append(fresh_var)
                         output.append(" = (")

--- a/tests/codegen/try_loop_controls_in_match.jakt
+++ b/tests/codegen/try_loop_controls_in_match.jakt
@@ -1,0 +1,31 @@
+/// Expect:
+/// - output: "handled error\n"
+
+
+enum Foo {
+    Bar
+    Baz
+}
+
+fn may_throw() throws {
+    throw Error::from_string_literal("handled error")
+}
+
+fn main() {
+
+    loop {
+         match Foo::Baz {
+            Bar => {
+                abort()
+            },
+            Baz => {
+                try may_throw() catch err {
+                    println("{}", err)
+                    break
+                }
+            }
+        }
+        println("should not have continued loop :)")
+        break
+    }
+}


### PR DESCRIPTION
`continue` and `break` should still work inside a match context. The
"inside try" part is only for the `try`'s IIFE, but it should still
forward the correct value when using control flow inside the `catch`.
