### PR TITLE
interpreter: Reserve throwing for soft errors

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -4643,13 +4643,13 @@ struct CodeGenerator {
                             yield_type_hint: TypeId?
                             containing_function_id: FunctionId? = None
                         ) throws -> CheckedBlock {
-                            throw Error::from_string_literal("Cannot typecheck a const block")
+                            panic("Cannot typecheck a const block")
                         }
 
                         register_function: fn(
                             function: CheckedFunction
                         ) throws -> FunctionId {
-                            throw Error::from_string_literal("Cannot typecheck a const function")
+                            panic("Cannot typecheck a const function")
                         }
                     )
                     spans: []

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -446,7 +446,7 @@ fn cast_value_to_type(anon this_value: Value, anon type_id: TypeId, interpreter:
 fn value_to_checked_expression(anon this_value: Value, anon mut interpreter: Interpreter) throws -> CheckedExpression => match this_value.impl {
     Void => {
         interpreter.error("Cannot convert void to expression", this_value.span)
-        throw Error::from_string_literal("Invalid type")
+        interpreter.compiler.panic("Invalid type")
     }
     Bool(x)  => CheckedExpression::Boolean(val: x, span: this_value.span)
     U8(x)    => CheckedExpression::NumericConstant(val: CheckedNumericConstant::U8(x), span: this_value.span, type_id: builtin(BuiltinType::U8))
@@ -507,7 +507,7 @@ fn value_to_checked_expression(anon this_value: Value, anon mut interpreter: Int
             interpreter.error_with_hint(
                 "Cannot convert struct to expression without constructor", this_value.span,
                 "Given struct cannot be created from its contents in any known way", this_value.span)
-            throw Error::from_string_literal("Invalid type")
+            interpreter.compiler.panic("Invalid type")
         }
 
         mut materialised_fields: [CheckedExpression] = []
@@ -535,7 +535,7 @@ fn value_to_checked_expression(anon this_value: Value, anon mut interpreter: Int
             interpreter.error_with_hint(
                 "Too many arguments for constructor", this_value.span,
                 format("Expected at most {} arguments, got {}", callee.params.size(), materialised_fields.size()), this_value.span)
-            throw Error::from_string_literal("Invalid type")
+            interpreter.compiler.panic("Invalid type")
         }
 
         let name = struct_.name
@@ -620,7 +620,7 @@ fn value_to_checked_expression(anon this_value: Value, anon mut interpreter: Int
         let inner_type_id = match interpreter.program.get_type(type_id) {
             GenericInstance(args) => args[0]
             else => {
-                panic("Expected generic instance of Array while materialising an array")
+                interpreter.compiler.panic("Expected generic instance of Array while materialising an array")
             }
         }
 
@@ -644,7 +644,7 @@ fn value_to_checked_expression(anon this_value: Value, anon mut interpreter: Int
         let (key_type_id, value_type_id) = match interpreter.program.get_type(type_id) {
             GenericInstance(args) => (args[0], args[1])
             else => {
-                panic("Expected generic instance of Dictionary while materialising an array")
+                interpreter.compiler.panic("Expected generic instance of Dictionary while materialising an array")
             }
         }
 
@@ -665,7 +665,7 @@ fn value_to_checked_expression(anon this_value: Value, anon mut interpreter: Int
         let value_type_id = match interpreter.program.get_type(type_id) {
             GenericInstance(args) => args[0]
             else => {
-                panic("Expected generic instance of Set while materialising an array")
+                interpreter.compiler.panic("Expected generic instance of Set while materialising an array")
             }
         }
 
@@ -762,7 +762,7 @@ fn value_to_checked_expression(anon this_value: Value, anon mut interpreter: Int
             format("Cannot materialise the type {}", this_value.impl)
             this_value.span
         )
-        throw Error::from_string_literal("Not yet implemented")
+        interpreter.compiler.panic("Not yet implemented")
     }
 }
 
@@ -776,15 +776,18 @@ class InterpreterScope {
     public parent: InterpreterScope?
     public type_bindings: [TypeId:TypeId] = [:]
     public defers: [Deferred] = []
+    compiler: Compiler
 
     public fn create(
         bindings: [String:Value] = [:]
         parent: InterpreterScope? = None
         type_bindings: [TypeId:TypeId] = [:]
+        compiler: Compiler
     ) -> InterpreterScope => InterpreterScope(
         bindings
         parent
         type_bindings
+        compiler
     )
 
     public fn from_runtime_scope(scope_id: ScopeId, program: CheckedProgram, parent: InterpreterScope? = None) -> InterpreterScope {
@@ -815,6 +818,7 @@ class InterpreterScope {
         return InterpreterScope(
             bindings
             parent
+            compiler: program.compiler
         )
     }
 
@@ -832,7 +836,7 @@ class InterpreterScope {
         }
 
         // How did this pass typecheck?
-        throw Error::from_string_literal("Could not find binding")
+        .compiler.panic("Could not find binding")
     }
 
     public fn set(mut this, anon name: String, anon value: Value) throws {
@@ -851,7 +855,7 @@ class InterpreterScope {
         }
 
         // How did this pass typecheck?
-        throw Error::from_string_literal("Could not find binding")
+        .compiler.panic("Could not find binding")
     }
 
     public fn all_bindings(this) -> [String:Value] {
@@ -1167,7 +1171,7 @@ class Interpreter {
                             if is_optional {
                                 if not id.equals(optional_struct_id) {
                                     .error("Optional chaining is only allowed on optional types", span)
-                                    throw Error::from_string_literal("Invalid operation")
+                                    .compiler.panic("Invalid operation")
                                 }
 
                                 type_id = args[0]
@@ -1196,18 +1200,18 @@ class Interpreter {
                                     }
 
                                     .error(format("unknown member of struct: {}.{}", structure.name, field), span)
-                                    throw Error::from_string_literal("Invalid operation")
+                                    .compiler.panic("Invalid operation")
                                 }
                                 else => {
                                     .error(format("Member field access on value of non-struct type ‘{}’", .program.type_name(checked_expr_type_id)), span)
-                                    throw Error::from_string_literal("Invalid operation")
+                                    .compiler.panic("Invalid operation")
                                 }
                             }
                         }
                         Type::Struct(struct_id) => {
                             if is_optional {
                                 .error("Optional chaining is not allowed on non-optional types", span)
-                                throw Error::from_string_literal("Invalid operation")
+                                .compiler.panic("Invalid operation")
                             }
 
                             let structure = .program.get_struct(struct_id)
@@ -1228,17 +1232,17 @@ class Interpreter {
                             }
 
                             .error(format("unknown member of struct: {}.{}", structure.name, field), span)
-                            throw Error::from_string_literal("Invalid operation")
+                            .compiler.panic("Invalid operation")
                         }
                         else => {
                             .error(format("Member field access on value of non-struct type ‘{}’", .program.type_name(checked_expr_type_id)), span)
-                            throw Error::from_string_literal("Invalid operation")
+                            .compiler.panic("Invalid operation")
                         }
                     }
                 }
                 UnsignedNumericValue(val) | SignedNumericValue(val) => {
                     .error("Unimplemented expression", span)
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 }
             }
         }
