### PR TITLE
typechecker: Make type casts use TypeHint::CouldBe

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -8578,19 +8578,9 @@ struct Typechecker {
                 Negate => .typecheck_expression_and_dereference_if_needed(expr, scope_id, safety_mode, type_hint, span)
                 TypeCast(cast) => match cast {
                     Infallible => {
-                        let type_hint = TypeHint::MustBe(type_id: .typecheck_typename(parsed_type: cast.parsed_type(), scope_id, name: None))
+                        let type_hint = TypeHint::CouldBe(type_id: .typecheck_typename(parsed_type: cast.parsed_type(), scope_id, name: None))
                         // The passed hint may be an actual cast, it may also just be a hint (None as! Foo?)
-                        // First try it as a hint, then try it as a cast.
-                        let old_ignore_errors = .ignore_errors
-                        .had_an_error = false
-                        .ignore_errors = true
-                        mut result = .typecheck_expression_and_dereference_if_needed(expr, scope_id, safety_mode, type_hint, span)
-                        .ignore_errors = old_ignore_errors
-                        if .had_an_error {
-                            result = .typecheck_expression_and_dereference_if_needed(expr, scope_id, safety_mode, type_hint: None, span)
-                            .had_an_error = false
-                        }
-                        yield result
+                        yield .typecheck_expression_and_dereference_if_needed(expr, scope_id, safety_mode, type_hint, span)
                     }
                     else => .typecheck_expression_and_dereference_if_needed(expr, scope_id, safety_mode, type_hint: None, span)
                 }

--- a/tests/typechecker/cast_nonexistent_mult.jakt
+++ b/tests/typechecker/cast_nonexistent_mult.jakt
@@ -1,0 +1,6 @@
+/// Expect:
+/// - error: "Variable 'r' not found\n"
+
+fn main() {
+    (42.0f32 * r) as! f32
+}


### PR DESCRIPTION
This is what the original logic was trying to do, but its scope of "ignore type errors" was much greater, leading to miscompilations.