### PR TITLE
selfhost: Add support for `export`s

### DIFF
--- a/editors/emacs/jakt-mode.el
+++ b/editors/emacs/jakt-mode.el
@@ -43,7 +43,7 @@
              (jakt-repeat '("while" "for" "loop"))
              (jakt-execution '("return" "break" "continue" "throw" "yield"))
              (jakt-boolean '("true" "false"))
-             (jakt-keyword '("fn" "extern" "comptime"))
+             (jakt-keyword '("fn" "extern" "comptime" "import" "export"))
              (jakt-exception '("throws"))
              (jakt-macro '("defer" "unsafe" "throw" "try" "must" "catch" "cpp"))
              (jakt-var-decls '("mut" "let" "anon" "raw"))

--- a/editors/kate/Jakt.xml
+++ b/editors/kate/Jakt.xml
@@ -37,6 +37,7 @@
             <item>extern</item>
             <item>import</item>
             <item>comptime</item>
+            <item>export</item>
             <item>fn</item>
             <item>boxed</item>
             <item>virtual</item>

--- a/editors/sublime/sublime-for-jakt.sublime-syntax
+++ b/editors/sublime/sublime-for-jakt.sublime-syntax
@@ -1275,5 +1275,5 @@ contexts:
     - match: \b(and|or|is|not)\b
       scope: keyword.operator.logical.jakt
 
-    - match: \b(import|super|self|Self)\b
+    - match: \b(export|import|super|self|Self)\b
       scope: keyword.other.jakt

--- a/editors/vim/syntax/jakt.vim
+++ b/editors/vim/syntax/jakt.vim
@@ -30,6 +30,7 @@ let s:jakt_syntax_keywords = {
     \ ,                ]
     \ , 'jaktKeyword' :["fn"
     \ ,                 "extern"
+    \ ,                 "export"
     \ ,                 "import"
     \ ,                 "comptime"
     \ ,                ]

--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -925,6 +925,15 @@
                     }
                 },
                 {
+                    "name": "keyword.control.export.jakt",
+                    "match": "\\b(export)\\b",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.control.export.jakt"
+                        }
+                    }
+                },
+                {
                     "name": "meta.control.match.jakt",
                     "begin": "(?<=match.*?)(\\{)",
                     "beginCaptures": {

--- a/jakttest/README.md
+++ b/jakttest/README.md
@@ -53,10 +53,15 @@ Most tests you'll se have a little comment at the top, with **three slashes**:
 /// - <tag>: "<escaped output>"
 ```
 
-There are currently three available tags:
+These are the currently available tags:
 - `output`: Expects the test to compile, succeed execution and output to
   standard output.
 - `stderr`: Expects the test to compile, but execution fails and output is
   written to standard error.
 - `error`: Expects the test to be rejected by the Jakt compiler, where the given
   output must appear somewhere in its error output.
+- `cppincludes`: Adds the directories relative to the test file (separated by `:`) to the include path.
+- `link`: Adds C++ files to be compiled alongside the test file (separated by
+`:`). The paths are relative to the test file's location.
+- `cppexports`: Sets an explicit directory for the exported headers. This directory is relative to the test file's location,
+  and will be available in the include path for any other C++ file that is either imported or linked against.

--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -416,6 +416,7 @@ struct Test {
     file_name: String
     directory_index: usize
     cppincludes: String
+    cppexports: String
     related_cpp_files: String
 }
 
@@ -641,8 +642,10 @@ struct TestScheduler {
             target_triple_string()
             "--cpp-compiler"
             cpp_compiler_path ?? default_compiler_path
+            "--cpp-export"
+            "none" // A sentinel value is passed here bceause Windows shell does not allow empty arguments
             "--cpp-include"
-            "None" // A sentinel value is passed here because Windows shell does not allow empty arguments
+            "none" // A sentinel value is passed here because Windows shell does not allow empty arguments
             "--cpp-link"
             ":"
             ""
@@ -655,6 +658,9 @@ struct TestScheduler {
             let directory = scheduler.directories[test.directory_index]
             if test.cppincludes.length() > 0 {
                 command_buffer[command_buffer.size() - 5] = test.cppincludes
+            }
+            if test.cppexports.length() > 0 {
+                command_buffer[command_buffer.size() - 7] = test.cppexports
             }
             if test.related_cpp_files.is_empty() {
                 command_buffer[command_buffer.size() - 3] = ":"
@@ -737,25 +743,28 @@ fn main(args: [String]) -> c_int {
         let input = String::from_utf8(file.read_all())
         let result = Parser::parse(input, test_base_dir: basedir(file_name))
         match result {
-            SuccessTest(related_cpp_files, output, cppincludes) => {
+            SuccessTest(related_cpp_files, output, cppincludes, cppexports) => {
                 tests.push(Test(result: ExpectedResult(kind: ResultKind::Okay, output)
                                 file_name
                                 directory_index: 0
                                 cppincludes
+                                cppexports
                                 related_cpp_files: join(related_cpp_files, separator: ":")))
             }
-            CompileErrorTest(related_cpp_files, output, cppincludes) => {
+            CompileErrorTest(related_cpp_files, output, cppincludes, cppexports) => {
                 tests.push(Test(result: ExpectedResult(kind: ResultKind::CompileError, output)
                                 file_name
                                 directory_index: 0
                                 cppincludes
+                                cppexports
                                 related_cpp_files: join(related_cpp_files, separator: ":")))
             }
-            RuntimeErrorTest(related_cpp_files, output, cppincludes) => {
+            RuntimeErrorTest(related_cpp_files, output, cppincludes, cppexports) => {
                 tests.push(Test(result: ExpectedResult(kind: ResultKind::RuntimeError, output)
                                 file_name
                                 directory_index: 0
                                 cppincludes
+                                cppexports
                                 related_cpp_files: join(related_cpp_files, separator: ":")))
             }
             SkipTest => {
@@ -789,16 +798,30 @@ fn main(args: [String]) -> c_int {
     )
 
     // delete directories
-    for dir in directories {
-        for file in fs::list_directory(path: dir) {
-            if file == "." or file == ".." {
-                continue
+    {
+        mut stack: [String] = []
+        stack.push(parsed_options.temp_dir)
+
+        while not stack.is_empty() {
+            let dir = stack.pop()!
+            mut is_empty = true
+            for file in fs::list_directory(path: dir) {
+                if file == "." or file == ".." {
+                    continue
+                }
+                let path = dir + "/" + file
+                if fs::is_directory(path) {
+                    stack.push(path)
+                    is_empty = false
+                } else {
+                    fs::unlink(path)
+                }
             }
-            fs::unlink(path: dir + "/" + file)
+            if is_empty {
+                fs::rmdir(path: dir)
+            }
         }
-        fs::rmdir(path: dir)
     }
-    fs::rmdir(path: parsed_options.temp_dir)
 
     println("==============================")
     println("{} passed" , run_result.passed_count)

--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -145,6 +145,7 @@ fn print_usage()  {
     eprintln("\t-b,--build-dir <BUILD_DIR>\t\tUse BUILD_DIR as the prefix for the jakt binary. Defaults to 'build'.")
     eprintln("\t--temp-dir <DIR>\t\tUse DIR as the temporary directory.")
     eprintln("\t\t\tWill try to use $TMP_DIR or /tmp in UNIX-based systems, or %TEMP% in Windows")
+    eprintln("\t--keep-temp-dir\t\tDo not remove directory after tests run. Useful for debugging failed tests.")
     eprintln("\t-C,--cpp-compiler <PATH>\t\tUse the C++ compiler at PATH to compile objects. Defaults to clang++.")
 }
 
@@ -243,6 +244,7 @@ struct Options {
     job_count: usize
     help_wanted: bool
     build_dir: String
+    keep_temp_dir: bool
     cpp_compiler_path: String?
 
     fn from_args(args: [String]) throws -> Options {
@@ -256,6 +258,7 @@ struct Options {
             job_count: 0
             help_wanted: false
             build_dir: "build"
+            keep_temp_dir: false
             cpp_compiler_path: None
         )
 
@@ -307,6 +310,12 @@ struct Options {
             if args[index] == "--hide-reasons" {
                 index++
                 options.show_reasons = false
+                continue
+            }
+
+            if args[index] == "--keep-temp-dir" {
+                index++
+                options.keep_temp_dir = true
                 continue
             }
 
@@ -798,7 +807,7 @@ fn main(args: [String]) -> c_int {
     )
 
     // delete directories
-    {
+    if not parsed_options.keep_temp_dir {
         mut stack: [String] = []
         stack.push(parsed_options.temp_dir)
 

--- a/jakttest/parser.jakt
+++ b/jakttest/parser.jakt
@@ -6,6 +6,8 @@ import error { JaktError }
 import utility { panic, todo, Span }
 
 enum ParsedTest {
+    cppexports: String = ""
+
     SuccessTest(related_cpp_files: [String], output: String, cppincludes: String)
     CompileErrorTest(related_cpp_files: [String], output: String, cppincludes: String)
     RuntimeErrorTest(related_cpp_files: [String], output: String, cppincludes: String)
@@ -96,8 +98,10 @@ struct Parser {
         mut runtime_error = false
         mut compile_error = false
         mut has_cppincludes = false
+        mut has_cppexports = false
         mut output = ""
         mut cppincludes = ""
+        mut cppexports = ""
         mut related_cpp_files: [String] = []
 
         while not .is_eof() {
@@ -133,7 +137,11 @@ struct Parser {
                 has_cppincludes =  .lex_literal("cppincludes")
             }
 
-            guard success_test or compile_error or runtime_error or has_cppincludes else {
+            if not has_cppexports {
+                has_cppexports = .lex_literal("cppexports")
+            }
+
+            guard success_test or compile_error or runtime_error or has_cppincludes or has_cppexports else {
                 return ParsedTest::NoExpectOrSkip
             }
 
@@ -160,19 +168,23 @@ struct Parser {
                 continue
             } else if is_related_cpp_file {
                 related_cpp_files.push(parsed_string)
-            } else if not has_cppincludes {
-                panic("Unexpected token state in parse_test_information")
+            } else if has_cppincludes {
+                cppincludes = parsed_string
+            } else {
+                guard has_cppexports else {
+                    panic("Unexpected token state in parse_test_information")
+                }
+                cppexports = parsed_string
             }
-            cppincludes = parsed_string
         }
         if success_test {
-            return ParsedTest::SuccessTest(related_cpp_files, output, cppincludes)
+            return ParsedTest::SuccessTest(cppexports, related_cpp_files, output, cppincludes)
         }
         if compile_error {
-            return ParsedTest::CompileErrorTest(related_cpp_files, output, cppincludes)
+            return ParsedTest::CompileErrorTest(cppexports, related_cpp_files, output, cppincludes)
         }
         if runtime_error {
-            return ParsedTest::RuntimeErrorTest(related_cpp_files, output, cppincludes)
+            return ParsedTest::RuntimeErrorTest(cppexports, related_cpp_files, output, cppincludes)
         }
         return ParsedTest::NoExpectOrSkip
     }

--- a/runtime/jaktlib/path.jakt
+++ b/runtime/jaktlib/path.jakt
@@ -162,6 +162,27 @@ struct Path {
         return parts
     }
 
+    fn relative_to(this, anon base: &Path) -> Path {
+        let base_parts = base.components()
+        let this_parts = .components()
+
+        mut common = 0uz
+        while common < base_parts.size() and common < this_parts.size() and base_parts[common] == this_parts[common] {
+            common += 1
+        }
+
+        mut relative_parts: [String] = []
+        for _ in 0..(base_parts.size() - common) {
+            relative_parts.push("..")
+        }
+
+        for i in common..this_parts.size() {
+            relative_parts.push(this_parts[i])
+        }
+
+        return Path::from_parts(relative_parts)
+    }
+
     private fn split_at_last_slash(this) -> (String, String) {
         let len = .path.length()
         let last_slash = Path::last_slash(.path)

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -15,7 +15,10 @@ import typechecker {
 import types { CheckedGenericParameter, CheckedParameter, FunctionGenericParameter, SafetyMode, StructLikeId }
 import utility { Queue, Span, escape_for_quotes, interpret_escapes, join, panic, prepend_to_each, todo }
 import compiler { Compiler }
+import jakt::path { Path }
 import interpreter { Interpreter, TypecheckFunctions, value_to_checked_expression }
+import jakt::platform { platform_fs }
+import platform_fs() { make_directory }
 
 enum AllowedControlExits {
     /// No control exit statements allowed
@@ -293,7 +296,7 @@ struct CodeGenerator {
         panic("Cyclic module imports")
     }
 
-    fn generate(compiler: Compiler, anon program: CheckedProgram, debug_info: bool) throws -> [String:(String, String)] {
+    fn generate(compiler: Compiler, anon program: CheckedProgram, debug_info: bool, exported_files: &mut [String:String]) throws -> [String:(String, String)] {
         mut generator = CodeGenerator(
             compiler
             program
@@ -630,6 +633,59 @@ struct CodeGenerator {
                 output.clear()
             }
             result.set(impl_name, (output.to_string(), module.resolved_import_path))
+        }
+
+        let export_dir = must compiler.exports_dir.absolute()
+        let binary_dir = must compiler.binary_dir.absolute()
+
+        for (file, exported_types) in generator.program.exports {
+            // Generate all the type aliases while making sure to import the correct
+            // module headers.
+            // I need to reserve output to find the headers
+            mut used_modules: {ModuleId} = {}
+            mut cpp_code = StringBuilder::create()
+
+            // TODO: it could be nicer if the exported types were grouped
+            // by the namespace they are imported in.
+            for (type_id, unprefixed_name) in exported_types {
+                used_modules.add(type_id.module)
+
+                let should_be_namespaced = unprefixed_name.size() > 1
+                if should_be_namespaced {
+                    cpp_code.appendff("namespace {}", unprefixed_name[0].name)
+                    if unprefixed_name.size() > 2 {
+                        for i in 1..(unprefixed_name.size() - 1) {
+                            cpp_code.append(format("::{}", unprefixed_name[i].name))
+                        }
+                    }
+                    cpp_code.append('{')
+                }
+
+                let name = unprefixed_name.last()!.name
+
+                let qualifier = generator.codegen_namespace_qualifier(scope_id: generator.program.find_type_scope_id(type_id))
+                cpp_code.appendff("using {} = Jakt::{}{};", name, qualifier, name)
+
+                if should_be_namespaced {
+                    cpp_code.append('}')
+                }
+            }
+
+            output.clear()
+            output.append("#pragma once\n")
+
+            let ordered_imports = get_topologically_sorted_modules(all_sorted_modules: &sorted_modules, dependencies: &used_modules)
+
+            for id in ordered_imports {
+                let module = generator.program.modules[id.id]
+                let module_path = binary_dir.join(format("{}.h", module.name))
+                let module_path_relative = module_path.relative_to(&export_dir)
+                output.appendff("#include \"{}\"\n", module_path_relative.to_string())
+            }
+
+            output.append(cpp_code.to_string())
+
+            exported_files.set(file, output.to_string())
         }
 
         return result

--- a/selfhost/compiler.jakt
+++ b/selfhost/compiler.jakt
@@ -24,6 +24,7 @@ class Compiler {
     public target_triple: String?
     public user_configuration: [String:String]
     public binary_dir: Path
+    public exports_dir: Path
     public assume_main_file_path: Path?
 
     public fn panic(this, anon message: String) -> never {

--- a/selfhost/formatter.jakt
+++ b/selfhost/formatter.jakt
@@ -196,6 +196,7 @@ struct FormattedToken {
         Else => "else"
         Enum => "enum"
         Extern => "extern"
+        Export => "export"
         False => "false"
         For => "for"
         Fn => "fn"

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -84,6 +84,7 @@ enum Token {
     Else(Span)
     Enum(Span)
     Extern(Span)
+    Export(Span)
     False(Span)
     For(Span)
     Fn(Span)
@@ -147,6 +148,7 @@ enum Token {
         "else" => Token::Else(span)
         "enum" => Token::Enum(span)
         "extern" => Token::Extern(span)
+        "export" => Token::Export(span)
         "false" => Token::False(span)
         "for" => Token::For(span)
         "fn" => Token::Fn(span)
@@ -272,7 +274,6 @@ struct Lexer implements(Iterable<Token>) {
             "double",
             "dynamic_cast",
             "explicit",
-            "export",
             "float",
             "friend",
             "goto",

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -62,6 +62,7 @@ fn help() -> String {
     output += "  --use-ccache\t\t\t\tUse ccache when compiling.\n"
     output += "  -o,--output-filename FILE\t\tName of the output binary.\n\t\t\t\t\tDefaults to the input-filename without the extension.\n"
     output += "  -B,--binary-dir PATH\t\t\tOutput directory for compiled files.\n\t\t\t\t\tDefaults to $PWD/build.\n"
+    output += "  -E,--exports-dir PATH\t\t\tOutput directory for exported files, relative to $PWD.\n\t\t\t\t\tDefaults to '$PWD/exports'.\n"
     output += "  -I PATH\t\t\t\tAdd PATH to compiler's include list. Can be specified multiple times.\n"
     output += "  -J,--jobs NUMBER\t\t\tSpecify the number of jobs to run in parallel, defaults to 2 (1 on windows).\n"
     output += "  -L PATH\t\t\t\tAdd PATH to linker's search list. Can be specified multiple times.\n"
@@ -507,6 +508,7 @@ fn compiler_main(anon args: [String]) throws -> c_int {
     let runtime_path = args_parser.option(["-R", "--runtime-path"]) ?? default_runtime_path.to_string()
     let assume_main_file_path = args_parser.option(["--assume-main-file-path"])
     let binary_dir = Path::from_string(args_parser.option(["-B", "--binary-dir"]) ?? "build")
+    let exports_dir = Path::from_string(args_parser.option(["-E", "--exports-dir"]) ?? "exports")
     let dot_clang_format_path = args_parser.option(["-D", "--dot-clang-format-path"])
     let cxx_compiler_path = args_parser.option(["-C", "--cxx-compiler-path"]) ?? default_compiler_path
     let archiver_path = args_parser.option(["-A", "--archiver"])
@@ -644,6 +646,7 @@ fn compiler_main(anon args: [String]) throws -> c_int {
         target_triple
         user_configuration
         binary_dir
+        exports_dir
         assume_main_file_path: match assume_main_file_path.has_value() {
             true => Some(Path::from_string(assume_main_file_path!))
             false => None
@@ -864,7 +867,17 @@ fn compiler_main(anon args: [String]) throws -> c_int {
         return 0
     }
 
-    let codegen_result = CodeGenerator::generate(compiler, checked_program, debug_info: codegen_debug)
+
+    if not binary_dir.exists() {
+        make_directory(path: binary_dir.to_string())
+    }
+
+    if not exports_dir.exists() {
+        make_directory(path: exports_dir.to_string())
+    }
+
+    mut exported_files: [String:String] = [:]
+    let codegen_result = CodeGenerator::generate(compiler, checked_program, debug_info: codegen_debug, &mut exported_files)
 
     if discover_only {
         for (file, contents_and_path) in codegen_result {
@@ -922,14 +935,19 @@ fn compiler_main(anon args: [String]) throws -> c_int {
         depfile_builder.append("\n")
     }
 
-    if not binary_dir.exists() {
-        make_directory(path: binary_dir.to_string())
-    }
-
     for (file, contents_and_path) in codegen_result {
         let (contents, module_file_path) = contents_and_path
 
         let path = binary_dir.join(file)
+
+        try write_only_if_updated(data: contents, output_filename: path.to_string()) catch error {
+            eprintln("Error: Could not write to file: {} ({})", file, error)
+            return 1
+        }
+    }
+
+    for (file, contents) in exported_files {
+        let path = exports_dir.join(file)
 
         try write_only_if_updated(data: contents, output_filename: path.to_string()) catch error {
             eprintln("Error: Could not write to file: {} ({})", file, error)

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -154,6 +154,15 @@ enum ImportName {
     }
 }
 
+// Export in the module. This will be aggregated by
+// the typechecker.
+struct ParsedExport {
+    // the filename is extracted from a quoted string
+    file: ParsedName
+    // each export is a namespaced name.
+    names: [[ParsedName]]
+}
+
 enum ImportList {
     List([ImportName])
     All
@@ -271,6 +280,7 @@ struct ParsedNamespace {
     aliases: [ParsedAlias] = []
     module_imports: [ParsedModuleImport] = []
     extern_imports: [ParsedExternImport] = []
+    exports: [ParsedExport] = []
     import_path_if_extern: String? = None
     generating_import_extern_before_include: [IncludeAction] = []
     generating_import_extern_after_include: [IncludeAction] = []
@@ -1831,6 +1841,16 @@ struct Parser {
                         break
                     }
                 }
+                Export => {
+                    // mirrored from 'Import' case.
+                    if not active_attributes.is_empty() {
+                        .error("Cannot apply attributes to exports", active_attributes[0].span)
+                        active_attributes = []
+                    }
+                    .index++
+                    .parse_export(parent: &mut parsed_namespace)
+                    saw_an_entity = true
+                }
                 Import => {
                     if not active_attributes.is_empty() {
                         .error("Cannot apply attributes to imports", active_attributes[0].span)
@@ -2707,6 +2727,112 @@ struct Parser {
                 record_type: RecordType::Garbage
             )
         }
+    }
+
+    // skip tokens until we find an EOF marker or a toplevel
+    // starter.
+    fn escape_toplevel(mut this) {
+        loop {
+            match .current() {
+                Eof | Extern | Export | Import | Namespace | Struct | Enum | Trait | Fn | Comptime => {
+                    break
+                }
+                else => {
+                    .index++
+                    continue
+                }
+            }
+        }
+    }
+
+    fn parse_export(mut this, parent: &mut ParsedNamespace) {
+        // export "filename" { <name> (, <name>)* }
+        guard .current() is QuotedString(quote: filename, span: filename_span) else {
+            .error("Expected filename", .current().span())
+            .escape_toplevel()
+            return
+        }
+
+        .index++
+
+        mut result = ParsedExport(
+            file: ParsedName(name:  filename, span: filename_span),
+            names: []
+        )
+
+
+        guard .current() is LCurly else {
+            .error("Expected '{'", .current().span())
+            parent.exports.push(result)
+            .escape_toplevel()
+            return
+        }
+
+        .index++
+
+        mut has_doublecolon = false
+
+        mut current_ns: [ParsedName] = []
+        loop {
+            match .current() {
+                Eol => {
+                    .index++
+                    continue
+                }
+                RCurly => {
+                    .index++
+                    break
+                }
+                Identifier(name, span) => {
+                    if not current_ns.is_empty() and not has_doublecolon {
+                        // Push the name anyway, since we can recover from
+                        // here easily
+                        .error("Expected ',' between exported names", span)
+                        result.names.push(current_ns)
+                        current_ns = []
+                    }
+
+                    current_ns.push(ParsedName(name, span))
+                    has_doublecolon = false
+
+                    .index++
+                    continue
+                }
+                ColonColon(span) => {
+                    if current_ns.is_empty() {
+                        // We can also recover easily from here by ignoring
+                        // the double colon
+                        .error("Expected name before '::'", span)
+                    }
+                    has_doublecolon = true
+
+                    .index++
+                    continue
+                }
+                Comma(span) => {
+                    if current_ns.is_empty() or has_doublecolon {
+                        .error("Expected name before ','", span)
+                    } else {
+                        result.names.push(current_ns)
+                        current_ns = []
+                    }
+
+                    .index++
+                    continue
+                }
+                else(span) => {
+                    .error("Expected exported name, ',' or '}'", span)
+                    .escape_toplevel()
+                    break
+                }
+            }
+        }
+
+        if not current_ns.is_empty() {
+            result.names.push(current_ns)
+        }
+
+        parent.exports.push(result)
     }
 
     fn parse_import(mut this, parent: &mut ParsedNamespace)  {

--- a/selfhost/repl.jakt
+++ b/selfhost/repl.jakt
@@ -189,6 +189,7 @@ struct REPL {
             target_triple
             user_configuration
             binary_dir: Path::from_string("build")
+            exports_dir: Path::from_string("build/exports")
             assume_main_file_path: Path::from_string("repl.jakt")
         )
 

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -855,6 +855,49 @@ struct Typechecker {
         .typecheck_namespace_declarations(parsed_namespace, scope_id, comptime_pass: true, generic_pass: true)
         .typecheck_namespace_declarations(parsed_namespace, scope_id, comptime_pass: false, generic_pass: false)
         .typecheck_namespace_declarations(parsed_namespace, scope_id, comptime_pass: false, generic_pass: true)
+        .collect_exports(parsed_namespace, scope_id)
+    }
+
+    fn collect_exports(mut this, parsed_namespace: ParsedNamespace, scope_id: ScopeId) {
+        let parent_scope = MaybeResolvedScope::Resolved(scope_id)
+        for exp in parsed_namespace.exports {
+            mut exported_types: [TypeId:[ParsedName]] = [:]
+            if .program.exports.get(exp.file.name) is Some(exported) {
+                exported_types = exported
+            }
+            for name_list in exp.names {
+                mut parent_scope: ScopeId? = scope_id
+                for i in 0..(name_list.size() - 1) {
+                    let found_scope = .program.find_namespace_in_immediate_children_of_scope(scope_id: parent_scope!, name_list[i].name)
+
+                    guard found_scope is Some(scope_id) else {
+                        .error(format("Cannot find scope for ‘{}‘", name_list[i].name), name_list[i].span)
+                        parent_scope = None
+                        break
+                    }
+                    parent_scope = scope_id
+                }
+
+                guard parent_scope is Some(search_scope) else {
+                    continue
+                }
+
+                let type_name = name_list.last()!
+
+                let found_type = must .program.find_type_in_scope(
+                    scope_id: search_scope
+                    name: type_name.name
+                )
+
+                guard found_type is Some(exported_type) else {
+                    .error(format("Cannot find exported type ‘{}‘", type_name.name), type_name.span)
+                    continue
+                }
+
+                exported_types.set(exported_type, name_list)
+            }
+            .program.exports.set(exp.file.name, exported_types)
+        }
     }
 
     fn typecheck_visibility(mut this, visibility: Visibility, scope_id: ScopeId) throws -> CheckedVisibility {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -2,7 +2,7 @@ import parser {
     ArgumentStoreLevel, BinaryOperator, DefinitionLinkage, EnumVariantPatternArgument, ExternalName, FunctionLinkage
     FunctionType, IncludeAction, InlineState, ParsedBlock, ParsedCall, ParsedCapture, ParsedExpression
     ParsedExternImport, ParsedField, ParsedFunction, ParsedMatchBody, ParsedMatchCase, ParsedModuleImport
-    ParsedNamespace, ParsedParameter, ParsedRecord, ParsedStatement, ParsedType, ParsedVarDecl, Parser, RecordType
+    ParsedNamespace, ParsedParameter, ParsedRecord, ParsedStatement, ParsedType, ParsedVarDecl, ParsedName, Parser, RecordType
     TypeCast, UnaryOperator, CheckedQualifiers
 }
 import utility { FileId, IterationDecision, Queue, Span, join, panic, todo }
@@ -1815,6 +1815,14 @@ fn builtin(anon builtin: BuiltinType) -> TypeId {
 class CheckedProgram {
     public compiler: Compiler
     public modules: [Module] = []
+    // exports by filename: each type saves how the type is resolved in terms of namespace names, which will be how it is seen from the C++:
+    // ```
+    // namespace [ParsedName] {
+    //   using {type_name} = {qualifier for type name}
+    // }
+    // ```
+    // This makes the code generator export each type in the namespace dictated by the list of parsed names.
+    public exports: [String:[TypeId:[ParsedName]]] = [:]
     public loaded_modules: [String: LoadedModule] = [:]
 
     public fn create_module(mut this, name: String, is_root: bool, path: String? = None) -> ModuleId {

--- a/tests/codegen/export.jakt
+++ b/tests/codegen/export.jakt
@@ -1,0 +1,21 @@
+/// Expect:
+/// - output: "3\n"
+/// - link: "export_helper/use_import.cpp"
+/// - cppexports: "export_helper"
+
+export "Exported.h" { Exported }
+
+struct Exported {
+    value: i32
+
+    fn print_value(this) {
+        println("{}", .value)
+    }
+}
+
+extern fn use_exported(anon e: &Exported)
+
+fn main() {
+    let e = Exported(value: 3)
+    use_exported(&e)
+}

--- a/tests/codegen/export_helper/use_import.cpp
+++ b/tests/codegen/export_helper/use_import.cpp
@@ -1,0 +1,11 @@
+#include <Exported.h>
+
+// NOTE: codegen currently puts extern functions under Jakt namespace for
+// simplicity. In reality, it should declare them without the Jakt namespacing,
+// and use Jakt:: prefix for any Jakt types that it uses. But that is too big
+// of a scope for what this test is trying to achieve.
+namespace Jakt {
+void use_exported(Exported const &e) {
+    e.print_value();
+}
+}


### PR DESCRIPTION
Supports exporting types to handy header files, following the design in the SerenityOS discord: https://discord.com/channels/830522505605283862/983664833096466462/1258917037988777985

This PR supports only exporting types. Exporting functions and namespaces is left out for now.

Things to  fix (sorted by relevance):
- ~~support exporting generic types~~ inherently supported by just `using name;`
- ~~specify an export directory other than `<builddir>/exports`~~ done by alimpfard
- ~~find out how to get to the build directory from the export directory, so that includes work without setting the build directory as include dir~~ done by alimpfard
- ~~group exports by namespace tree, not by type.~~ Discarded, it's pretty but not needed