### PR TITLE
Disallow assigning Optional<void>, allow yielding void functions and nothing

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -4580,12 +4580,15 @@ struct CodeGenerator {
 
                 let (var_name, end_label) = .entered_yieldable_blocks.last()!
 
-                if expr.type() != void_type_id() {
-                    output.append(var_name)
-                    output.append(" = ")
+                if expr.has_value() {
+                    if expr!.type() != void_type_id() {
+                        output.append(var_name)
+                        output.append(" = ")
+                    }
+
+                    .codegen_expression(expr!, &mut output)
                 }
 
-                .codegen_expression(expr, &mut output)
                 output.append("; goto ")
                 output.append(end_label)
                 output.append(";\n")

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -3245,7 +3245,7 @@ struct CodeGenerator {
                     }
 
                     .control_flow_state = last_control_flow
-                    if catch_block!.yielded_type.has_value() {
+                    if catch_block!.yielded_type.has_value() and not catch_block!.yielded_type!.equals(void_type_id()) {
                         output.append(fresh_var)
                         output.append(" = (")
                         .codegen_block(block: catch_block!, &mut output)
@@ -3695,10 +3695,9 @@ struct CodeGenerator {
                     expr.type() == unknown_type_id() and
                     not expr is OptionalNone
                 ) {
-
-                    output.append("return (")
+                    output.append("return ({")
                     .codegen_expression(expr, &mut output)
-                    output.append("), JaktInternal::ExplicitValue<void>();\n")
+                    output.append(";}), JaktInternal::ExplicitValue<void>();\n")
                 } else {
                     output.append("return JaktInternal::ExplicitValue(")
                     .codegen_expression(expr, &mut output)
@@ -4387,11 +4386,13 @@ struct CodeGenerator {
 
             .entered_yieldable_blocks.push((fresh_var, fresh_label))
 
-            output.append("({ Optional<")
-            output.append(type_output)
-            output.append("> ")
-            output.append(fresh_var)
-            output.append("; ")
+            if not yielded_type.equals(void_type_id()) {
+                output.append("({ Optional<")
+                output.append(type_output)
+                output.append("> ")
+                output.append(fresh_var)
+                output.append("; ")
+            }
         }
 
         output.append("{\n")
@@ -4407,11 +4408,13 @@ struct CodeGenerator {
 
             output.append(label)
             output.append(":; ")
-            output.append(var)
-            if not block.yielded_none {
-                output.append(".release_value()")
+            if not block.yielded_type!.equals(void_type_id()) {
+                output.append(var)
+                if not block.yielded_none {
+                    output.append(".release_value()")
+                }
+                output.append("; })")
             }
-            output.append("; })")
         }
     }
 
@@ -4577,8 +4580,11 @@ struct CodeGenerator {
 
                 let (var_name, end_label) = .entered_yieldable_blocks.last()!
 
-                output.append(var_name)
-                output.append(" = ")
+                if expr.type() != void_type_id() {
+                    output.append(var_name)
+                    output.append(" = ")
+                }
+
                 .codegen_expression(expr, &mut output)
                 output.append("; goto ")
                 output.append(end_label)

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -623,7 +623,10 @@ fn find_span_in_statement(program: CheckedProgram, statement: CheckedStatement, 
             }
             yield find_span_in_statement(program, statement: var_decl, span)
         }
-        Yield(expr) => find_span_in_expression(program, expr, span)
+        Yield(expr) => match expr.has_value() {
+            true => find_span_in_expression(program, expr: expr!, span)
+            false => none
+        }
         Break | Continue | Garbage => none
     }
 }

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -1123,7 +1123,10 @@ class Interpreter {
         }
         Break | Continue | InlineCpp | Garbage => statement
         Throw(expr, span) => CheckedStatement::Throw(expr: .perform_final_interpretation_expr_pass(expr, scope, function_id), span)
-        Yield(expr, span) => CheckedStatement::Yield(expr: .perform_final_interpretation_expr_pass(expr, scope, function_id), span)
+        Yield(expr, span) => match expr.has_value() {
+            true => CheckedStatement::Yield(expr: .perform_final_interpretation_expr_pass(expr: expr!, scope, function_id), span)
+            false => statement
+        }
     }
 
     public fn perform_final_interpretation_expr_pass(
@@ -3822,24 +3825,30 @@ class Interpreter {
             Continue => {
                 return StatementResult::Continue
             }
-            Yield(expr) => match .execute_expression(expr, scope) {
-                JustValue(value) => {
-                    return StatementResult::Yield(value)
+            Yield(expr) => {
+                if not expr.has_value() {
+                    return StatementResult::Yield(Value(impl: ValueImpl::Void, span: call_span))
                 }
-                Throw(value) => {
-                    return StatementResult::Throw(value)
-                }
-                Return(value) => {
-                    return StatementResult::Return(value)
-                }
-                Continue => {
-                    return StatementResult::Continue
-                }
-                Break => {
-                    return StatementResult::Break
-                }
-                Yield => {
-                    panic("Invalid control flow")
+
+                return match .execute_expression(expr!, scope) {
+                    JustValue(value) => {
+                        return StatementResult::Yield(value)
+                    }
+                    Throw(value) => {
+                        return StatementResult::Throw(value)
+                    }
+                    Return(value) => {
+                        return StatementResult::Return(value)
+                    }
+                    Continue => {
+                        return StatementResult::Continue
+                    }
+                    Break => {
+                        return StatementResult::Break
+                    }
+                    Yield => {
+                        panic("Invalid control flow")
+                    }
                 }
             }
             Throw(expr) => match .execute_expression(expr, scope) {

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -534,7 +534,11 @@ struct ParsedBlock {
     fn find_yield_span(this) -> Span? {
         for stmt in .stmts {
             if stmt is Yield(expr) {
-                return expr.span()
+                if expr.has_value() {
+                    return expr!.span()
+                }
+
+                return stmt.span()
             }
         }
         return None
@@ -584,7 +588,7 @@ boxed enum ParsedStatement {
     Continue(Span)
     Return(expr: ParsedExpression?, span: Span)
     Throw(expr: ParsedExpression, span: Span)
-    Yield(expr: ParsedExpression, span: Span)
+    Yield(expr: ParsedExpression?, span: Span)
     InlineCpp(block: ParsedBlock, span: Span)
     Guard(expr: ParsedExpression, else_block: ParsedBlock, remaining_code: ParsedBlock, span: Span)
     Garbage(Span)
@@ -685,7 +689,16 @@ boxed enum ParsedStatement {
             else => false
         }
         Yield(expr: lhs_expr) =>  match rhs_statement {
-            Yield(expr: rhs_expr) => lhs_expr.equals(rhs_expr)
+            Yield(expr: rhs_expr) => {
+                if not lhs_expr.has_value() {
+                    return not rhs_expr.has_value()
+                } else {
+                    if not rhs_expr.has_value() {
+                        return false
+                    }
+                    return lhs_expr!.equals(rhs_expr!)
+                }
+            }
             else => false
         }
         InlineCpp(block: lhs_block) =>  match rhs_statement {
@@ -4578,11 +4591,25 @@ struct Parser {
             }
             Yield => {
                 .index++
-                let expr = .parse_expression(allow_assignments: false, allow_newlines: false)
-                if not inside_block {
-                    .error("‘yield’ can only be used inside a block", span: merge_spans(start, end: expr.span()))
+
+                yield match .current() {
+                    Eol | Eof | RCurly => {
+                        if not inside_block {
+                            .error("‘yield’ can only be used inside a block", span: start)
+                        }
+
+                        yield ParsedStatement::Yield(expr: None, span: start)
+                    }
+                    else => {
+                        let expr = .parse_expression(allow_assignments: false, allow_newlines: false)
+
+                        if not inside_block {
+                            .error("‘yield’ can only be used inside a block", span: merge_spans(start, end: expr.span()))
+                        }
+
+                        yield ParsedStatement::Yield(expr, span: merge_spans(start, .previous().span()))
+                    }
                 }
-                yield ParsedStatement::Yield(expr, span: merge_spans(start, .previous().span()))
             }
             Return => {
                 .index++

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -7086,6 +7086,11 @@ struct Typechecker {
 
         if rhs_type_id.equals(void_type_id()) {
             .error("Cannot assign `void` to a variable", checked_expr.span())
+        } else {
+            let unwrapped_type = .unwrap_type_from_optional_if_needed(type: .get_type(rhs_type_id))
+            if unwrapped_type.equals(.get_type(void_type_id())) {
+                .error("Cannot assign `Optional<void>` to a variable", checked_expr.span())
+            }
         }
 
         if .get_type(lhs_type_id).qualifiers.is_immutable {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4857,7 +4857,10 @@ struct Typechecker {
         Throw => BlockControlFlow::AlwaysReturns
         Break => BlockControlFlow::AlwaysTransfersControl(might_break: true)
         Continue => BlockControlFlow::AlwaysTransfersControl(might_break: false)
-        Yield(expr) => expr.control_flow().updated(BlockControlFlow::AlwaysTransfersControl(might_break: false))
+        Yield(expr) => match expr.has_value() {
+            true => expr!.control_flow().updated(BlockControlFlow::AlwaysTransfersControl(might_break: false))
+            false => BlockControlFlow::AlwaysTransfersControl(might_break: false)
+        }
         If(condition, then_block, else_statement) => match condition {
             Boolean(val) => match val {
                 true => then_block.control_flow
@@ -5489,33 +5492,54 @@ struct Typechecker {
             checked_block.control_flow = checked_block.control_flow.updated(.statement_control_flow(checked_statement))
 
             let yield_span: Span? = match parsed_statement {
-                ParsedStatement::Yield(expr) => Some(expr.span())
+                ParsedStatement::Yield(expr) => match expr.has_value() {
+                    true => expr!.span()
+                    false => None
+                }
                 ParsedStatement::Guard(expr) => Some(expr.span())
                 else => None
             }
+
+            mut yield_present = false
             let checked_yield_expression: CheckedExpression? = match checked_statement {
-                CheckedStatement::Yield(expr) => Some(expr)
+                CheckedStatement::Yield(expr) => {
+                    yield_present = true
+                    yield expr
+                }
                 else => None
             }
 
-            if yield_span.has_value() and checked_yield_expression.has_value() {
-                let type_var_type_id = checked_yield_expression!.type()
-                let type_ = .resolve_type_var(type_var_type_id , scope_id: block_scope_id)
+            if yield_present {
+                if yield_span.has_value() and checked_yield_expression.has_value() {
+                    let type_var_type_id = checked_yield_expression!.type()
+                    let type_ = .resolve_type_var(type_var_type_id , scope_id: block_scope_id)
 
-                if checked_yield_expression! is OptionalNone {
-                    checked_block.yielded_none = true
-                }
+                    if checked_yield_expression! is OptionalNone {
+                        checked_block.yielded_none = true
+                    }
 
-                if checked_block.yielded_type.has_value() {
-                    // TODO check types for compat
-                    .check_types_for_compat(
-                        lhs_type_id: checked_block.yielded_type.value()
-                        rhs_type_id: type_
-                        generic_inferences: &mut .generic_inferences
-                        span: yield_span.value()
-                    )
+                    if checked_block.yielded_type.has_value() {
+                        // TODO check types for compat
+                        .check_types_for_compat(
+                            lhs_type_id: checked_block.yielded_type.value()
+                            rhs_type_id: type_
+                            generic_inferences: &mut .generic_inferences
+                            span: yield_span.value()
+                        )
+                    } else {
+                        checked_block.yielded_type = Some(type_)
+                    }
                 } else {
-                    checked_block.yielded_type = Some(type_)
+                    if checked_block.yielded_type.has_value() {
+                        .check_types_for_compat(
+                            lhs_type_id: checked_block.yielded_type.value()
+                            rhs_type_id: void_type_id()
+                            generic_inferences: &mut .generic_inferences
+                            span: yield_span.value()
+                        )
+                    } else {
+                        checked_block.yielded_type = Some(void_type_id())
+                    }
                 }
             }
 
@@ -6399,7 +6423,7 @@ struct Typechecker {
     fn typecheck_statement(mut this, anon statement: ParsedStatement, scope_id: ScopeId, safety_mode: SafetyMode, type_hint: TypeId? = None) throws -> CheckedStatement => match statement {
         Expression(expr, span) => CheckedStatement::Expression(expr: .typecheck_expression(expr, scope_id, safety_mode, type_hint: TypeId::none()), span)
         UnsafeBlock(block, span) => CheckedStatement::Block(block: .typecheck_block(block, parent_scope_id: scope_id, safety_mode: SafetyMode::Unsafe), span)
-        Yield(expr, span) => CheckedStatement::Yield(expr: .typecheck_expression(expr, scope_id, safety_mode, type_hint: type_hint), span)
+        Yield(expr, span) => .typecheck_yield(expr, span, scope_id, safety_mode, type_hint)
         Return(expr, span) => .typecheck_return(expr, span, scope_id, safety_mode)
         Block(block, span) => .typecheck_block_statement(parsed_block: block, scope_id, safety_mode, span)
         InlineCpp(block, span) => .typecheck_inline_cpp(block, span, safety_mode)
@@ -6415,6 +6439,14 @@ struct Typechecker {
         Garbage(span) => CheckedStatement::Garbage(span)
         For(iterator_name, name_span, is_destructuring, range, block, span) => .typecheck_for(iterator_name, name_span, is_destructuring, range, block, scope_id, safety_mode, span)
         Guard(expr, else_block, remaining_code, span) => .typecheck_guard(expr, else_block, remaining_code, scope_id, safety_mode, span)
+    }
+
+    fn typecheck_yield(mut this, expr: ParsedExpression?, span: Span, scope_id: ScopeId, safety_mode: SafetyMode, type_hint: TypeId? = None) throws -> CheckedStatement {
+        if not expr.has_value() {
+            return CheckedStatement::Yield(expr: None, span)
+        }
+
+        return CheckedStatement::Yield(expr: .typecheck_expression(expr!, scope_id, safety_mode, type_hint), span)
     }
 
     fn typecheck_continue(mut this, span: Span) -> CheckedStatement {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -1346,7 +1346,7 @@ boxed enum CheckedStatement {
     Break(Span)
     Continue(Span)
     Throw(expr: CheckedExpression, span: Span)
-    Yield(expr: CheckedExpression, span: Span)
+    Yield(expr: CheckedExpression?, span: Span)
     InlineCpp(lines: [String], span: Span)
     Garbage(Span)
 

--- a/tests/codegen/match_yield_void.jakt
+++ b/tests/codegen/match_yield_void.jakt
@@ -1,0 +1,16 @@
+/// Expect:
+/// - output: "1\n2\n"
+
+fn is_void() {
+    println("1")
+}
+
+fn main() {
+    match 1 {
+        1 => {
+            yield is_void()
+        }
+        else => { }
+    }
+    println("2")
+}

--- a/tests/typechecker/assign_optional_void.jakt
+++ b/tests/typechecker/assign_optional_void.jakt
@@ -1,0 +1,16 @@
+/// Expect:
+/// - error: "Cannot assign `Optional<void>` to a variable"
+
+fn may_throw() throws {}
+
+fn thing() {
+    let a = match 1 {
+        1 => try may_throw() catch {},
+        else => {}
+    }
+}
+
+fn main() {
+    thing()
+    println("PASS")
+}

--- a/tests/typechecker/yield_void_match.jakt
+++ b/tests/typechecker/yield_void_match.jakt
@@ -1,0 +1,21 @@
+/// Expect:
+/// - output: "PASS\n"
+
+fn is_void() {
+    println("PASS")
+}
+
+fn test() {
+    match 1 {
+        1 => {
+            is_void();
+            yield
+        }
+        else => {
+        }
+    }
+}
+
+fn main() {
+    test()
+}

--- a/tests/typechecker/yield_void_match_inside_match.jakt
+++ b/tests/typechecker/yield_void_match_inside_match.jakt
@@ -1,0 +1,26 @@
+/// Expect:
+/// - output: "1\n2\n"
+
+fn test() {
+    let x = 3
+    match 1 {
+        1 => {
+            match x {
+                2 => println("FAIL")
+                else => {
+                    println("1")
+                    yield
+                }
+            }
+
+            // Note that this will execute, inner match does not yield out of the outer match
+            println("2")
+        }
+        else => {
+        }
+    }
+}
+
+fn main() {
+    test()
+}

--- a/tests/typechecker/yield_void_try_catch_in_match.jakt
+++ b/tests/typechecker/yield_void_try_catch_in_match.jakt
@@ -1,0 +1,31 @@
+/// Expect:
+/// - output: "1\n2\n3\n"
+
+fn maybe_throws(x: i64) throws {
+    println("1")
+
+    if x == 3 {
+        throw Error::from_string_literal("fun")
+    }
+}
+
+fn test() {
+    let x = 3
+    match 1 {
+        1 => {
+            try maybe_throws(x) catch {
+                println("2")
+                yield
+            }
+
+            // Note that this will execute, catch block does not yield out of the match
+            println("3")
+        }
+        else => {
+        }
+    }
+}
+
+fn main() {
+    test()
+}


### PR DESCRIPTION
Fixes #1544. First sample now shows an error "Cannot assign `Optional<void>` to a variable". Second sample prints "PASS".