### PR TITLE
typechecker: Error on missing non-default args when defaults provided

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -11174,6 +11174,11 @@ struct Typechecker {
 
                         invalid_considered_argument_uses[consumed_arg].push((i, reason))
                     }
+                } else {
+                    if not param.default_value_expression.has_value() {
+                        .error(format("Missing argument for function parameter '{}'", param.variable.name), span)
+                        continue
+                    }
                 }
             }
 

--- a/tests/typechecker/missing_argument_when_default_argument_involved.jakt
+++ b/tests/typechecker/missing_argument_when_default_argument_involved.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - error: "Missing argument for function parameter 'b'"
+
+fn test(a: i32 = 1, b: usize) {
+    println("Wrong")
+}
+
+fn main() {
+    test(a: 1)
+}


### PR DESCRIPTION
Fixes #1543