### PR TITLE
typechecker: Try namespaces last when resolving calls

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -10317,28 +10317,6 @@ struct Typechecker {
 
         for namespace_index in 0..call.namespace_.size() {
             let scope_name = call.namespace_[namespace_index]
-            let maybe_ns_scope = .find_namespace_in_scope(
-                scope_id: current_scope_id
-                name: scope_name
-            )
-            if maybe_ns_scope.has_value() {
-                let (scope_id, is_import) = maybe_ns_scope!
-                if is_import {
-                    namespaces[namespace_index].name = .program.modules[scope_id.module_id.id].name
-                }
-                namespaces[namespace_index].external_name = .get_scope(scope_id).external_name
-
-                is_base_ns_alias_or_import[
-                    namespace_index
-                ] = .find_namespace_in_scope(
-                    scope_id: current_scope_id
-                    name: scope_name
-                    treat_aliases_as_imports: true
-                )!.1
-
-                current_scope_id = scope_id
-                continue
-            }
             let maybe_struct_scope = .find_struct_in_scope(scope_id: current_scope_id, name: scope_name)
             if maybe_struct_scope.has_value() {
                 let structure = .get_struct(maybe_struct_scope!)
@@ -10365,6 +10343,31 @@ struct Typechecker {
                     }
                     else => {}
                 }
+            }
+
+            let maybe_ns_scope = .find_namespace_in_scope(
+                scope_id: current_scope_id
+                name: scope_name
+            )
+
+            if maybe_ns_scope.has_value() {
+                let (scope_id, is_import) = maybe_ns_scope!
+                if is_import {
+                    namespaces[namespace_index].name = .program.modules[scope_id.module_id.id].name
+                }
+                namespaces[namespace_index].external_name = .get_scope(scope_id).external_name
+
+
+                is_base_ns_alias_or_import[
+                    namespace_index
+                ] = .find_namespace_in_scope(
+                    scope_id: current_scope_id
+                    name: scope_name
+                    treat_aliases_as_imports: true
+                )!.1
+
+                current_scope_id = scope_id
+                continue
             }
 
             .error(format("Not a namespace, enum, class, or struct: ‘{}’", join(call.namespace_, separator: "::")), span)


### PR DESCRIPTION
Fixes a bug where an imported class with the same name as its defining
module/namespace would be skipped in call resolution:

```
// in tvec3.jakt
class tvec3 {
    thing: i32
    public fn create(...) -> tvec3 => ...
}
```

```
// in main.jakt
import tvec3 { tvec3 }

fn main() {
    let t = tvec3::create(...)
}
```

Prior to this change, Jakt will reject the `create` call in `main.jakt`
as an `unknown function`.