@@ -1364,7 +1368,7 @@ class Interpreter {
                                 format("Expected string as first argument to format, got {}", arguments[0].impl),
                                 call_span
                             )
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     yield StatementResult::JustValue(
@@ -1381,7 +1385,7 @@ class Interpreter {
                         JaktString(x) => x
                         else => {
                             .error(format( "println expects a string as its first argument, but got {}", arguments[0].impl), call_span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     let formatted_string = comptime_format_impl(format_string, arguments: arguments[1..], program: &.program)
@@ -1421,82 +1425,82 @@ class Interpreter {
                                     U8(y) => ValueImpl::U8(unchecked_mul(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 U16(x) => match rhs_value.impl {
                                     U16(y) => ValueImpl::U16(unchecked_mul(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 U32(x) => match rhs_value.impl {
                                     U32(y) => ValueImpl::U32(unchecked_mul(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 U64(x) => match rhs_value.impl {
                                     U64(y) => ValueImpl::U64(unchecked_mul(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 I8(x) => match rhs_value.impl {
                                     I8(y) => ValueImpl::I8(unchecked_mul(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 I16(x) => match rhs_value.impl {
                                     I16(y) => ValueImpl::I16(unchecked_mul(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 I32(x) => match rhs_value.impl {
                                     I32(y) => ValueImpl::I32(unchecked_mul(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 I64(x) => match rhs_value.impl {
                                     I64(y) => ValueImpl::I64(unchecked_mul(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 F32(x) => match rhs_value.impl {
                                     F32(y) => ValueImpl::F32(unchecked_mul(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 F64(x) => match rhs_value.impl {
                                     F64(y) => ValueImpl::F64(unchecked_mul(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 USize(x) => match rhs_value.impl {
                                     USize(y) => ValueImpl::USize(unchecked_mul(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 else => {
                                     .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                    throw Error::from_string_literal("Invalid type")
+                                    .compiler.panic("Invalid type")
                                 }
                             }
                             span
@@ -1515,82 +1519,82 @@ class Interpreter {
                                     U8(y) => ValueImpl::U8(unchecked_add(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 U16(x) => match rhs_value.impl {
                                     U16(y) => ValueImpl::U16(unchecked_add(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 U32(x) => match rhs_value.impl {
                                     U32(y) => ValueImpl::U32(unchecked_add(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 U64(x) => match rhs_value.impl {
                                     U64(y) => ValueImpl::U64(unchecked_add(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 I8(x) => match rhs_value.impl {
                                     I8(y) => ValueImpl::I8(unchecked_add(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 I16(x) => match rhs_value.impl {
                                     I16(y) => ValueImpl::I16(unchecked_add(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 I32(x) => match rhs_value.impl {
                                     I32(y) => ValueImpl::I32(unchecked_add(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 I64(x) => match rhs_value.impl {
                                     I64(y) => ValueImpl::I64(unchecked_add(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 F32(x) => match rhs_value.impl {
                                     F32(y) => ValueImpl::F32(unchecked_add(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 F64(x) => match rhs_value.impl {
                                     F64(y) => ValueImpl::F64(unchecked_add(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 USize(x) => match rhs_value.impl {
                                     USize(y) => ValueImpl::USize(unchecked_add(x, y))
                                     else => {
                                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                        throw Error::from_string_literal("Invalid type")
+                                        .compiler.panic("Invalid type")
                                     }
                                 }
                                 else => {
                                     .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                                    throw Error::from_string_literal("Invalid type")
+                                    .compiler.panic("Invalid type")
                                 }
                             }
                             span
@@ -1617,7 +1621,7 @@ class Interpreter {
                 "Set" => {
                     if type_bindings.size() != 1 {
                         .error("Set constructor expects one generic argument", call_span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                     let set_struct_id = .program.find_struct_in_prelude("Set")
                     let type_id = .find_or_add_type_id(Type::GenericInstance(id: set_struct_id, args: [type_bindings.get(type_bindings.keys()[0])!]))
@@ -1630,7 +1634,7 @@ class Interpreter {
                 "Dictionary" => {
                     if type_bindings.size() != 2 {
                         .error("Dictionary constructor expects two generic argumenst", call_span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                     let dictionary_struct_id = .program.find_struct_in_prelude("Dictionary")
                     let type_id = .find_or_add_type_id(Type::GenericInstance(id: dictionary_struct_id, args: [
@@ -1651,7 +1655,7 @@ class Interpreter {
                         format("Prelude function {}::{} is not implemented yet", namespace_, prelude_function),
                         call_span
                     )
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 }
             }
         }
@@ -1704,7 +1708,7 @@ class Interpreter {
                                 format("Error should have `i32` as its code, but got {}", fields[0].impl),
                                 call_span
                             )
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
@@ -1712,7 +1716,7 @@ class Interpreter {
                             format("Prelude function `Error::code` expects an Error as its this argument, but got {}", this_argument!.impl),
                             call_span
                         )
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 else => {
@@ -1720,7 +1724,7 @@ class Interpreter {
                         format("Prelude function `Error::{}` is not implemented", prelude_function),
                         call_span
                     )
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 }
             }
             "File" => match prelude_function {
@@ -1732,7 +1736,7 @@ class Interpreter {
                                 format("Prelude function `File::{}` expects a string as its first argument, but got {}", prelude_function, arguments[0].impl),
                                 call_span
                             )
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     let path = .program.compiler.get_file_path(call_span.file_id)!.parent().join(requested_path)
@@ -1768,7 +1772,7 @@ class Interpreter {
                                 format("Prelude function `File::{}` expects a string as its first argument, but got {}", prelude_function, arguments[0].impl),
                                 call_span
                             )
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     let path = .program.compiler.get_file_path(call_span.file_id)!.parent().join(requested_path)
@@ -1809,7 +1813,7 @@ class Interpreter {
                                 format("Prelude function `File::read_all` expects a `File` as its this argument, but got {}", this_argument!.impl),
                                 call_span
                             )
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     let file_struct_id = .program.find_struct_in_prelude("File")
@@ -1823,7 +1827,9 @@ class Interpreter {
                                     "Cannot read from a file not opened for reading"
                                     call_span
                                 )
-                                throw Error::from_string_literal("Invalid type")
+                                // FIXME: This could contain a better error
+                                // message
+                                .compiler.panic("Invalid type")
                             }
                         }
                         else => {
@@ -1864,7 +1870,7 @@ class Interpreter {
                                 format("Prelude function `File::read` expects a `File` as its this argument, but got {}", this_argument!.impl),
                                 call_span
                             )
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     let file_struct_id = .program.find_struct_in_prelude("File")
@@ -1878,7 +1884,7 @@ class Interpreter {
                                     "Cannot read from a file not opened for reading"
                                     call_span
                                 )
-                                throw Error::from_string_literal("Invalid type")
+                                .compiler.panic("Invalid type")
                             }
                         }
                         else => {
@@ -1893,7 +1899,7 @@ class Interpreter {
                                 format("Prelude function `File::read` expects a `[u8]` as its argument, but got {}", arguments[0].impl),
                                 call_span
                             )
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     mut byte_buffer: [u8] = [0; values_buffer.size()]
@@ -1921,7 +1927,7 @@ class Interpreter {
                                 format("Prelude function `File::{}` expects a string as its first argument, but got {}", prelude_function, arguments[0].impl),
                                 call_span
                             )
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     let path = .program.compiler.get_file_path(call_span.file_id)!.parent().join(requested_path)
@@ -1945,7 +1951,7 @@ class Interpreter {
                                 format("Prelude function `File::write` expects a `File` as its this argument, but got {}", this_argument!.impl),
                                 call_span
                             )
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     let file_struct_id = .program.find_struct_in_prelude("File")
@@ -1959,7 +1965,8 @@ class Interpreter {
                                     "Cannot write to a file not opened for writing"
                                     call_span
                                 )
-                                throw Error::from_string_literal("Invalid type")
+                                // FIXME: This could have a better message
+                                .compiler.panic("Invalid type")
                             }
                         }
                         else => {
@@ -1974,7 +1981,7 @@ class Interpreter {
                                 format("Prelude function `File::write` expects a `[u8]` as its argument, but got {}", arguments[0].impl),
                                 call_span
                             )
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     mut data: [u8] = []
@@ -1998,7 +2005,7 @@ class Interpreter {
                         format("Prelude function `File::{}` is not implemented", prelude_function),
                         call_span
                     )
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 }
             }
             "StringBuilder" => match prelude_function {
@@ -2028,7 +2035,7 @@ class Interpreter {
                                 format("Prelude function `StringBuilder::{}` expects a StringBuilder as its this argument", prelude_function),
                                 call_span
                             )
-                            throw Error::from_string_literal("Not yet implemented")
+                            .compiler.panic("Invalid call")
                         }
                     }
 
@@ -2042,21 +2049,21 @@ class Interpreter {
                             // FIXME: When we can represent raw pointers in the interpreter, implement the 2 arg overload
                             else => {
                                 .error(format("Invalid use of StringBuilder::append({})", arguments[0].impl), call_span)
-                                throw Error::from_string_literal("Invalid type")
+                                .compiler.panic("Invalid type")
                             }
                         }
                         "append_escaped_for_json" => builder.append_escaped_for_json(match arguments[0].impl {
                             JaktString(value) => value
                             else => {
                                 .error("Invalid use of StringBuilder::append_escaped_for_json()", call_span)
-                                throw Error::from_string_literal("Invalid type")
+                                .compiler.panic("Invalid type")
                             }
                         })
                         "append_code_point" => builder.append_code_point(match arguments[0].impl {
                             U32(value) => value
                             else => {
                                 .error("Invalid use of StringBuilder::append_code_point()", call_span)
-                                throw Error::from_string_literal("Invalid type")
+                                .compiler.panic("Invalid type")
                             }
                         })
                         else => {
@@ -2080,7 +2087,7 @@ class Interpreter {
                             format("Prelude function `StringBuilder::{}` expects a StringBuilder as its this argument", prelude_function),
                             call_span
                         )
-                        throw Error::from_string_literal("Not yet implemented")
+                        .compiler.panic("Not yet implemented")
                     }
                 }
                 "is_empty" => match this_argument!.impl {
@@ -2095,7 +2102,7 @@ class Interpreter {
                             format("Prelude function `StringBuilder::{}` expects a StringBuilder as its this argument", prelude_function),
                             call_span
                         )
-                        throw Error::from_string_literal("Not yet implemented")
+                        .compiler.panic("Not yet implemented")
                     }
                 }
                 "length" => match this_argument!.impl {
@@ -2110,7 +2117,7 @@ class Interpreter {
                             format("Prelude function `StringBuilder::{}` expects a StringBuilder as its this argument", prelude_function),
                             call_span
                         )
-                        throw Error::from_string_literal("Not yet implemented")
+                        .compiler.panic("Not yet implemented")
                     }
                 }
                 "clear" => match this_argument!.impl {
@@ -2124,7 +2131,7 @@ class Interpreter {
                             format("Prelude function `StringBuilder::{}` expects a StringBuilder as its this argument", prelude_function),
                             call_span
                         )
-                        throw Error::from_string_literal("Not yet implemented")
+                        .compiler.panic("Not yet implemented")
                     }
                 }
                 else => {
@@ -2132,14 +2139,14 @@ class Interpreter {
                         format("Prelude function `StringBuilder::{}` is not implemented", prelude_function),
                         call_span
                     )
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 }
             }
             "Dictionary" => match prelude_function {
                 "Dictionary" => {
                     if type_bindings.size() != 2 {
                         .error("Dictionary constructor expects two generic argumenst", call_span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                     let dictionary_struct_id = .program.find_struct_in_prelude("Dictionary")
                     let type_id = .find_or_add_type_id(Type::GenericInstance(id: dictionary_struct_id, args: [
@@ -2292,7 +2299,7 @@ class Interpreter {
                         }
                         else => {
                             .error("Dictionary::ensure_capacity must be called with a usize", arguments[0].span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
@@ -2383,7 +2390,7 @@ class Interpreter {
                         format("Prelude function `Dictionary::{}` is not implemented", prelude_function),
                         call_span
                     )
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 }
             }
             "Array" => match prelude_function {
@@ -2555,7 +2562,7 @@ class Interpreter {
                         }
                         else => {
                             .error("Array::ensure_capacity must be called with a usize", arguments[0].span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
@@ -2576,7 +2583,7 @@ class Interpreter {
                         }
                         else => {
                             .error("Array::add_capacity must be called with a usize", arguments[0].span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
@@ -2597,7 +2604,7 @@ class Interpreter {
                         }
                         else => {
                             .error("Array::shrink must be called with a usize", arguments[0].span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
@@ -2609,7 +2616,7 @@ class Interpreter {
                         format("Prelude function `Array::{}` is not implemented", prelude_function),
                         call_span
                     )
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 }
             }
             "ArrayIterator" => match prelude_function {
@@ -2647,7 +2654,7 @@ class Interpreter {
                         format("Prelude function `ArrayIterator::{}` is not implemented", prelude_function),
                         call_span
                     )
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 }
             }
             // Note: This does _not_ share the same layout in the rt, but we can just increment/decrement the start value.
@@ -2727,7 +2734,7 @@ class Interpreter {
                         format("Prelude function `Range::{}` is not implemented", prelude_function),
                         call_span
                     )
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 }
             }
             "String" => match prelude_function {
@@ -2768,12 +2775,12 @@ class Interpreter {
                             }
                             else => {
                                 .error("String::substring must be called with unsigned arguments", arguments[1].span)
-                                throw Error::from_string_literal("Invalid type")
+                                .compiler.panic("Invalid type")
                             }
                         }
                         else => {
                             .error("String::substring must be called with unsigned arguments", arguments[0].span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
@@ -2791,18 +2798,18 @@ class Interpreter {
                     => StatementResult::JustValue(Value(impl: ValueImpl::JaktString(String::number(number as! i64)), span: call_span))
                     USize() | U64() => {
                         .error("String::number must not be called with a usize or u64", arguments[0].span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                     else => {
                         .error("String::number must be called with an integer", arguments[0].span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 "to_number" => match this_argument!.impl {
                     JaktString(value) => {
                         if type_bindings.size() < 1 {
                             .error("to_number expects one generic argument", call_span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
 
                         let target_type = .program.get_type(type_bindings.get(type_bindings.keys()[0])!)
@@ -2825,7 +2832,7 @@ class Interpreter {
                             }
                             // FIXME: Add support for other number types
                             else => {
-                                throw Error::from_string_literal("Invalid or unsupported type for String::to_number")
+                                .compiler.panic("Invalid or unsupported type for String::to_number")
                             }
                         }
                     }
@@ -2844,7 +2851,7 @@ class Interpreter {
                         JaktString(arg) => StatementResult::JustValue(Value(impl: ValueImpl::Bool(value.contains(arg)), span: call_span))
                         else => {
                             .error("String::contains must be called with a string", arguments[0].span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
@@ -2857,12 +2864,12 @@ class Interpreter {
                             JaktString(with) => StatementResult::JustValue(Value(impl: ValueImpl::JaktString(value.replace(replace, with)), span: call_span))
                             else => {
                                 .error("String::replace must be called with strings", arguments[1].span)
-                                throw Error::from_string_literal("Invalid type")
+                                .compiler.panic("Invalid type")
                             }
                         }
                         else => {
                             .error("String::replace must be called with strings", arguments[0].span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
@@ -2879,7 +2886,7 @@ class Interpreter {
                         => StatementResult::JustValue(Value(impl: ValueImpl::U8(value.byte_at(index as! usize)), span: call_span))
                         else => {
                             .error("String::byte_at must be called with an unsigned integer", arguments[0].span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
@@ -2907,7 +2914,7 @@ class Interpreter {
                         }
                         else => {
                             .error("String::split must be called with a c_char", arguments[0].span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
@@ -2919,7 +2926,7 @@ class Interpreter {
                         JaktString(arg) => StatementResult::JustValue(Value(impl: ValueImpl::Bool(value.starts_with(arg)), span: call_span))
                         else => {
                             .error("String::starts_with must be called with a string", arguments[0].span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
@@ -2931,7 +2938,7 @@ class Interpreter {
                         JaktString(arg) => StatementResult::JustValue(Value(impl: ValueImpl::Bool(value.ends_with(arg)), span: call_span))
                         else => {
                             .error("String::ends_with must be called with a string", arguments[0].span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
@@ -2941,19 +2948,19 @@ class Interpreter {
                 "repeated" => {
                     if arguments.size() != 2 {
                         .error("String::repeated must be called with a c_char and a usize", call_span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                     let (character, count) = match arguments[0].impl {
                         CChar(arg) => match arguments[1].impl {
                             USize(c) => (arg, c)
                             else => {
                                 .error("String::repeated must be called with a usize", arguments[1].span)
-                                throw Error::from_string_literal("Invalid type")
+                                .compiler.panic("Invalid type")
                             }
                         }
                         else => {
                             .error("String::repeated must be called with a c_char", arguments[0].span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     yield StatementResult::JustValue(Value(impl: ValueImpl::JaktString(String::repeated(character, count)), span: call_span))
@@ -2963,14 +2970,14 @@ class Interpreter {
                         format("Prelude function `String::{}` is not implemented", prelude_function),
                         call_span
                     )
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 }
             }
             "Set" => match prelude_function {
                 "Set" => {
                     if type_bindings.size() != 1 {
                         .error("Set constructor expects one generic argument", call_span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                     let set_struct_id = .program.find_struct_in_prelude("Set")
                     let type_id = .find_or_add_type_id(Type::GenericInstance(id: set_struct_id, args: [type_bindings.get(type_bindings.keys()[0])!]))
@@ -3094,7 +3101,7 @@ class Interpreter {
                         }
                         else => {
                             .error("Set::ensure_capacity must be called with a usize", arguments[0].span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
@@ -3130,7 +3137,7 @@ class Interpreter {
                         format("Prelude function `Set::{}` is not implemented", prelude_function),
                         call_span
                     )
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 }
             }
             "SetIterator" => match prelude_function {
@@ -3168,7 +3175,7 @@ class Interpreter {
                         format("Prelude function `ArrayIterator::{}` is not implemented", prelude_function),
                         call_span
                     )
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 }
             }
             "DictionaryIterator" => match prelude_function {
@@ -3226,7 +3233,7 @@ class Interpreter {
                         format("Prelude function `DictionaryIterator::{}` is not implemented", prelude_function),
                         call_span
                     )
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 }
             }
             "Optional" => match prelude_function {
@@ -3244,7 +3251,7 @@ class Interpreter {
                             format("Cannot unwrap optional none", prelude_function),
                             call_span
                         )
-                        throw Error::from_string_literal("Attempt to unwrap None")
+                        yield StatementResult::Throw(.error_value("Attempt to unwrap None", call_span))
                     }
                     else => {
                         panic("Invalid Optional configuration")
@@ -3256,7 +3263,7 @@ class Interpreter {
                         guard mapper_value.impl is Function(block, params, return_type_id, checked_params) else {
                             panic("Invalid mapper type in Optional::map")
                         }
-                        mut scope = InterpreterScope::create()
+                        mut scope = InterpreterScope::create(compiler: .compiler, compiler: .compiler)
                         mut first = true
                         for declared_param in checked_params {
                             let name = declared_param.variable.name
@@ -3297,7 +3304,7 @@ class Interpreter {
                         format("Prelude function `Optional::{}` is not implemented", prelude_function),
                         call_span
                     )
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 }
             }
             else => {
@@ -3305,7 +3312,7 @@ class Interpreter {
                     format("Prelude function `{}::{}` is not implemented", namespace_[0].name, prelude_function),
                     call_span
                 )
-                throw Error::from_string_literal("Not yet implemented")
+                .compiler.panic("Not yet implemented")
             }
         }
     }
@@ -3340,7 +3347,7 @@ class Interpreter {
                     format("Cannot call external function '{}'", function_to_run.name)
                     call_span
                 )
-                throw Error::from_string_literal("Attempt to call external function")
+                return ExecutionResult::Throw(.error_value("Attempt to call external function", call_span))
             }
 
             is_prelude_function = true
@@ -3361,7 +3368,7 @@ class Interpreter {
                 message: format("function call {} a this argument, yet one was{} provided", expected, not_provided),
                 span: function_to_run.name_span
             ));
-            throw Error::from_string_literal("Invalid this argument")
+            .compiler.panic("Invalid this argument")
         }
 
         mut this_offset = 0uz
@@ -3374,7 +3381,7 @@ class Interpreter {
                 message: format("Function called with wrong number of arguments, expected {} but got {}", function_to_run.params.size(), arguments.size()),
                 span: call_span
             )
-            throw Error::from_string_literal("Mismatching arguments")
+            .compiler.panic("Mismatching arguments")
         }
 
         if is_prelude_function {
@@ -3390,7 +3397,7 @@ class Interpreter {
                             GenericInstance(args) => args
                             else => {
                                 .error("Attempted to call a prelude function  on a non-generic array", call_span)
-                                throw Error::from_string_literal("Invalid type")
+                                .compiler.panic("Invalid type")
                             }
                         }
                         effective_namespace.push(ResolvedNamespace(name: "Array", generic_parameters))
@@ -3400,7 +3407,7 @@ class Interpreter {
                             GenericInstance(args) => args
                             else => {
                                 .error("Attempted to call a prelude function  on a non-generic dictionary", call_span)
-                                throw Error::from_string_literal("Invalid type")
+                                .compiler.panic("Invalid type")
                             }
                         }
                         effective_namespace.push(ResolvedNamespace(name: "Dictionary", generic_parameters))
@@ -3408,7 +3415,7 @@ class Interpreter {
                     JaktSet(type_id) => {
                         guard .program.get_type(id: type_id) is GenericInstance(args: generic_parameters) else {
                             .error("Attempted to call a prelude function  on a non-generic set", call_span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                         effective_namespace.push(ResolvedNamespace(name: "Set", generic_parameters))
                     }
@@ -3429,7 +3436,7 @@ class Interpreter {
                     }
                     else => {
                         .error("Attempted to call an instance method on a non-struct/enum type", call_span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
 
@@ -3458,7 +3465,7 @@ class Interpreter {
 
         match function_to_run.type {
             Normal => {
-                mut scope = InterpreterScope::create(parent: invocation_scope)
+                mut scope = InterpreterScope::create(parent: invocation_scope, compiler: .compiler)
                 defer {
                     scope.perform_defers(interpreter: this, span: call_span)
                 }
@@ -3491,7 +3498,7 @@ class Interpreter {
                 }
             }
             Closure | Expression => {
-                mut scope = InterpreterScope::create(parent: invocation_scope)
+                mut scope = InterpreterScope::create(parent: invocation_scope, compiler: .compiler)
                 defer {
                     scope.perform_defers(interpreter: this, span: call_span)
                 }
@@ -3539,7 +3546,7 @@ class Interpreter {
                                     format("Cannot create instance of non-struct type {}", struct_.name),
                                     call_span
                                 )
-                                throw Error::from_string_literal("Invalid type")
+                                .compiler.panic("Invalid type")
                             }
                         }
                         return ExecutionResult::Return(Value(
@@ -3552,7 +3559,7 @@ class Interpreter {
                             format("Implicit constructor can only return a struct or a generic instance"),
                             call_span
                         )
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
             }
@@ -3577,7 +3584,7 @@ class Interpreter {
                             format("Implicit enum constructor can only return an enum or a generic instance of one"),
                             call_span
                         )
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
             }
@@ -3588,7 +3595,7 @@ class Interpreter {
             format("Function type {} is not implemented", function_to_run.type),
             call_span
         )
-        throw Error::from_string_literal("Not yet implemented")
+        .compiler.panic("Not yet implemented")
     }
 
     public fn execute_statement(mut this, statement: CheckedStatement, mut scope: InterpreterScope, call_span: Span) throws -> StatementResult {
@@ -3684,7 +3691,7 @@ class Interpreter {
                                 format("if condition must be a boolean, but got {}", value.impl),
                                 span
                             )
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     Return(value) => {
@@ -3730,7 +3737,7 @@ class Interpreter {
                 }
             }
             Block(block, span) => {
-                mut new_scope = InterpreterScope::create(parent: scope)
+                mut new_scope = InterpreterScope::create(parent: scope, compiler: .compiler)
                 defer new_scope.perform_defers(interpreter: this, span)
 
                 return .execute_block(block, scope: new_scope, call_span: span)
@@ -3920,89 +3927,89 @@ class Interpreter {
                         U8(y) => ValueImpl::U8(x + y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U16(x) => match rhs_value.impl {
                         U16(y) => ValueImpl::U16(x + y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U32(x) => match rhs_value.impl {
                         U32(y) => ValueImpl::U32(x + y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U64(x) => match rhs_value.impl {
                         U64(y) => ValueImpl::U64(x + y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I8(x) => match rhs_value.impl {
                         I8(y) => ValueImpl::I8(x + y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I16(x) => match rhs_value.impl {
                         I16(y) => ValueImpl::I16(x + y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I32(x) => match rhs_value.impl {
                         I32(y) => ValueImpl::I32(x + y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I64(x) => match rhs_value.impl {
                         I64(y) => ValueImpl::I64(x + y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F32(x) => match rhs_value.impl {
                         F32(y) => ValueImpl::F32(x + y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F64(x) => match rhs_value.impl {
                         F64(y) => ValueImpl::F64(x + y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     USize(x) => match rhs_value.impl {
                         USize(y) => ValueImpl::USize(x + y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     JaktString(x) => match rhs_value.impl {
                         JaktString(y) => ValueImpl::JaktString(x + y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -4015,82 +4022,82 @@ class Interpreter {
                         U8(y) => ValueImpl::U8(x - y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U16(x) => match rhs_value.impl {
                         U16(y) => ValueImpl::U16(x - y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U32(x) => match rhs_value.impl {
                         U32(y) => ValueImpl::U32(x - y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U64(x) => match rhs_value.impl {
                         U64(y) => ValueImpl::U64(x - y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I8(x) => match rhs_value.impl {
                         I8(y) => ValueImpl::I8(x - y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I16(x) => match rhs_value.impl {
                         I16(y) => ValueImpl::I16(x - y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I32(x) => match rhs_value.impl {
                         I32(y) => ValueImpl::I32(x - y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I64(x) => match rhs_value.impl {
                         I64(y) => ValueImpl::I64(x - y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F32(x) => match rhs_value.impl {
                         F32(y) => ValueImpl::F32(x - y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F64(x) => match rhs_value.impl {
                         F64(y) => ValueImpl::F64(x - y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     USize(x) => match rhs_value.impl {
                         USize(y) => ValueImpl::USize(x - y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -4103,82 +4110,82 @@ class Interpreter {
                         U8(y) => ValueImpl::U8(x * y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U16(x) => match rhs_value.impl {
                         U16(y) => ValueImpl::U16(x * y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U32(x) => match rhs_value.impl {
                         U32(y) => ValueImpl::U32(x * y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U64(x) => match rhs_value.impl {
                         U64(y) => ValueImpl::U64(x * y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I8(x) => match rhs_value.impl {
                         I8(y) => ValueImpl::I8(x * y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I16(x) => match rhs_value.impl {
                         I16(y) => ValueImpl::I16(x * y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I32(x) => match rhs_value.impl {
                         I32(y) => ValueImpl::I32(x * y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I64(x) => match rhs_value.impl {
                         I64(y) => ValueImpl::I64(x * y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F32(x) => match rhs_value.impl {
                         F32(y) => ValueImpl::F32(x * y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F64(x) => match rhs_value.impl {
                         F64(y) => ValueImpl::F64(x * y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     USize(x) => match rhs_value.impl {
                         USize(y) => ValueImpl::USize(x * y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -4191,82 +4198,82 @@ class Interpreter {
                         U8(y) => ValueImpl::U8(x / y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U16(x) => match rhs_value.impl {
                         U16(y) => ValueImpl::U16(x / y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U32(x) => match rhs_value.impl {
                         U32(y) => ValueImpl::U32(x / y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U64(x) => match rhs_value.impl {
                         U64(y) => ValueImpl::U64(x / y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I8(x) => match rhs_value.impl {
                         I8(y) => ValueImpl::I8(x / y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I16(x) => match rhs_value.impl {
                         I16(y) => ValueImpl::I16(x / y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I32(x) => match rhs_value.impl {
                         I32(y) => ValueImpl::I32(x / y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I64(x) => match rhs_value.impl {
                         I64(y) => ValueImpl::I64(x / y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F32(x) => match rhs_value.impl {
                         F32(y) => ValueImpl::F32(x / y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F64(x) => match rhs_value.impl {
                         F64(y) => ValueImpl::F64(x / y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     USize(x) => match rhs_value.impl {
                         USize(y) => ValueImpl::USize(x / y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -4279,103 +4286,103 @@ class Interpreter {
                         U8(y) => ValueImpl::Bool(x == y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U16(x) => match rhs_value.impl {
                         U16(y) => ValueImpl::Bool(x == y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U32(x) => match rhs_value.impl {
                         U32(y) => ValueImpl::Bool(x == y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U64(x) => match rhs_value.impl {
                         U64(y) => ValueImpl::Bool(x == y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I8(x) => match rhs_value.impl {
                         I8(y) => ValueImpl::Bool(x == y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I16(x) => match rhs_value.impl {
                         I16(y) => ValueImpl::Bool(x == y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I32(x) => match rhs_value.impl {
                         I32(y) => ValueImpl::Bool(x == y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I64(x) => match rhs_value.impl {
                         I64(y) => ValueImpl::Bool(x == y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F32(x) => match rhs_value.impl {
                         F32(y) => ValueImpl::Bool(x == y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F64(x) => match rhs_value.impl {
                         F64(y) => ValueImpl::Bool(x == y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     USize(x) => match rhs_value.impl {
                         USize(y) => ValueImpl::Bool(x == y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     CInt(x) => match rhs_value.impl {
                         CInt(y) => ValueImpl::Bool(x == y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     CChar(x) => match rhs_value.impl {
                         CChar(y) => ValueImpl::Bool(x == y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     JaktString(x) => match rhs_value.impl {
                         JaktString(y) => ValueImpl::Bool(x == y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -4388,103 +4395,103 @@ class Interpreter {
                         U8(y) => ValueImpl::Bool(x != y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U16(x) => match rhs_value.impl {
                         U16(y) => ValueImpl::Bool(x != y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U32(x) => match rhs_value.impl {
                         U32(y) => ValueImpl::Bool(x != y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U64(x) => match rhs_value.impl {
                         U64(y) => ValueImpl::Bool(x != y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I8(x) => match rhs_value.impl {
                         I8(y) => ValueImpl::Bool(x != y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I16(x) => match rhs_value.impl {
                         I16(y) => ValueImpl::Bool(x != y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I32(x) => match rhs_value.impl {
                         I32(y) => ValueImpl::Bool(x != y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I64(x) => match rhs_value.impl {
                         I64(y) => ValueImpl::Bool(x != y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F32(x) => match rhs_value.impl {
                         F32(y) => ValueImpl::Bool(x != y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F64(x) => match rhs_value.impl {
                         F64(y) => ValueImpl::Bool(x != y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     USize(x) => match rhs_value.impl {
                         USize(y) => ValueImpl::Bool(x != y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     CInt(x) => match rhs_value.impl {
                         CInt(y) => ValueImpl::Bool(x != y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     CChar(x) => match rhs_value.impl {
                         CChar(y) => ValueImpl::Bool(x != y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     JaktString(x) => match rhs_value.impl {
                         JaktString(y) => ValueImpl::Bool(x != y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -4497,89 +4504,89 @@ class Interpreter {
                         U8(y) => ValueImpl::Bool(x < y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U16(x) => match rhs_value.impl {
                         U16(y) => ValueImpl::Bool(x < y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U32(x) => match rhs_value.impl {
                         U32(y) => ValueImpl::Bool(x < y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U64(x) => match rhs_value.impl {
                         U64(y) => ValueImpl::Bool(x < y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I8(x) => match rhs_value.impl {
                         I8(y) => ValueImpl::Bool(x < y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I16(x) => match rhs_value.impl {
                         I16(y) => ValueImpl::Bool(x < y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I32(x) => match rhs_value.impl {
                         I32(y) => ValueImpl::Bool(x < y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I64(x) => match rhs_value.impl {
                         I64(y) => ValueImpl::Bool(x < y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F32(x) => match rhs_value.impl {
                         F32(y) => ValueImpl::Bool(x < y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F64(x) => match rhs_value.impl {
                         F64(y) => ValueImpl::Bool(x < y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     USize(x) => match rhs_value.impl {
                         USize(y) => ValueImpl::Bool(x < y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     JaktString(x) => match rhs_value.impl {
                         JaktString(y) => ValueImpl::Bool(x < y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -4592,89 +4599,89 @@ class Interpreter {
                         U8(y) => ValueImpl::Bool(x <= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U16(x) => match rhs_value.impl {
                         U16(y) => ValueImpl::Bool(x <= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U32(x) => match rhs_value.impl {
                         U32(y) => ValueImpl::Bool(x <= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U64(x) => match rhs_value.impl {
                         U64(y) => ValueImpl::Bool(x <= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I8(x) => match rhs_value.impl {
                         I8(y) => ValueImpl::Bool(x <= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I16(x) => match rhs_value.impl {
                         I16(y) => ValueImpl::Bool(x <= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I32(x) => match rhs_value.impl {
                         I32(y) => ValueImpl::Bool(x <= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I64(x) => match rhs_value.impl {
                         I64(y) => ValueImpl::Bool(x <= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F32(x) => match rhs_value.impl {
                         F32(y) => ValueImpl::Bool(x <= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F64(x) => match rhs_value.impl {
                         F64(y) => ValueImpl::Bool(x <= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     USize(x) => match rhs_value.impl {
                         USize(y) => ValueImpl::Bool(x <= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     JaktString(x) => match rhs_value.impl {
                         JaktString(y) => ValueImpl::Bool(x <= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -4687,89 +4694,89 @@ class Interpreter {
                         U8(y) => ValueImpl::Bool(x > y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U16(x) => match rhs_value.impl {
                         U16(y) => ValueImpl::Bool(x > y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U32(x) => match rhs_value.impl {
                         U32(y) => ValueImpl::Bool(x > y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U64(x) => match rhs_value.impl {
                         U64(y) => ValueImpl::Bool(x > y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I8(x) => match rhs_value.impl {
                         I8(y) => ValueImpl::Bool(x > y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I16(x) => match rhs_value.impl {
                         I16(y) => ValueImpl::Bool(x > y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I32(x) => match rhs_value.impl {
                         I32(y) => ValueImpl::Bool(x > y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I64(x) => match rhs_value.impl {
                         I64(y) => ValueImpl::Bool(x > y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F32(x) => match rhs_value.impl {
                         F32(y) => ValueImpl::Bool(x > y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F64(x) => match rhs_value.impl {
                         F64(y) => ValueImpl::Bool(x > y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     USize(x) => match rhs_value.impl {
                         USize(y) => ValueImpl::Bool(x > y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     JaktString(x) => match rhs_value.impl {
                         JaktString(y) => ValueImpl::Bool(x > y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -4782,89 +4789,89 @@ class Interpreter {
                         U8(y) => ValueImpl::Bool(x >= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U16(x) => match rhs_value.impl {
                         U16(y) => ValueImpl::Bool(x >= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U32(x) => match rhs_value.impl {
                         U32(y) => ValueImpl::Bool(x >= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U64(x) => match rhs_value.impl {
                         U64(y) => ValueImpl::Bool(x >= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I8(x) => match rhs_value.impl {
                         I8(y) => ValueImpl::Bool(x >= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I16(x) => match rhs_value.impl {
                         I16(y) => ValueImpl::Bool(x >= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I32(x) => match rhs_value.impl {
                         I32(y) => ValueImpl::Bool(x >= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I64(x) => match rhs_value.impl {
                         I64(y) => ValueImpl::Bool(x >= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F32(x) => match rhs_value.impl {
                         F32(y) => ValueImpl::Bool(x >= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     F64(x) => match rhs_value.impl {
                         F64(y) => ValueImpl::Bool(x >= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     USize(x) => match rhs_value.impl {
                         USize(y) => ValueImpl::Bool(x >= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     JaktString(x) => match rhs_value.impl {
                         JaktString(y) => ValueImpl::Bool(x >= y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -4877,68 +4884,68 @@ class Interpreter {
                         U8(y) => ValueImpl::U8((x & y) as! u8)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U16(x) => match rhs_value.impl {
                         U16(y) => ValueImpl::U16((x & y) as! u16)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U32(x) => match rhs_value.impl {
                         U32(y) => ValueImpl::U32(x & y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U64(x) => match rhs_value.impl {
                         U64(y) => ValueImpl::U64(x & y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I8(x) => match rhs_value.impl {
                         I8(y) => ValueImpl::I8((x & y) as! i8)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I16(x) => match rhs_value.impl {
                         I16(y) => ValueImpl::I16((x & y) as! i16)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I32(x) => match rhs_value.impl {
                         I32(y) => ValueImpl::I32(x & y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I64(x) => match rhs_value.impl {
                         I64(y) => ValueImpl::I64(x & y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     USize(x) => match rhs_value.impl {
                         USize(y) => ValueImpl::USize(x & y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -4951,68 +4958,68 @@ class Interpreter {
                         U8(y) => ValueImpl::U8((x | y) as! u8)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U16(x) => match rhs_value.impl {
                         U16(y) => ValueImpl::U16((x | y) as! u16)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U32(x) => match rhs_value.impl {
                         U32(y) => ValueImpl::U32(x | y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U64(x) => match rhs_value.impl {
                         U64(y) => ValueImpl::U64(x | y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I8(x) => match rhs_value.impl {
                         I8(y) => ValueImpl::I8((x | y) as! i8)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I16(x) => match rhs_value.impl {
                         I16(y) => ValueImpl::I16((x | y) as! i16)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I32(x) => match rhs_value.impl {
                         I32(y) => ValueImpl::I32(x | y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I64(x) => match rhs_value.impl {
                         I64(y) => ValueImpl::I64(x | y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     USize(x) => match rhs_value.impl {
                         USize(y) => ValueImpl::USize(x | y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -5025,68 +5032,68 @@ class Interpreter {
                         U8(y) => ValueImpl::U8((x ^ y) as! u8)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U16(x) => match rhs_value.impl {
                         U16(y) => ValueImpl::U16((x ^ y) as! u16)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U32(x) => match rhs_value.impl {
                         U32(y) => ValueImpl::U32(x ^ y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U64(x) => match rhs_value.impl {
                         U64(y) => ValueImpl::U64(x ^ y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I8(x) => match rhs_value.impl {
                         I8(y) => ValueImpl::I8((x ^ y) as! i8)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I16(x) => match rhs_value.impl {
                         I16(y) => ValueImpl::I16((x ^ y) as! i16)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I32(x) => match rhs_value.impl {
                         I32(y) => ValueImpl::I32(x ^ y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I64(x) => match rhs_value.impl {
                         I64(y) => ValueImpl::I64(x ^ y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     USize(x) => match rhs_value.impl {
                         USize(y) => ValueImpl::USize(x ^ y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -5099,68 +5106,68 @@ class Interpreter {
                         U8(y) => ValueImpl::U8((x << y) as! u8)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U16(x) => match rhs_value.impl {
                         U16(y) => ValueImpl::U16((x << y) as! u16)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U32(x) => match rhs_value.impl {
                         U32(y) => ValueImpl::U32(x << y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U64(x) => match rhs_value.impl {
                         U64(y) => ValueImpl::U64(x << y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I8(x) => match rhs_value.impl {
                         I8(y) => ValueImpl::I8((x << y) as! i8)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I16(x) => match rhs_value.impl {
                         I16(y) => ValueImpl::I16((x << y) as! i16)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I32(x) => match rhs_value.impl {
                         I32(y) => ValueImpl::I32(x << y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I64(x) => match rhs_value.impl {
                         I64(y) => ValueImpl::I64(x << y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     USize(x) => match rhs_value.impl {
                         USize(y) => ValueImpl::USize(x << y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -5173,68 +5180,68 @@ class Interpreter {
                         U8(y) => ValueImpl::U8((x >> y) as! u8)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U16(x) => match rhs_value.impl {
                         U16(y) => ValueImpl::U16((x >> y) as! u16)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U32(x) => match rhs_value.impl {
                         U32(y) => ValueImpl::U32(x >> y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U64(x) => match rhs_value.impl {
                         U64(y) => ValueImpl::U64(x >> y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I8(x) => match rhs_value.impl {
                         I8(y) => ValueImpl::I8((x >> y) as! i8)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I16(x) => match rhs_value.impl {
                         I16(y) => ValueImpl::I16((x >> y) as! i16)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I32(x) => match rhs_value.impl {
                         I32(y) => ValueImpl::I32(x >> y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I64(x) => match rhs_value.impl {
                         I64(y) => ValueImpl::I64(x >> y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     USize(x) => match rhs_value.impl {
                         USize(y) => ValueImpl::USize(x >> y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -5247,68 +5254,68 @@ class Interpreter {
                         U8(y) => ValueImpl::U8((x <<< y) as! u8)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U16(x) => match rhs_value.impl {
                         U16(y) => ValueImpl::U16((x <<< y) as! u16)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U32(x) => match rhs_value.impl {
                         U32(y) => ValueImpl::U32(x <<< y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U64(x) => match rhs_value.impl {
                         U64(y) => ValueImpl::U64(x <<< y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I8(x) => match rhs_value.impl {
                         I8(y) => ValueImpl::I8((x <<< y) as! i8)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I16(x) => match rhs_value.impl {
                         I16(y) => ValueImpl::I16((x <<< y) as! i16)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I32(x) => match rhs_value.impl {
                         I32(y) => ValueImpl::I32(x <<< y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I64(x) => match rhs_value.impl {
                         I64(y) => ValueImpl::I64(x <<< y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     USize(x) => match rhs_value.impl {
                         USize(y) => ValueImpl::USize(x <<< y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -5321,68 +5328,68 @@ class Interpreter {
                         U8(y) => ValueImpl::U8(x >>> y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U16(x) => match rhs_value.impl {
                         U16(y) => ValueImpl::U16(x >>> y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U32(x) => match rhs_value.impl {
                         U32(y) => ValueImpl::U32(x >>> y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     U64(x) => match rhs_value.impl {
                         U64(y) => ValueImpl::U64(x >>> y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I8(x) => match rhs_value.impl {
                         I8(y) => ValueImpl::I8(x >>> y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I16(x) => match rhs_value.impl {
                         I16(y) => ValueImpl::I16(x >>> y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I32(x) => match rhs_value.impl {
                         I32(y) => ValueImpl::I32(x >>> y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     I64(x) => match rhs_value.impl {
                         I64(y) => ValueImpl::I64(x >>> y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     USize(x) => match rhs_value.impl {
                         USize(y) => ValueImpl::USize(x >>> y)
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -5395,12 +5402,12 @@ class Interpreter {
                         Bool(y) => ValueImpl::Bool(x or y),
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -5413,12 +5420,12 @@ class Interpreter {
                         Bool(y) => ValueImpl::Bool(x and y),
                         else => {
                             .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
                         .error(format("Invalid operands '{}' and '{}' to binary operation", lhs_value.type_name(), rhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
                 span
@@ -5440,7 +5447,7 @@ class Interpreter {
                 format("Unimplemented binary operator '{}'", op),
                 span
             )
-            throw Error::from_string_literal("Not yet implemented")
+            .compiler.panic("Not yet implemented")
         }
     }
 
@@ -5513,7 +5520,7 @@ class Interpreter {
                     format("Invalid left-hand side of assignment {}", binding),
                     span
                 )
-                throw Error::from_string_literal("Invalid type")
+                .compiler.panic("Invalid type")
             }
         }
     }
@@ -5599,7 +5606,7 @@ class Interpreter {
                     }
                     else => {
                         .error(format("Invalid operand '{}' to binary operation", lhs_value.type_name()), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 })
                 else => {
@@ -5683,7 +5690,7 @@ class Interpreter {
                                 format("Invalid type for unary operator"),
                                 span
                             )
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     PostIncrement => StatementResult::JustValue(match value.impl {
@@ -5736,7 +5743,7 @@ class Interpreter {
                                 format("Invalid type for unary operator"),
                                 span
                             )
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     })
                     PreIncrement => StatementResult::JustValue(match value.impl {
@@ -5800,7 +5807,7 @@ class Interpreter {
                                 format("Invalid type for unary operator"),
                                 span
                             )
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     })
                     PostDecrement => StatementResult::JustValue(match value.impl {
@@ -5853,7 +5860,7 @@ class Interpreter {
                                 format("Invalid type for unary operator"),
                                 span
                             )
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     })
                     PreDecrement => StatementResult::JustValue(match value.impl {
@@ -5917,7 +5924,7 @@ class Interpreter {
                                 format("Invalid type for unary operator"),
                                 span
                             )
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     })
                     TypeCast(cast) => match cast {
@@ -5955,7 +5962,7 @@ class Interpreter {
                             //             format("Unimplemented value enum for unary operator '{}'", op),
                             //             span
                             //         )
-                            //         throw Error::from_string_literal("Not yet implemented")
+                            //         .compiler.panic("Not yet implemented")
                             //     }
                             // }
 
@@ -5971,7 +5978,7 @@ class Interpreter {
                                 format("Invalid value for unary operator '{}'", op),
                                 span
                             )
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     else => {
@@ -5979,7 +5986,7 @@ class Interpreter {
                             format("Unimplemented unary operator '{}'", op),
                             span
                         )
-                        throw Error::from_string_literal("Not yet implemented")
+                        .compiler.panic("Not yet implemented")
                     }
                 }
             }
@@ -6006,7 +6013,7 @@ class Interpreter {
                 }
                 false => {
                     .error("Partial ranges are not implemented", span)
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 }
             }
             let end = match to.has_value() {
@@ -6030,7 +6037,7 @@ class Interpreter {
                 }
                 false => {
                     .error("Partial ranges are not implemented", span)
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 }
             }
 
@@ -6088,7 +6095,7 @@ class Interpreter {
                     format("Cannot call a closure (nyi)"),
                     span
                 )
-                throw Error::from_string_literal("Not yet implemented")
+                .compiler.panic("Not yet implemented")
             }
             mut this_argument: Value? = None
             mut arguments: [Value] = []
@@ -6130,9 +6137,7 @@ class Interpreter {
                 this_argument
                 arguments
                 call_span: span
-                invocation_scope: InterpreterScope::create(
-                    type_bindings
-                )
+                invocation_scope: InterpreterScope::create(type_bindings, compiler: .compiler)
             ) {
                 Return(value) => StatementResult::JustValue(value)
                 Throw(value) => StatementResult::Throw(value)
@@ -6169,7 +6174,7 @@ class Interpreter {
                         GenericInstance(args) => args
                         else => {
                             .error("Attempted to call a prelude function  on a non-generic array", this_argument.span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     effective_namespace.push(ResolvedNamespace(name: "Array", generic_parameters))
@@ -6179,7 +6184,7 @@ class Interpreter {
                         GenericInstance(args) => args
                         else => {
                             .error("Attempted to call a prelude function  on a non-generic dictionary", this_argument.span)
-                            throw Error::from_string_literal("Invalid type")
+                            .compiler.panic("Invalid type")
                         }
                     }
                     effective_namespace.push(ResolvedNamespace(name: "Dictionary", generic_parameters))
@@ -6187,7 +6192,7 @@ class Interpreter {
                 JaktSet(type_id) => {
                     guard .program.get_type(id: type_id) is GenericInstance(args: generic_parameters) else {
                         .error("Attempted to call a prelude function  on a non-generic set", this_argument.span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                     effective_namespace.push(ResolvedNamespace(name: "Set", generic_parameters))
                 }
@@ -6208,7 +6213,7 @@ class Interpreter {
                 }
                 else => {
                     .error("Attempted to call an instance method on a non-struct/enum type", this_argument.span)
-                    throw Error::from_string_literal("Invalid type")
+                    .compiler.panic("Invalid type")
                 }
             }
 
@@ -6283,9 +6288,7 @@ class Interpreter {
                 this_argument
                 arguments
                 call_span: span
-                invocation_scope: InterpreterScope::create(
-                    type_bindings
-                )
+                invocation_scope: InterpreterScope::create(type_bindings, compiler: .compiler)
             ) {
                 Return(value) => StatementResult::JustValue(value)
                 Throw(value) => StatementResult::Throw(value)
@@ -6321,14 +6324,14 @@ class Interpreter {
 
             if value.impl is OptionalNone {
                 .error("Attempted to unwrap an optional value that was None", value.span)
-                throw Error::from_string_literal("Invalid type")
+                .compiler.panic("Invalid type")
             }
 
             yield match value.impl {
                 OptionalSome(value) => StatementResult::JustValue(value)
                 else => {
                     .error("Invalid type for unwrap", value.span)
-                    throw Error::from_string_literal("Invalid type")
+                    .compiler.panic("Invalid type")
                 }
             }
         }
@@ -6389,14 +6392,14 @@ class Interpreter {
                         .error(
                             format("Index {} out of bounds (max={})", numeric_index, values.size())
                             span)
-                        throw Error::from_string_literal("Invalid type")
+                        return StatementResult::Throw(.error_value("Invalid type", span))
                     }
 
                     yield StatementResult::JustValue(values[numeric_index])
                 }
                 else => {
                     .error("Invalid or unsupported indexed expression", span)
-                    throw Error::from_string_literal("Invalid type")
+                    .compiler.panic("Invalid type")
                 }
             }
         }
@@ -6435,14 +6438,14 @@ class Interpreter {
                     }
                     if not found_index.has_value() {
                         .error("Attempted to access a field that does not exist", value.span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
 
                     yield StatementResult::JustValue(fields[found_index!])
                 }
                 else => {
                     .error("Attempted to access a field on a non-struct/enum type", value.span)
-                    throw Error::from_string_literal("Invalid type")
+                    .compiler.panic("Invalid type")
                 }
             }
         }
@@ -6479,14 +6482,14 @@ class Interpreter {
                     }
                     if not found_index.has_value() {
                         .error("Attempted to access a field that does not exist", value.span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
 
                     yield StatementResult::JustValue(fields[found_index!])
                 }
                 else => {
                     .error("Attempted to access a field on a non-struct/enum type", value.span)
-                    throw Error::from_string_literal("Invalid type")
+                    .compiler.panic("Invalid type")
                 }
             }
         }
@@ -6584,7 +6587,7 @@ class Interpreter {
                     }
                     else => {
                         .error(format("Invalid type {} for string literal", .program.get_type(val.type_id)), span)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                 }
 
@@ -6611,7 +6614,7 @@ class Interpreter {
             let code_point = code_points.next()
             if not code_point.has_value() {
                 .error("Invalid character constant", span)
-                throw Error::from_string_literal("Invalid character constant")
+                .compiler.panic("Invalid character constant")
             }
 
             yield StatementResult::JustValue(Value(impl: ValueImpl::U32(code_point!), span: span))
@@ -6775,7 +6778,7 @@ class Interpreter {
                             }
                             ClassInstance(marker_span) | Expression(marker_span) => {
                                 .error("Value matches are not allowed on enums", marker_span)
-                                throw Error::from_string_literal("Invalid type")
+                                .compiler.panic("Invalid type")
                             }
                             CatchAll(body, marker_span) => {
                                 catch_all_case = body
@@ -6787,14 +6790,14 @@ class Interpreter {
 
                     if not catch_all_case.has_value() and not found_body.has_value() {
                         .error("Match is not exhaustive", span!)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
 
                     found_body = found_body ?? catch_all_case!
                     let empty_args: [EnumVariantPatternArgument] = []
                     found_args = found_args ?? empty_args
 
-                    mut new_scope = InterpreterScope::create(parent: scope)
+                    mut new_scope = InterpreterScope::create(parent: scope, compiler: .compiler)
                     defer new_scope.perform_defers(interpreter: this, span: span!)
 
                     if found_variant_index.has_value() and not found_args!.is_empty() {
@@ -6888,13 +6891,13 @@ class Interpreter {
                             ClassInstance(marker_span) => {
                                 // FIXME: Implement this
                                 .error("Class instance matches are not implemented yet", marker_span)
-                                throw Error::from_string_literal("Invalid type")
+                                .compiler.panic("Invalid type")
                             }
                             EnumVariant(marker_span) => {
                                 .error(
                                     format("Value matches cannot have enum variant arms (matching on {})", value.type_name()),
                                     marker_span)
-                                throw Error::from_string_literal("Invalid type")
+                                .compiler.panic("Invalid type")
                             }
                         }
                     }
@@ -6903,10 +6906,10 @@ class Interpreter {
                         .error(
                             format("No match found for value of type {}", value.type_name()),
                             .spans.last()!)
-                        throw Error::from_string_literal("Invalid type")
+                        .compiler.panic("Invalid type")
                     }
                     found_body = found_body ?? catch_all_case!
-                    mut new_scope = InterpreterScope::create(parent: scope)
+                    mut new_scope = InterpreterScope::create(parent: scope, compiler: .compiler)
                     defer new_scope.perform_defers(interpreter: this, span: span!)
 
                     yield match found_body! {
@@ -6978,7 +6981,7 @@ class Interpreter {
                     .error(
                         format("Value matches cannot have enum variant arms (matching on {})", value.type_name()),
                         span)
-                    throw Error::from_string_literal("Invalid type")
+                    .compiler.panic("Invalid type")
                 }
             }
         }
@@ -7000,7 +7003,7 @@ class Interpreter {
                         return StatementResult::Break
                     }
                     Yield => {
-                        panic("Invalid control flow")
+                        .compiler.panic("Invalid control flow")
                     }
                 }
                 fields.push(value)
@@ -7050,7 +7053,7 @@ class Interpreter {
                     .error(
                         format("Cannot capture by reference in a comptime function (nyi)"),
                         span)
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 }
 
                 resolved_captures.set(name, scope.must_get(name))
@@ -7091,7 +7094,7 @@ class Interpreter {
             let fixed_block = .perform_final_interpretation_pass(
                 block
                 runtime_scope: scope_id
-                scope: InterpreterScope::create(bindings: resolved_captures, parent: scope)
+                scope: InterpreterScope::create(bindings: resolved_captures, parent: scope, compiler: .compiler)
                 function_id: pseudo_function_id
             )
 
@@ -7120,7 +7123,7 @@ class Interpreter {
             match .execute_statement(statement: stmt, scope, call_span: span) {
                 JustValue => {}
                 Throw(value) => {
-                    mut catch_scope = InterpreterScope::create(parent: scope)
+                    mut catch_scope = InterpreterScope::create(parent: scope, compiler: .compiler, compiler: .compiler)
                     defer catch_scope.perform_defers(interpreter: this, span)
 
                     catch_scope.bindings.set(
@@ -7156,7 +7159,7 @@ class Interpreter {
         Reflect(type: type_id, span) => StatementResult::JustValue(.reflect_type(type_id, span, scope))
         else => {
             .error(format("expression not implemented: {}", expr), expr.span())
-            throw Error::from_string_literal("Not yet implemented")
+            .compiler.panic("Not yet implemented")
         }
     }
 
@@ -7243,7 +7246,7 @@ class Interpreter {
         JaktString(x) => x
         else => {
             .error("Expected string value", value.span)
-            throw Error::from_string_literal("Invalid type")
+            .compiler.panic("Invalid type")
         }
     }
 
@@ -7552,7 +7555,7 @@ class Interpreter {
 
                 if not constructor.has_value() {
                     .error("Attempted to access a variant that does not exist", span)
-                    throw Error::from_string_literal("Invalid type")
+                    .compiler.panic("Invalid type")
                 }
 
                 yield constructor!
@@ -7564,7 +7567,7 @@ class Interpreter {
 
                 if not constructor.has_value() {
                     .error("Attempted to access a variant that does not exist", span)
-                    throw Error::from_string_literal("Invalid type")
+                    .compiler.panic("Invalid type")
                 }
 
                 fields = [.string_value(name, span)]
@@ -7587,7 +7590,7 @@ class Interpreter {
 
                 if not constructor.has_value() {
                     .error("Attempted to access a variant that does not exist", span)
-                    throw Error::from_string_literal("Invalid type")
+                    .compiler.panic("Invalid type")
                 }
 
                 let record_struct_id = match .program.find_reflected_primitive("Record") {
@@ -7702,7 +7705,7 @@ class Interpreter {
 
                 if not constructor.has_value() {
                     .error("Attempted to access a variant that does not exist", span)
-                    throw Error::from_string_literal("Invalid type")
+                    .compiler.panic("Invalid type")
                 }
 
                 let record_struct_id = match .program.find_reflected_primitive("Record") {
@@ -7770,7 +7773,7 @@ class Interpreter {
                 mut record_type_fields: [Value] = []
                 if is_value_enum {
                     .error("Unimplemented reflected type: value enum", span)
-                    throw Error::from_string_literal("Not yet implemented")
+                    .compiler.panic("Not yet implemented")
                 } else {
                     record_type_fields = .reflect_sum_enum_variants(subject_enum, span, scope)
                 }
@@ -7828,7 +7831,7 @@ class Interpreter {
 
                 if not constructor.has_value() {
                     .error("Attempted to access a variant that does not exist", span)
-                    throw Error::from_string_literal("Invalid type")
+                    .compiler.panic("Invalid type")
                 }
 
                 fields = []
@@ -7836,7 +7839,7 @@ class Interpreter {
             }
             else => {
                 .error(format("Type reflection not implemented: {}", type), span)
-                throw Error::from_string_literal("Not yet implemented")
+                .compiler.panic("Not yet implemented")
             }
         }
 

--- a/selfhost/repl.jakt
+++ b/selfhost/repl.jakt
@@ -236,7 +236,7 @@ struct REPL {
             scope_id: root_scope_id
         )
 
-        let root_interpreter_scope = InterpreterScope::create()
+        let root_interpreter_scope = InterpreterScope::create(compiler)
 
         return REPL(
             compiler

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4491,6 +4491,7 @@ struct Typechecker {
                         type_bindings: [
                             .find_or_add_type_id(Type::Self): generic_argument
                         ]
+                        compiler: .compiler
                     )
                     let result = try interpreter.execute_expression(expr, scope)
                     mut meets_requirement = false
@@ -10971,7 +10972,7 @@ struct Typechecker {
             }
 
             mut result: ExecutionResult? = None
-            mut invocation_scope = InterpreterScope::create(parent: eval_scope, type_bindings)
+            mut invocation_scope = InterpreterScope::create(parent: eval_scope, type_bindings, compiler: .compiler)
             try {
                 result = interpreter.execute(
                     function_to_run_id: resolved_function_id!


### PR DESCRIPTION
"not implemented" and "invalid type" should not be throwing and instead
panicking, since getting to those means the typechecker failed at its
job. When wanting a checked expression from a void value, it can be
handled manually if needed, before calling in the function.

Also, there are parts of the interpreter that throw when encountering a
user-facing error like unwrapping a None. These should forward the error
using the `*Result` values from the interpreter, since that's the
mechanism for handling errors that are raised when interpreting user
code.
