### PR TITLE
Make returning Optional, WeakPtr and None from match less of a pain. Fix for subclasses and classes

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -5469,7 +5469,7 @@ struct Typechecker {
                 }
             }
             Struct(lhs_struct_id) => {
-                if lhs_type_id.equals(rhs_type_id) or .is_subclass_of(ancestor_type_id: rhs_type_id, child_type_id: lhs_type_id) {
+                if lhs_type_id.equals(rhs_type_id) {
                     return true
                 }
 

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -9530,7 +9530,7 @@ struct Typechecker {
         arguments_span: Span
         scope_id: ScopeId
         safety_mode: SafetyMode
-    ) throws -> (String?, CheckedMatchCase, TypeId?) {
+    ) throws -> (String?, CheckedMatchCase, TypeId?, bool) {
         mut covered_name: String? = None
 
         let new_scope_id = .create_scope(
@@ -9657,7 +9657,7 @@ struct Typechecker {
             defaults.push(checked_var_decl)
         }
 
-        let (checked_body, result_type) = .typecheck_match_body(
+        let (checked_body, result_type, seen_none) = .typecheck_match_body(
             body: case_.body
             scope_id: new_scope_id
             safety_mode
@@ -9677,7 +9677,7 @@ struct Typechecker {
             marker_span: case_.marker_span
         )
 
-        return (covered_name, checked_match_case, result_type)
+        return (covered_name, checked_match_case, result_type, seen_none)
     }
 
     fn typecheck_match(
@@ -9714,6 +9714,8 @@ struct Typechecker {
                 }
             }
         }
+
+        mut yielded_none = false
 
         match type_to_match_on {
             Enum(enum_id) | GenericEnumInstance(id: enum_id) => {
@@ -9765,7 +9767,7 @@ struct Typechecker {
                                     return CheckedExpression::Match(expr: checked_expr, match_cases: [], span, type_id: unknown_type_id(), all_variants_constant: false)
                                 }
 
-                                let (covered_name, checked_match_case, result_type) = .typecheck_match_variant(
+                                let (covered_name, checked_match_case, result_type, seen_none) = .typecheck_match_variant(
                                     case_
                                     subject_type_id
                                     variant_index: variant_index!
@@ -9777,6 +9779,9 @@ struct Typechecker {
                                     scope_id
                                     safety_mode
                                 )
+
+                                yielded_none |= seen_none
+
                                 if covered_name.has_value() {
                                     covered_variants.add(covered_name!)
                                 }
@@ -9802,7 +9807,7 @@ struct Typechecker {
                                         if not covered_variants.contains(variant.name()) {
                                             expanded_catch_all = true
 
-                                            let (covered_name, checked_match_case, result_type) = .typecheck_match_variant(
+                                            let (covered_name, checked_match_case, result_type, seen_none) = .typecheck_match_variant(
                                                 case_
                                                 subject_type_id
                                                 variant_index
@@ -9814,6 +9819,9 @@ struct Typechecker {
                                                 scope_id
                                                 safety_mode
                                             )
+
+                                            yielded_none |= seen_none
+
                                             if covered_name.has_value() {
                                                 covered_variants.add(covered_name!)
                                             }
@@ -9843,7 +9851,7 @@ struct Typechecker {
                                         defaults.push(checked_var_decl)
                                     }
 
-                                    let (checked_body, result_type) = .typecheck_match_body(
+                                    let (checked_body, result_type, seen_none) = .typecheck_match_body(
                                         body: case_.body
                                         scope_id: new_scope_id
                                         safety_mode
@@ -9851,6 +9859,7 @@ struct Typechecker {
                                         final_result_type
                                         span: case_.marker_span
                                     )
+                                    yielded_none |= seen_none
                                     final_result_type = result_type
 
                                     let checked_match_case = CheckedMatchCase::CatchAll(
@@ -10059,7 +10068,7 @@ struct Typechecker {
                                         )
                                     }
 
-                                    let (checked_body, result_type) = .typecheck_match_body(
+                                    let (checked_body, result_type, seen_none) = .typecheck_match_body(
                                         body: case_.body
                                         scope_id: new_scope_id
                                         safety_mode
@@ -10067,6 +10076,7 @@ struct Typechecker {
                                         final_result_type
                                         span: case_.marker_span
                                     )
+                                    yielded_none |= seen_none
                                     final_result_type = result_type
 
                                     checked_cases.push(CheckedMatchCase::ClassInstance(
@@ -10097,7 +10107,7 @@ struct Typechecker {
                                             )
                                         }
 
-                                        let (checked_body, result_type) = .typecheck_match_body(
+                                        let (checked_body, result_type, seen_none) = .typecheck_match_body(
                                             body: case_.body
                                             scope_id: new_scope_id
                                             safety_mode
@@ -10105,6 +10115,7 @@ struct Typechecker {
                                             final_result_type
                                             span: case_.marker_span
                                         )
+                                        yielded_none |= seen_none
                                         final_result_type = result_type
 
                                         checked_cases.push(CheckedMatchCase::CatchAll(
@@ -10197,7 +10208,7 @@ struct Typechecker {
                                         defaults.push(checked_var_decl)
                                     }
 
-                                    let (checked_body, result_type) = .typecheck_match_body(
+                                    let (checked_body, result_type, seen_none) = .typecheck_match_body(
                                         body: case_.body
                                         scope_id: new_scope_id
                                         safety_mode
@@ -10205,6 +10216,7 @@ struct Typechecker {
                                         final_result_type
                                         span: case_.marker_span
                                     )
+                                    yielded_none |= seen_none
                                     final_result_type = result_type
 
                                     let checked_match_case = CheckedMatchCase::EnumVariant(
@@ -10253,7 +10265,7 @@ struct Typechecker {
                                         defaults.push(checked_var_decl)
                                     }
 
-                                    let (checked_body, result_type) = .typecheck_match_body(
+                                    let (checked_body, result_type, seen_none) = .typecheck_match_body(
                                         body: case_.body
                                         scope_id: new_scope_id
                                         safety_mode
@@ -10261,6 +10273,7 @@ struct Typechecker {
                                         final_result_type
                                         span: case_.marker_span
                                     )
+                                    yielded_none |= seen_none
                                     final_result_type = result_type
 
                                     let checked_match_case = CheckedMatchCase::CatchAll(
@@ -10337,7 +10350,7 @@ struct Typechecker {
                                     }
 
                                     let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw, debug_name: format("catch-expression({})", expr))
-                                    let (checked_body, result_type) = .typecheck_match_body(
+                                    let (checked_body, result_type, seen_none) = .typecheck_match_body(
                                         body: case_.body
                                         scope_id: new_scope_id
                                         safety_mode
@@ -10345,6 +10358,7 @@ struct Typechecker {
                                         final_result_type
                                         span: case_.marker_span
                                     )
+                                    yielded_none |= seen_none
                                     final_result_type = result_type
 
                                     let checked_match_case = CheckedMatchCase::Expression(
@@ -10376,11 +10390,29 @@ struct Typechecker {
             }
         }
 
+        // FIXME: These errors should probably point at the case that returns None, all maybe even all the cases that do (but that could be excessive).
+        if yielded_none and final_result_type.has_value() {
+            if .get_type(final_result_type!) is GenericInstance(id, args) {
+                if not id.equals(.find_struct_in_prelude("Optional")) and not id.equals(.find_struct_in_prelude("WeakPtr")) {
+                    .error(
+                        message: format("Type mismatch: expected ‘{}’, but got None", .type_name(final_result_type!))
+                        span: span
+                    )
+                }
+            } else {
+                .error(
+                    message: format("Type mismatch: expected ‘{}’, but got None", .type_name(final_result_type!))
+                    span: span
+                )
+            }
+        }
+
         return CheckedExpression::Match(expr: checked_expr, match_cases: checked_cases, span, type_id: final_result_type ?? void_type_id(), all_variants_constant: true)
     }
 
-    fn typecheck_match_body(mut this, body: ParsedMatchBody, scope_id: ScopeId, safety_mode: SafetyMode, generic_inferences: &mut GenericInferences, final_result_type: TypeId?, span: Span) throws -> (CheckedMatchBody, TypeId?) {
+    fn typecheck_match_body(mut this, body: ParsedMatchBody, scope_id: ScopeId, safety_mode: SafetyMode, generic_inferences: &mut GenericInferences, final_result_type: TypeId?, span: Span) throws -> (CheckedMatchBody, TypeId?, bool) {
         mut result_type = final_result_type
+        mut seen_none = false
         let checked_match_body = match body {
             Block(block) => {
                 mut result_type_hint: TypeHint? = None
@@ -10394,6 +10426,8 @@ struct Typechecker {
                 if checked_block.control_flow.may_return() or checked_block.yielded_type.has_value() {
                     let block_type_id = checked_block.yielded_type ?? void_type_id()
                     let yield_span = block.find_yield_span() ?? span
+
+                    seen_none = checked_block.yielded_none
 
                     if result_type.has_value() {
                         if not .check_types_for_compat(
@@ -10441,6 +10475,11 @@ struct Typechecker {
                 }
 
                 let checked_expression = .typecheck_expression(expr, scope_id, safety_mode, type_hint: result_type_hint)
+
+                if checked_expression is OptionalNone {
+                    seen_none = true
+                }
+
                 if result_type.has_value() {
                     if not .check_types_for_compat(
                         lhs_type_hint: result_type_hint!
@@ -10469,7 +10508,7 @@ struct Typechecker {
                 yield CheckedMatchBody::Expression(checked_expression)
             }
         }
-        return (checked_match_body, result_type)
+        return (checked_match_body, result_type, seen_none)
     }
 
     fn typecheck_dictionary(mut this, values: [(ParsedExpression, ParsedExpression)], span: Span, scope_id: ScopeId, safety_mode: SafetyMode, type_hint: TypeHint?) throws -> CheckedExpression {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -5642,7 +5642,7 @@ struct Typechecker {
 
     fn substitute_typevars_in_type(mut this, type_id: TypeId , generic_inferences: GenericInferences) throws -> TypeId => .program.substitute_typevars_in_type(type_id, generic_inferences, module_id: .current_module_id)
 
-    fn typecheck_block(mut this, anon parsed_block: ParsedBlock, parent_scope_id: ScopeId, safety_mode: SafetyMode, yield_type_hint: TypeId? = None) throws -> CheckedBlock {
+    fn typecheck_block(mut this, anon parsed_block: ParsedBlock, parent_scope_id: ScopeId, safety_mode: SafetyMode, yield_type_hint: TypeHint? = None) throws -> CheckedBlock {
         let parent_throws = .get_scope(parent_scope_id).can_throw
         let block_scope_id = .create_scope(parent_scope_id, can_throw: parent_throws, debug_name: "block")
         mut checked_block = CheckedBlock(
@@ -5657,16 +5657,11 @@ struct Typechecker {
                 .error("Unreachable code", parsed_statement.span())
             }
 
-            mut type_hint: TypeHint? = None
-            if yield_type_hint.has_value() {
-                type_hint = TypeHint::MustBe(type_id: yield_type_hint!)
-            }
-
             let checked_statement = .typecheck_statement(
                 statement: parsed_statement
                 scope_id: block_scope_id
                 safety_mode
-                type_hint: type_hint
+                type_hint: yield_type_hint
             )
             checked_block.control_flow = checked_block.control_flow.updated(checked_statement.control_flow())
 
@@ -7190,7 +7185,12 @@ struct Typechecker {
                     .current_function_id = previous_function_id
                 }
 
-                return .typecheck_block(parsed_block, parent_scope_id, safety_mode, yield_type_hint)
+                mut type_hint: TypeHint? = None
+                if yield_type_hint.has_value() {
+                    type_hint = TypeHint::MustBe(type_id: yield_type_hint!)
+                }
+
+                return .typecheck_block(parsed_block, parent_scope_id, safety_mode, yield_type_hint: type_hint)
             }
 
             register_function: fn[this](
@@ -10383,22 +10383,42 @@ struct Typechecker {
         mut result_type = final_result_type
         let checked_match_body = match body {
             Block(block) => {
-                let checked_block = .typecheck_block(parsed_block: block, parent_scope_id: scope_id, safety_mode, yield_type_hint: final_result_type)
+                mut result_type_hint: TypeHint? = None
+
+                if result_type.has_value() {
+                    result_type_hint = TypeHint::CouldBe(type_id: result_type!)
+                }
+
+                let checked_block = .typecheck_block(parsed_block: block, parent_scope_id: scope_id, safety_mode, yield_type_hint: result_type_hint)
 
                 if checked_block.control_flow.may_return() or checked_block.yielded_type.has_value() {
                     let block_type_id = checked_block.yielded_type ?? void_type_id()
                     let yield_span = block.find_yield_span() ?? span
 
                     if result_type.has_value() {
-                        .check_types_for_compat(
-                            lhs_type_id: result_type!
+                        if not .check_types_for_compat(
+                            lhs_type_hint: result_type_hint!
                             rhs_type_id: block_type_id
                             generic_inferences
                             span: yield_span
-                        )
+                        ) and .check_types_for_compat(
+                            lhs_type_id: block_type_id
+                            rhs_type_hint: result_type_hint!
+                            generic_inferences
+                            span: yield_span
+                        ) {
+                            result_type = block_type_id
+                        }
                     } else {
                         result_type = block_type_id
                     }
+
+                    .check_types_for_compat(
+                        lhs_type_id: result_type!
+                        rhs_type_id: block_type_id
+                        generic_inferences
+                        span: yield_span
+                    )
                 }
 
                 mut final_body: CheckedMatchBody? = None

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -6444,7 +6444,18 @@ struct Typechecker {
 
                 let effective_lhs_type_id = .find_or_add_type_id(lhs_type)
 
-                let result = .unify(lhs: rhs_type_id, lhs_span: rhs_span, rhs: effective_lhs_type_id, rhs_span: lhs_span)
+                let old_ignore_errors = .ignore_errors
+                .ignore_errors = true
+
+                mut result = .unify(lhs: lhs_type_id, lhs_span, rhs: rhs_type_id, rhs_span)
+
+                // If the lhs type is a generic optional type, we need to unify with an unwrapped type
+                if not result.has_value() {
+                    result = .unify(lhs: effective_lhs_type_id, lhs_span, rhs: rhs_type_id, rhs_span)
+                }
+
+                .ignore_errors = old_ignore_errors
+
                 if not result.has_value() {
                     .error(format("Assignment between incompatible types (‘{}’ and ‘{}’)", .type_name(lhs_type_id), .type_name(rhs_type_id)), span)
                 }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -10415,22 +10415,36 @@ struct Typechecker {
                 yield final_body!
             }
             Expression(expr) => {
-                mut type_hint: TypeHint? = None
+                mut result_type_hint: TypeHint? = None
                 if result_type.has_value() {
-                    type_hint = TypeHint::MustBe(type_id: result_type!)
+                    result_type_hint = TypeHint::CouldBe(type_id: result_type!)
                 }
 
-                let checked_expression = .typecheck_expression(expr, scope_id, safety_mode, type_hint)
+                let checked_expression = .typecheck_expression(expr, scope_id, safety_mode, type_hint: result_type_hint)
                 if result_type.has_value() {
-                    .check_types_for_compat(
-                        lhs_type_id: result_type!
+                    if not .check_types_for_compat(
+                        lhs_type_hint: result_type_hint!
                         rhs_type_id: checked_expression.type()
                         generic_inferences
                         span
-                    )
+                    ) and .check_types_for_compat(
+                        lhs_type_id: checked_expression.type()
+                        rhs_type_hint: result_type_hint!
+                        generic_inferences
+                        span
+                    ) {
+                        result_type = checked_expression.type()
+                    }
                 } else {
                     result_type = checked_expression.type()
                 }
+
+                .check_types_for_compat(
+                    lhs_type_id: result_type!
+                    rhs_type_id: checked_expression.type()
+                    generic_inferences
+                    span
+                )
 
                 yield CheckedMatchBody::Expression(checked_expression)
             }

--- a/tests/typechecker/assign_base_to_derived.jakt
+++ b/tests/typechecker/assign_base_to_derived.jakt
@@ -1,0 +1,17 @@
+/// Expect:
+/// - error: "Assignment between incompatible types (‘Derived’ and ‘Base’)"
+
+class Base {
+    public fn test(this) {
+        println("ERROR")
+    }
+}
+
+class Derived: Base {}
+
+fn main() {
+    mut derived = Derived()
+    mut base: Base = Base()
+    derived = base
+    base.test()
+}

--- a/tests/typechecker/match_do_not_infer_none.jakt
+++ b/tests/typechecker/match_do_not_infer_none.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - error: "Type mismatch: expected ‘Foo’, but got None"
+
+enum Foo {
+    A
+    B
+}
+
+fn main() {
+    let val = match 1 {
+        1 => {
+            yield Foo::A()
+        }
+        else => {
+            yield match 2 {
+                2 => Foo::B()
+                else => {
+                    yield None
+                }
+            }
+        }
+    }
+}

--- a/tests/typechecker/match_expression_type_mismatch.jakt
+++ b/tests/typechecker/match_expression_type_mismatch.jakt
@@ -1,0 +1,19 @@
+/// Expect:
+/// - error: "Type mismatch: expected ‘Foo’, but got ‘i32’"
+
+enum Foo {
+    A
+    B
+}
+
+fn ret() -> Foo? {
+    return None
+}
+
+fn main() {
+    let val = match 1 {
+        1 => Foo::A()
+        2 => 5i32
+        else => ret()
+    }
+}

--- a/tests/typechecker/match_infer_class_from_block.jakt
+++ b/tests/typechecker/match_infer_class_from_block.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - output: "PASS\n"
+
+class A { }
+
+class B : A { }
+
+fn ret() -> B {
+    return B()
+}
+
+fn main() {
+    let val = match 1 {
+        1 => {
+            yield ret()
+        }
+        else => {
+            yield A()
+        }
+    }
+
+    println("PASS")
+}

--- a/tests/typechecker/match_infer_class_from_expression.jakt
+++ b/tests/typechecker/match_infer_class_from_expression.jakt
@@ -1,0 +1,19 @@
+/// Expect:
+/// - output: "PASS\n"
+
+class A { }
+
+class B : A { }
+
+fn ret() -> B {
+    return B()
+}
+
+fn main() {
+    let val = match 1 {
+        1 => ret()
+        else => A()
+    }
+
+    println("PASS")
+}

--- a/tests/typechecker/match_infer_optional_from_block.jakt
+++ b/tests/typechecker/match_infer_optional_from_block.jakt
@@ -1,0 +1,26 @@
+/// Expect:
+/// - output: "PASS\n"
+
+enum Foo {
+    A
+    B
+}
+
+fn ret() -> Foo? {
+    return None
+}
+
+fn main() {
+    let val = match 1 {
+        1 => {
+            yield Foo::A()
+        }
+        else => {
+            yield ret()
+        }
+    }
+
+    if val.has_value() {
+        println("PASS")
+    }
+}

--- a/tests/typechecker/match_infer_optional_from_block_bad.jakt
+++ b/tests/typechecker/match_infer_optional_from_block_bad.jakt
@@ -1,0 +1,22 @@
+/// Expect:
+/// - error: "Type mismatch: expected ‘Foo’, but got ‘Foo?’"
+
+enum Foo {
+    A
+    B
+}
+
+fn ret() -> Foo? {
+    return None
+}
+
+fn main() {
+    let val: Foo = match 1 {
+        1 => {
+            yield Foo::A()
+        }
+        else => {
+            yield ret()
+        }
+    }
+}

--- a/tests/typechecker/match_infer_optional_from_expression.jakt
+++ b/tests/typechecker/match_infer_optional_from_expression.jakt
@@ -1,0 +1,22 @@
+/// Expect:
+/// - output: "PASS\n"
+
+enum Foo {
+    A
+    B
+}
+
+fn ret() -> Foo? {
+    return None
+}
+
+fn main() {
+    let val = match 1 {
+        1 => Foo::A()
+        else => ret()
+    }
+
+    if val.has_value() {
+        println("PASS")
+    }
+}

--- a/tests/typechecker/match_infer_optional_from_expression_bad.jakt
+++ b/tests/typechecker/match_infer_optional_from_expression_bad.jakt
@@ -1,0 +1,18 @@
+/// Expect:
+/// - error: "Type mismatch: expected ‘Foo’, but got ‘Foo?’"
+
+enum Foo {
+    A
+    B
+}
+
+fn ret() -> Foo? {
+    return None
+}
+
+fn main() {
+    let val: Foo = match 1 {
+        1 => Foo::A()
+        else => ret()
+    }
+}


### PR DESCRIPTION
2b7e74b
6e2ba49
Previously we would wrongly assume that given:
```rs
class A { }
class B : A { }
```
assignment of `A` to a variable of type `B` would be fine which led to a C++ compiler error.

acf7229
6f43208
When yielding ex. an `Optional<T>` or a `WeakPtr<T>` out of the match, if we already inferred the result type to be `T`, we would just print an error that types are incompatible. On the other hand, if we first inferred the result type to be ex. `T?`, everything would be fine. Inferring the "most compatible" type seems more reasonable. This not only works for Optionals, WeakPtrs, but also for classes and subclasses since the code is based on the `check_types_for_compat` method (which works correctly after the fixes in the first two commits).

5d80411
Yielding `None` if the result type is not directly declared is ambiguous (it can either mean an `Optional` or a `WeakPtr`.
This previously led to C++ compiler errors.

Fixes #1139