### PR TITLE
editors/vim: Fix multiline string highlight support

### DIFF
--- a/editors/vim/syntax/jakt.vim
+++ b/editors/vim/syntax/jakt.vim
@@ -112,7 +112,7 @@ syntax region jaktCommentLine start="//" end="$"
 
 
 
-syntax region jaktString matchgroup=jaktStringDelimiter start=+"+ skip=+\\\\\|\\"+ end=+"+ oneline contains=jaktEscape
+syntax region jaktString matchgroup=jaktStringDelimiter start=+"+ skip=+\\"+ end=+"+ contains=jaktEscape
 syntax region jaktChar matchgroup=jaktCharDelimiter start=+'+ skip=+\\\\\|\\'+ end=+'+ oneline contains=jaktEscape
 syntax match jaktEscape        display contained /\\./
 


### PR DESCRIPTION
Multiline strings were highlighted as if they were Jakt code, making the
`appendff` format strings in codegen hard to distinguish from the
*proper* Jakt code. Now `oneline` is not assumed and those highlight
correctly.
