### PR TITLE
CI: Sync lint commits job with serenity

### DIFF
--- a/.github/workflows/lintcommits.yml
+++ b/.github/workflows/lintcommits.yml
@@ -7,14 +7,17 @@ on: [pull_request_target]
 
 jobs:
   lint_commits:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always() && github.repository == 'SerenityOS/jakt'
 
     steps:
       - name: Lint PR commits
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           script: |
+            const excludedBotIds = [
+              49699333,  // dependabot[bot]
+            ];
             const rules = [
               {
                 pattern: /^[^\r]*$/,
@@ -27,6 +30,10 @@ jobs:
               {
                 pattern: /^.{0,72}(?:\r?\n(?:(.{0,72})|(.*?([a-z]+:\/\/)?(([a-zA-Z0-9_]|-)+\.)+[a-z]{2,}(:\d+)?([a-zA-Z_0-9@:%\+.~\?&/=]|-)+).*?))*$/,
                 error: "Commit message lines are too long (maximum allowed is 72 characters, except for URLs)",
+              },
+              {
+                pattern: /^((?!^Merge branch )[\s\S])*$/,
+                error: "Commit is a git merge commit, use the rebase command instead",
               },
               {
                 pattern: /^\S.*?\S: .+/,
@@ -58,7 +65,10 @@ jobs:
             const commits = await github.paginate(opts);
 
             const errors = [];
-            for (const { sha, commit: { message } } of commits) {
+            for (const { sha, commit: { message }, author } of commits) {
+              if (author !== null && excludedBotIds.includes(author.id)) {
+                continue;
+              }
               const commitErrors = [];
               for (const { pattern, error } of rules) {
                 if (!pattern.test(message)) {
@@ -77,7 +87,7 @@ jobs:
 
       - name: Comment on PR
         if: ${{ failure() && !github.event.pull_request.draft }}
-        uses: IdanHo/comment-on-pr@5f51df338210754f519f721f8320d8f72525a4d0
+        uses: IdanHo/comment-on-pr@63ea2bf352997c66e524b8b5be7a79163fb3a88a
         env:
           GITHUB_TOKEN: ${{ secrets.BUGGIEBOT }}
         with:


### PR DESCRIPTION
This includes the following changes:
- Update to Ubuntu 22.04
- Update github script job revision
- Exclude commits from dependabot (though it's not enabled here)
- Catch merge commits explicitly
- Update comment-on-pr revision to one using ruby 3