### PR TITLE
interpreter: Search for the main function in the main module

### DIFF
--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -3382,6 +3382,7 @@ class Interpreter {
         arguments: [Value]
         call_span: Span
         invocation_scope: InterpreterScope? = None
+        is_main: bool = false
     ) throws -> ExecutionResult {
         let function_to_run = .program.get_function(function_to_run_id)
         .enter_span(call_span)
@@ -3568,7 +3569,7 @@ class Interpreter {
                 }
 
                 let blk = .execute_block(block: function_to_run.block, scope, call_span)
-                if blk is JustValue(x) and x.impl is Void {
+                if blk is JustValue(x) and x.impl is Void and not is_main {
                     eprintln("Comptime function returned void, scope: {}", .program.get_scope(function_to_run.function_scope_id).debug_name)
                     abort()
                 }

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -721,12 +721,12 @@ fn compiler_main(anon args: [String]) throws -> c_int {
     if interpret_run {
         mut interpreter = typechecker.interpreter()
 
-        // Find the main function
-        let prelude_scope_id = ScopeId(module_id: ModuleId(id: 0), id: 0)
+        // Find the main function in the main module
+        let main_module_scope_id = ScopeId(module_id: ModuleId(id: 1), id: 0)
         mut main_function_id: FunctionId? = None
         for module in checked_program.modules {
             for scope in module.scopes {
-                if not (scope.parent?.equals(prelude_scope_id) ?? false) {
+                if not (scope.parent?.equals(main_module_scope_id) ?? false) {
                     continue
                 }
 
@@ -773,7 +773,8 @@ fn compiler_main(anon args: [String]) throws -> c_int {
             namespace_
             this_argument: None
             arguments
-            call_span)
+            call_span
+            is_main: true)
 
         match main_result {
             Return(x) => match x.impl {


### PR DESCRIPTION
It previously didn't find it because prelude is not the direct parent
scope of the main module. Also it panicked because main returned void,
which is our exceptional case for comptime evaluation.
