### PR TITLE
README: fix markdown typo in document

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ fn zero_out(foo: &mut Foo) {
 
 ### Closures TODO:
 
-- [] Return function from function
+- [ ] Return function from function
 
 ## Compiletime Execution
 


### PR DESCRIPTION
I found a typo in the task list element in the "Closures" section and fixed it.

**Before**:
![Screenshot_20240510_183211](https://github.com/SerenityOS/jakt/assets/56413673/3803551f-8165-486f-a3a2-7277982d8375)

**After**:
![Screenshot_20240510_183156](https://github.com/SerenityOS/jakt/assets/56413673/84db1256-3d31-4c26-b79a-1503539f779f)

