### PR TITLE
CMake: Always grab the resource-dir from the Clang we find_package'd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,10 @@ find_package(Clang CONFIG)
 set(JAKT_CPP_AUTO_IMPORT_PROCESSOR_DEFAULT none)
 if (Clang_FOUND)
   set(JAKT_CPP_AUTO_IMPORT_PROCESSOR_DEFAULT clang)
-  find_program(CLANG_PATH clang REQUIRED)
+  find_program(CLANG_PATH clang REQUIRED
+    PATHS "${CLANG_INSTALL_PREFIX}/bin"
+    NO_DEFAULT_PATH
+  )
   execute_process(
     COMMAND
       ${CLANG_PATH} -print-resource-dir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,9 @@ find_package(Threads REQUIRED)
 
 SET(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
 SET(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
-find_package(Clang CONFIG)
+find_package(Clang CONFIG
+  PATHS /opt/homebrew/opt/llvm
+)
 
 set(JAKT_CPP_AUTO_IMPORT_PROCESSOR_DEFAULT none)
 if (Clang_FOUND)

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -995,7 +995,9 @@ fn compiler_main(anon args: [String]) throws -> c_int {
         if target_triple.has_value() {
             if compiler_is("clang++") and target_triple! != Target::active().name() {
                 extra_compiler_flags.push("-target")
-                extra_compiler_flags.push(target_triple!)
+                // FIXME: The Serenity clang toolchain doesn't like getting -unknown appended to the target triple
+                //        This is fine for now unless you're targeting musl libc, in which case, you're out of luck
+                extra_compiler_flags.push(Target::from_triple(target_triple!).name(abbreviate: true))
             }
         }
 

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -576,7 +576,7 @@ fn compiler_main(anon args: [String]) throws -> c_int {
     }
 
     let compiler_is = fn[cxx_compiler_path](anon name: String) throws -> bool {
-        return Path::from_string(cxx_compiler_path).basename() == name
+        return Path::from_string(cxx_compiler_path).basename().contains(name)
     }
 
     mut file_name: String? = None

--- a/selfhost/platform/posix_compiler.jakt
+++ b/selfhost/platform/posix_compiler.jakt
@@ -15,7 +15,7 @@ fn run_compiler(
     mut file_path = Path::from_string(cxx_compiler_path)
 
     mut extra_flags: [String] = []
-    if file_path.basename() == "g++" {
+    if file_path.basename().contains("g++") {
         extra_flags.push("-Wno-literal-suffix")
         extra_flags.push("-Wno-unused-parameter")
         extra_flags.push("-Wno-unused-but-set-variable")


### PR DESCRIPTION
If the developer has another `clang` in their path that is different
from the one that ends up getting found via find_package, this could
lead to some really unexpected behavior.