### PR TITLE
selfhost: Fetch prelude contents from dynamic runtime path

### DIFF
--- a/selfhost/compiler.jakt
+++ b/selfhost/compiler.jakt
@@ -18,6 +18,7 @@ class Compiler {
     public ignore_parser_errors: bool
     public debug_print: bool
     public std_include_path: Path
+    public prelude_path: Path
     public include_paths: [String]
     public json_errors: bool
     public dump_type_hints: bool

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -564,7 +564,10 @@ fn compiler_main(anon args: [String]) throws -> c_int {
     } as! usize
 
     if args_parser.flag(["--repl"]) {
-        mut repl = REPL::create(runtime_path: Path::from_parts([runtime_path, "jaktlib"]), target_triple, user_configuration)
+        mut repl = REPL::create(
+            std_include_path: Path::from_parts([runtime_path, "jaktlib"])
+            prelude_path: Path::from_parts([runtime_path, "prelude.jakt"])
+            target_triple, user_configuration)
         repl.run()
         return 0
     }
@@ -638,6 +641,7 @@ fn compiler_main(anon args: [String]) throws -> c_int {
         debug_print: debug_print
         // FIXME: Case sensitivity on win/mac requires this path be named different than the jakt cpp lib
         std_include_path: Path::from_parts([runtime_path, "jaktlib"])
+        prelude_path: Path::from_parts([runtime_path, "prelude.jakt"])
         include_paths: extra_include_paths
         json_errors
         dump_type_hints

--- a/selfhost/repl.jakt
+++ b/selfhost/repl.jakt
@@ -169,7 +169,7 @@ struct REPL {
     root_interpreter_scope: InterpreterScope
     file_id: FileId
 
-    fn create(runtime_path: Path, target_triple: String? = None, user_configuration: [String:String]) throws -> REPL {
+    fn create(std_include_path: Path, prelude_path: Path, target_triple: String? = None, user_configuration: [String:String]) throws -> REPL {
         mut compiler = Compiler(
             files: []
             file_ids: [:]
@@ -180,7 +180,8 @@ struct REPL {
             dump_parser: false
             ignore_parser_errors: false
             debug_print: false
-            std_include_path: runtime_path
+            std_include_path
+            prelude_path
             include_paths: []
             json_errors: false
             dump_type_hints: false

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -405,16 +405,15 @@ struct Typechecker {
         return module_id
     }
 
-    private comptime get_prelude_contents() throws -> [u8] {
-        // FIXME: Don't hardcode the relative runtime path.
-        mut file = File::open_for_reading("../runtime/prelude.jakt")
+    private fn get_prelude_contents(this) throws -> [u8] {
+        mut file = File::open_for_reading(.compiler.prelude_path.to_string())
         return file.read_all()
     }
 
     fn include_prelude(mut this) throws {
         let module_name = "__prelude__"
         let file_name = Path::from_string(module_name)
-        let file_contents = get_prelude_contents()
+        let file_contents = .get_prelude_contents()
 
         let old_file_id = .compiler.current_file
         let old_file_contents = .compiler.current_file_contents


### PR DESCRIPTION
Now Jakt does not bake the contents of prelude in the binary, instead it
uses the provided runtime path so that prelude can be edited and
overridden when required.

Saves ~186 kB of generated C++ code, which were the contents of the
prelude, encoded as an array of static casts.
