### PR TITLE
codegen+runtime: Make C++ output easier to parse visually

### DIFF
--- a/runtime/jaktlib/prelude/operators.jakt
+++ b/runtime/jaktlib/prelude/operators.jakt
@@ -192,6 +192,18 @@ type T implements(
         return .compare_impl(rhs) as! Ordering
     }
 
+    [[name="operator(<)"]]
+    extern fn less_than(this, anon rhs: T) -> bool
+
+    [[name="operator(<=)"]]
+    extern fn less_than_or_equal(this, anon rhs: T) -> bool
+
+    [[name="operator(>)"]]
+    extern fn greater_than(this, anon rhs: T) -> bool
+
+    [[name="operator(>=)"]]
+    extern fn greater_than_or_equal(this, anon rhs: T) -> bool
+
     [[name="operator(+=)"]]
     extern fn add_assign(mut this, anon rhs: T) -> void
 

--- a/samples/basics/escape_sequence.jakt
+++ b/samples/basics/escape_sequence.jakt
@@ -2,7 +2,7 @@
 /// - output: "hello\nworld"
 
 fn main() {
-    let str_c: c_char = '\n'
+    let str_c: c_char = c'\n'
     print("hello{}", str_c)
     print("world")
 }

--- a/samples/closures/capture_by_reference.jakt
+++ b/samples/closures/capture_by_reference.jakt
@@ -11,6 +11,6 @@ class Foo {
 
 fn main() {
     let pass = Foo(message: "PASS")
-    test(cb: fn[&pass]() => println(pass.message))
+    test(cb: fn[&pass]() => println("{}", pass.message))
 }
 

--- a/samples/closures/capture_by_value.jakt
+++ b/samples/closures/capture_by_value.jakt
@@ -7,5 +7,5 @@ fn test(cb: fn() -> void) {
 
 fn main() {
     let pass = "PASS"
-    test(cb: fn[pass]() => println(pass))
+    test(cb: fn[pass]() => println("{}", pass))
 }

--- a/samples/closures/trailing_closure_parameter.jakt
+++ b/samples/closures/trailing_closure_parameter.jakt
@@ -10,6 +10,6 @@ fn wrapped(anon action: &fn() -> void) {
 fn main() {
     let message = "Well, hello friends!"
     wrapped() {
-        println(message)
+        println("{}", message)
     }
 }

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2650,6 +2650,7 @@ struct CodeGenerator {
         mut this
         anon expression: CheckedExpression
         output: &mut StringBuilder
+        syntactically_self_contained: bool
     ) throws {
         if .program.get_type(expression.type()) is TypeVariable {
             output.append("(*([]<typename V>(V&& value) {{ if constexpr (IsSpecializationOf<V, NonnullRefPtr>) return &*value; else return &value; }})(")
@@ -2657,15 +2658,17 @@ struct CodeGenerator {
             output.append("))")
             return
         }
-        .codegen_expression(expression, &mut output)
+        .codegen_expression(expression, &mut output, syntactically_self_contained: true)
     }
 
     // `forward_error_with_try` controls whether errors are handled through the TRY() macro or through an external mechanism put by the caller.
+    // `syntactically_self_contained` will wrap the expression in parentheses if it's not by default.
     fn codegen_expression(
         mut this
         anon expression: CheckedExpression
         output: &mut StringBuilder
         forward_error_with_try: bool = true
+        syntactically_self_contained: bool = false
     ) throws {
         .generic_inferences = expression.generic_inferences ?? .generic_inferences
         defer .generic_inferences = None
@@ -2682,7 +2685,6 @@ struct CodeGenerator {
                         panic("Internal error: range expression doesn't have Range type")
                     }
                 }
-                output.append("(")
                 output.append(.codegen_type(type_id))
                 output.append("{")
                 output.append("static_cast<")
@@ -2701,7 +2703,7 @@ struct CodeGenerator {
                 } else {
                     output.append("9223372036854775807LL")
                 }
-                output.append(")})")
+                output.append(")}")
             }
             OptionalNone => {
                 output.append("JaktInternal::OptionalNone()")
@@ -2714,9 +2716,8 @@ struct CodeGenerator {
                 output.append(")")
             }
             ForcedUnwrap(expr, type_id) => {
-                output.append("(")
-                .codegen_expression(expr, &mut output)
-                output.append(".value())")
+                .codegen_expression(expr, &mut output, syntactically_self_contained: true)
+                output.append(".value()")
             }
             QuotedString(val) => {
                 let original_string = val.to_string()
@@ -2762,41 +2763,45 @@ struct CodeGenerator {
             }
             Var(var) => {
                 let name = var.name_for_codegen().as_name_for_use()
-                output.append(match name {
-                    "this" => .this_replacement ?? "*this"
-                    else => name
-                })
+
+                if name == "this" {
+                    if .this_replacement is Some(replacement) {
+                        // the replacement is always a variable name, which never needs
+                        // parentheses.
+                        output.append(replacement)
+                    } else {
+                        if syntactically_self_contained {
+                            output.append("(*this)")
+                        } else {
+                            output.append("*this")
+                        }
+                    }
+                } else {
+                    output.append(name)
+                }
             }
             IndexedExpression(expr, index) => {
-                output.append("((")
-                .codegen_expression(expr, &mut output)
-                output.append(")[")
+                .codegen_expression(expr, &mut output, syntactically_self_contained: true)
+                output.append('[')
                 .codegen_expression(index, &mut output)
-                output.append("])")
+                output.append(']')
             }
             IndexedDictionary(expr, index) => {
-                output.append("((")
-                .codegen_expression(expr, &mut output)
-                output.append(")[")
+                .codegen_expression(expr, &mut output, syntactically_self_contained: true)
+                output.append('[')
                 .codegen_expression(index, &mut output)
-                output.append("])")
+                output.append(']')
             }
             IndexedTuple(expr, index, is_optional) => {
-                output.append("((")
-                .codegen_expression(expr, &mut output)
+                .codegen_expression(expr, &mut output, syntactically_self_contained: true)
                 if is_optional {
-                    output.appendff(").map([](auto& _value) {{ return _value.template get<{}>(); }}))", index)
+                    output.appendff(".map([](auto& _value) {{ return _value.template get<{}>(); }})", index)
                 } else {
-                    output.appendff(").template get<{}>())", index)
+                    output.appendff(".template get<{}>()", index)
                 }
             }
             IndexedStruct(expr, name, index, is_optional) => {
-                mut object_builder = StringBuilder::create()
-                .codegen_expression(expression: expr, output: &mut object_builder)
-                let object = object_builder.to_string()
-                output.append("((")
-                output.append(object)
-                output.append(")")
+                .codegen_expression(expression: expr, output, syntactically_self_contained: true)
 
                 let var_name = match index.has_value() {
                     true => .program.get_variable(index!).name_for_codegen().as_name_for_use()
@@ -2809,8 +2814,9 @@ struct CodeGenerator {
                         output.append("->")
                     }
                     Struct(id) | GenericInstance(id) => {
+
                         let structure = .program.get_struct(id)
-                        if structure.record_type is Class and object != "*this" {
+                        if structure.record_type is Class and not .expr_codegens_to_this_pointer(expr) {
                             output.append("->")
                         } else {
                             output.append(".")
@@ -2839,15 +2845,9 @@ struct CodeGenerator {
                 } else {
                     output.append(var_name)
                 }
-                output.append(")")
             }
             IndexedCommonEnumMember(expr, index, is_optional) => {
-                mut object_builder = StringBuilder::create()
-                .codegen_expression(expression: expr, output: &mut object_builder)
-                let object = object_builder.to_string()
-                output.append("((")
-                output.append(object)
-                output.append(")")
+                .codegen_expression(expression: expr, output, syntactically_self_contained: true)
 
                 match .program.get_type(expr.type()) {
                     RawPtr => {
@@ -2855,7 +2855,7 @@ struct CodeGenerator {
                     }
                     Enum(id) | GenericEnumInstance(id) => {
                         let structure = .program.get_enum(id)
-                        if structure.record_type is SumEnum(is_boxed) and is_boxed and object != "*this" {
+                        if structure.record_type is SumEnum(is_boxed) and is_boxed and not .expr_codegens_to_this_pointer(expr) {
                             output.append("->common.init_common.")
                         } else {
                             output.append(".common.init_common.")
@@ -2872,7 +2872,6 @@ struct CodeGenerator {
                 } else {
                     output.append(index)
                 }
-                output.append(")")
             }
             ComptimeIndex() => {
                 panic("Internal error: ComptimeIndex should have been replaced by now")
@@ -2884,7 +2883,7 @@ struct CodeGenerator {
                 .codegen_call(call, &mut output, forward_error_with_try)
             }
             MethodCall(expr, call, is_optional) => {
-                .codegen_method_call(expr, call, is_optional, &mut output, forward_error_with_try)
+                .codegen_method_call(expr, call, is_optional, &mut output, forward_error_with_try, syntactically_self_contained)
             }
             Boolean(val) => {
                 output.append(match val {
@@ -2893,23 +2892,38 @@ struct CodeGenerator {
                 })
             }
             UnaryOp(expr, op, type_id) => {
-                output.append("(")
-                output.append(match op {
-                    PreIncrement => "++"
-                    PreDecrement => "--"
-                    Negate => "-"
+
+
+                match op {
+                    PreIncrement    => .codegen_prefix_unary(expr, cpp_operator: "++", output, syntactically_self_contained)
+                    PreDecrement    => .codegen_prefix_unary(expr, cpp_operator: "--", output, syntactically_self_contained)
+                    Negate          => .codegen_prefix_unary(expr, cpp_operator: "-",  output, syntactically_self_contained)
+                    LogicalNot      => .codegen_prefix_unary(expr, cpp_operator: "!",  output, syntactically_self_contained)
+                    BitwiseNot      => .codegen_prefix_unary(expr, cpp_operator: "~",  output, syntactically_self_contained)
+
+                    PostIncrement   => .codegen_postfix_unary(expr, cpp_operator: "++", output, syntactically_self_contained)
+                    PostDecrement   => .codegen_postfix_unary(expr, cpp_operator: "--", output, syntactically_self_contained)
+
                     Dereference => match .program.get_type(expr.type()) {
-                        RawPtr => "*"
-                        else => ""
+                        RawPtr  => .codegen_prefix_unary(expr, cpp_operator: "*", output, syntactically_self_contained)
+                        else    => .codegen_expression(expr, output, syntactically_self_contained)
                     }
+
+                    Reference | MutableReference => .codegen_expression(expr, output, syntactically_self_contained)
+
                     // FIXME: Remove this once we have proper type mutability support
-                    RawAddress => match .program.get_type(expr.type()).is_boxed(program: .program) {
-                        true => "const_cast<" + .codegen_type_possibly_as_namespace(type_id, as_namespace: true) + ">(" + "&*"
-                        false => "const_cast<" + .codegen_type(type_id) + ">(" + "&"
+                    RawAddress => {
+                        let is_boxed = .program.get_type(expr.type()).is_boxed(program: .program)
+                        output.appendff("const_cast<{}>(&", .codegen_type_possibly_as_namespace(type_id, as_namespace: is_boxed))
+                        if is_boxed {
+                            output.append('*')
+                        }
+                        .codegen_expression(expr, output, syntactically_self_contained: true)
+                        output.append(')')
                     }
-                    LogicalNot => "!"
-                    BitwiseNot => "~"
-                    Sizeof => "sizeof"
+
+                    Sizeof(type_id) => output.appendff("sizeof({})", .codegen_type(type_id))
+
                     Is(type_id) => {
                         let is_type = match .program.get_type(type_id) {
                             Struct(id) => {
@@ -2918,9 +2932,22 @@ struct CodeGenerator {
                             }
                             else => .codegen_type(type_id)
                         }
-                        yield "is<" + is_type + ">("
+                        output.appendff("is<{}>(", is_type)
+                        .codegen_expression(expr, output)
+                        output.append(')')
                     }
-                    IsNone => "!"
+
+                    IsNone => {
+                        output.append('!')
+                        .codegen_expression(expr, output, syntactically_self_contained: true)
+                        output.append(".has_value()")
+                    }
+
+                    IsSome => {
+                        .codegen_expression(expr, output, syntactically_self_contained: true)
+                        output.append(".has_value()")
+                    }
+
                     TypeCast(cast) => {
                         mut final_type_id = cast.type_id()
                         let type = .program.get_type(final_type_id)
@@ -2969,32 +2996,19 @@ struct CodeGenerator {
                             }
                             Identity => "static_cast"
                         }
-                        yield cast_type + "<" + .codegen_type(final_type_id) + ">("
+                        output.appendff("{}<{}>(", cast_type , .codegen_type(final_type_id))
+                        .codegen_expression(expr, output)
+                        output.append(')')
                     }
-                    else => ""
-                })
-                output.append("(")
-                mut object_builder = StringBuilder::create()
-                if op is Sizeof(type_id) {
-                    object_builder.append(.codegen_type(type_id))
-                } else {
-                    .codegen_expression(expr, output: &mut object_builder)
-                }
-                let object = object_builder.to_string()
-                output.append(object)
-                match op {
-                    PostIncrement => {
-                        output.append("++)")
-                    }
-                    PostDecrement => {
-                        output.append("--)")
-                    }
-                    TypeCast | Is => {
-                        output.append("))")
-                    }
+
                     IsEnumVariant(enum_variant, type_id: enum_type_id) => {
+
+                        if syntactically_self_contained { output.append('(') }
+                        defer if syntactically_self_contained { output.append(')') }
+
+                        .codegen_expression(expr, output, syntactically_self_contained: true)
+
                         let name = enum_variant.name()
-                        output.append(")")
                         let enum_id = match .program.get_type(enum_type_id) {
                             Enum(enum_id) => enum_id
                             GenericEnumInstance(id) => id
@@ -3006,7 +3020,8 @@ struct CodeGenerator {
                         match enum_.record_type {
                             SumEnum => {
                                 let is_boxed = enum_.is_boxed
-                                if is_boxed and object != "*this"{
+
+                                if is_boxed and not .expr_codegens_to_this_pointer(expr) {
                                     output.append("->")
                                 } else {
                                     output.append(".")
@@ -3030,20 +3045,12 @@ struct CodeGenerator {
                             }
                         }
                     }
-                    IsSome | IsNone => {
-                        output.append(").has_value()")
-                    }
-                    RawAddress => {
-                        output.append("))")
-                    }
-                    else => {
-                        output.append(")")
-                    }
+
                 }
-                output.append(")")
+
             }
             BinaryOp(lhs, rhs, op, type_id) => {
-                .codegen_binary_expression(expression, type_id, lhs, rhs, op, &mut output, forward_error_with_try)
+                .codegen_binary_expression(expression, type_id, lhs, rhs, op, &mut output, forward_error_with_try, syntactically_self_contained)
             }
             NumericConstant(val, type_id) => {
                 let suffix = match val {
@@ -3120,9 +3127,7 @@ struct CodeGenerator {
                     field_name = "value"
                 }
 
-                output.append("(")
-                .codegen_expression(expr, &mut output)
-                output.append(")")
+                .codegen_expression(expr, &mut output, syntactically_self_contained: true)
                 output.append(cpp_deref_operator)
                 output.append(section)
                 output.append(".")
@@ -3191,7 +3196,7 @@ struct CodeGenerator {
                 output.append("})")
             }
             JaktTuple(vals, span, type_id) => {
-                output.append("(Tuple{")
+                output.append("Tuple{")
                 mut first = true
                 for val in vals {
                     if not first {
@@ -3202,7 +3207,7 @@ struct CodeGenerator {
 
                     .codegen_expression(val, &mut output)
                 }
-                output.append("})")
+                output.append("}")
             }
             DependentFunction => {
                 .compiler.panic("Dependent functions should have been resolved by now")
@@ -3419,6 +3424,29 @@ struct CodeGenerator {
         }
     }
 
+    fn expr_codegens_to_this_pointer(this, anon expr: CheckedExpression) -> bool {
+        guard expr is Var(var) else { return false }
+        return var.name == "this" and .this_replacement is None
+    }
+
+    fn codegen_prefix_unary(mut this, expr: CheckedExpression, cpp_operator: StringView, output: &mut StringBuilder, syntactically_self_contained: bool) throws {
+        if syntactically_self_contained { output.append('(') }
+
+        output.append(cpp_operator)
+        .codegen_expression(expr, output, syntactically_self_contained: true)
+
+        if syntactically_self_contained { output.append(')') }
+    }
+
+    fn codegen_postfix_unary(mut this, expr: CheckedExpression, cpp_operator: StringView, output: &mut StringBuilder, syntactically_self_contained: bool) throws {
+        if syntactically_self_contained { output.append('(') }
+
+        .codegen_expression(expr, output, syntactically_self_contained: true)
+        output.append(cpp_operator)
+
+        if syntactically_self_contained { output.append(')') }
+    }
+
     fn codegen_match(
         mut this
         expr: CheckedExpression
@@ -3606,7 +3634,7 @@ struct CodeGenerator {
                         output.append("if (__jakt_enum_value")
                         if from.has_value() {
                             output.append(" >= ")
-                            .codegen_expression(from!, &mut output)
+                            .codegen_expression(from!, &mut output, syntactically_self_contained: true)
                         }
 
                         if to.has_value() {
@@ -3614,7 +3642,7 @@ struct CodeGenerator {
                                 output.append("&& __jakt_enum_value ")
                             }
                             output.append("< ")
-                            .codegen_expression(to!, &mut output)
+                            .codegen_expression(to!, &mut output, syntactically_self_contained: true)
                         }
                     } else {
                         output.append("if (__jakt_enum_value == ")
@@ -3626,7 +3654,7 @@ struct CodeGenerator {
                             output.append(escaped_value)
                             output.append("\"sv")
                         } else {
-                            .codegen_expression(expression, &mut output)
+                            .codegen_expression(expression, &mut output, syntactically_self_contained: true)
                         }
                     }
                     output.append(") {\n")
@@ -3885,7 +3913,8 @@ struct CodeGenerator {
         rhs: CheckedExpression
         op: CheckedBinaryOperator
         output: &mut StringBuilder
-        forward_error_with_try: bool = true
+        forward_error_with_try: bool
+        syntactically_self_contained: bool
     ) throws {
         if op.trait_implementation is Some(implementation) {
             // Since the binary op is done through a call, then TRY() forwarding
@@ -3896,6 +3925,7 @@ struct CodeGenerator {
                 is_optional: false
                 &mut output
                 forward_error_with_try
+                syntactically_self_contained
             )
             return
         }
@@ -3914,7 +3944,7 @@ struct CodeGenerator {
                 output.append("((")
             }
 
-            .codegen_expression(lhs, &mut output)
+            .codegen_expression(lhs, &mut output, syntactically_self_contained: true)
             if rhs_type is GenericInstance(id) and .program.get_struct(id).name_for_codegen().as_name_for_definition() == "Optional" {
                 if rhs_can_throw {
                     output.append(".try_value_or_lazy_evaluated_optional")
@@ -3975,7 +4005,7 @@ struct CodeGenerator {
         }
 
         if op.op is Assign and lhs is IndexedDictionary(expr, index) {
-            .codegen_expression(expr, &mut output)
+            .codegen_expression(expr, &mut output, syntactically_self_contained: true)
             output.append(".set(")
             .codegen_expression(index, &mut output)
             output.append(", ")
@@ -3988,31 +4018,31 @@ struct CodeGenerator {
             // Integer arithmetic is checked by default.
             match op.op {
                 Add | Subtract | Multiply | Divide | Modulo => {
-                    output.append("(")
                     if .compiler.optimize {
+                        if syntactically_self_contained { output.append('(') }
                         .codegen_unchecked_binary_op(lhs, rhs, op.op, type_id, &mut output)
+                        if syntactically_self_contained { output.append(')') }
                     } else {
                         .codegen_checked_binary_op(lhs, rhs, op.op, type_id, &mut output)
                     }
-                    output.append(")")
                     return
                 }
                 AddAssign | SubtractAssign | MultiplyAssign | DivideAssign | ModuloAssign => {
-                    output.append("(")
                     if .compiler.optimize {
+                        if syntactically_self_contained { output.append('(') }
                         .codegen_unchecked_binary_op_assignment(lhs, rhs, op.op, type_id, &mut output)
+                        if syntactically_self_contained { output.append(')') }
                     } else {
                         .codegen_checked_binary_op_assignment(lhs, rhs, op.op, type_id, &mut output)
                     }
-                    output.append(")")
                 }
                 else => { }
             }
         }
 
-        output.append("(")
+        if syntactically_self_contained { output.append('(') }
 
-        .codegen_expression(lhs, &mut output)
+        .codegen_expression(lhs, &mut output, syntactically_self_contained: true)
         output.append(match op.op {
             Add => " + "
             Subtract => " - "
@@ -4048,9 +4078,9 @@ struct CodeGenerator {
                 todo(format("codegen_binary_expression {}", op))
             }
         })
-        .codegen_expression(rhs, &mut output)
+        .codegen_expression(rhs, &mut output, syntactically_self_contained: true)
 
-        output.append(")")
+        if syntactically_self_contained { output.append(')') }
     }
 
     fn codegen_unchecked_binary_op(
@@ -4177,15 +4207,16 @@ struct CodeGenerator {
         is_optional: bool
         output: &mut StringBuilder
         forward_error_with_try: bool = true
+        syntactically_self_contained: bool
     ) throws {
         if call.callee_throws {
             output.append(.current_error_handler(forward_error_with_try))
             output.append("((")
         }
 
-        mut object_builder = StringBuilder::create()
-        .codegen_expression_and_deref_if_generic_and_needed(expr, output: &mut object_builder)
-        let object = object_builder.to_string()
+        let generate_object = fn[this, &expr](output: &mut StringBuilder, syntactically_self_contained: bool) throws {
+            .codegen_expression_and_deref_if_generic_and_needed(expr, output, syntactically_self_contained)
+        }
 
         if call.function_id.has_value() and (call.force_inline is ForceInline) {
             let function = .program.get_function(call.function_id!)
@@ -4243,7 +4274,7 @@ struct CodeGenerator {
             .this_replacement = old_this_replacement
 
             output.append("(")
-            output.append(object)
+            generate_object(output, syntactically_self_contained: false)
             for (_, arg) in call.args {
                 output.append(",")
                 .codegen_expression(arg, &mut output)
@@ -4258,15 +4289,17 @@ struct CodeGenerator {
         let expression_type = .program.get_type(expr.type())
         let name = call.name_for_codegen()
 
+        let object_is_this = .expr_codegens_to_this_pointer(expr)
+
         let field_accessor = match name {
             Operator => ""
             else => match expression_type {
                 RawPtr => "->"
-                Struct(id) | GenericInstance(id) => match .program.get_struct(id).record_type is Class and object != "*this" {
+                Struct(id) | GenericInstance(id) => match .program.get_struct(id).record_type is Class and not object_is_this {
                     true => "->"
                     false => "."
                 }
-                Enum(id) => match .program.get_enum(id).is_boxed and object != "*this" {
+                Enum(id) => match .program.get_enum(id).is_boxed and not object_is_this {
                     true => "->"
                     false => "."
                 }
@@ -4278,11 +4311,6 @@ struct CodeGenerator {
         }
 
         let generate_method_name = fn[this, &call, &name, &output]() throws {
-            if name is Operator {
-                output.append(name.as_name_for_use())
-                return
-            }
-
             let generic_parameters = call.type_args
             if not generic_parameters.is_empty() {
                 output.append("template ")
@@ -4301,16 +4329,19 @@ struct CodeGenerator {
 
         let is_called_as_method = not name.is_prefix() and (not field_accessor.is_empty() or (not is_optional and name is Operator))
 
+        let needs_wrapping_parens = syntactically_self_contained and name is Operator and not is_optional and not call.callee_throws
+
+        if needs_wrapping_parens { output.append('(') }
+        defer if needs_wrapping_parens { output.append(')') }
+
         if is_called_as_method {
-            output.append("((")
-            output.append(object)
-            output.append(")")
+            generate_object(output, syntactically_self_contained: true)
             output.append(field_accessor)
         } else {
             // object.method(...) -> method(object, ...)
             generate_method_name()
             output.append("(")
-            output.append(object)
+            generate_object(output, syntactically_self_contained: true)
         }
 
         if is_optional {
@@ -4332,7 +4363,9 @@ struct CodeGenerator {
 
         if is_called_as_method {
             generate_method_name()
-            output.append("(")
+            if not name is Operator {
+                output.append("(")
+            }
         }
 
         mut first = is_called_as_method
@@ -4342,17 +4375,16 @@ struct CodeGenerator {
             } else {
                 output.append(",")
             }
-            .codegen_expression(expr, &mut output)
+            .codegen_expression(expr, &mut output, syntactically_self_contained: first and name is Operator)
         }
 
-        if is_called_as_method {
-            output.append(")")
+        if not name is Operator {
+            output.append(')')
         }
 
         if is_optional {
             output.append("; })")
         }
-        output.append(")")
 
         if call.callee_throws {
             output.append("))")
@@ -5631,4 +5663,3 @@ struct CodeGenerator {
         output.append("}\n")
     }
 }
-

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2797,15 +2797,20 @@ struct CodeGenerator {
                 output.append(']')
             }
             IndexedTuple(expr, index, is_optional) => {
-                .codegen_expression(expr, &mut output, syntactically_self_contained: true)
                 if is_optional {
+                    .codegen_expression(expr, &mut output, syntactically_self_contained: true)
                     output.appendff(".map([](auto& _value) {{ return _value.template get<{}>(); }})", index)
                 } else {
-                    output.appendff(".template get<{}>()", index)
+                    if .expr_codegens_to_this_pointer(expr) {
+                        output.append("this->")
+                    } else {
+                        .codegen_expression(expr, output, syntactically_self_contained: true)
+                        output.append('.')
+                    }
+                    output.appendff("template get<{}>()", index)
                 }
             }
             IndexedStruct(expr, name, index, is_optional) => {
-                .codegen_expression(expression: expr, output, syntactically_self_contained: true)
 
                 let var_name = match index.has_value() {
                     true => .program.get_variable(index!).name_for_codegen().as_name_for_use()
@@ -2815,19 +2820,31 @@ struct CodeGenerator {
                 let expression_type = .program.get_type(expr.type())
                 match expression_type {
                     RawPtr => {
+                        .codegen_expression(expr, output, syntactically_self_contained: true)
                         output.append("->")
                     }
                     Struct(id) | GenericInstance(id) => {
 
-                        let structure = .program.get_struct(id)
-                        if structure.record_type is Class and not .expr_codegens_to_this_pointer(expr) {
-                            output.append("->")
+                        let expr_is_thisptr = .expr_codegens_to_this_pointer(expr)
+                        if not is_optional and expr_is_thisptr {
+                            output.append("this->")
                         } else {
-                            output.append(".")
+                            .codegen_expression(expr, output, syntactically_self_contained: true)
+                            let structure = .program.get_struct(id)
+                            if structure.record_type is Class and not expr_is_thisptr {
+                                output.append("->")
+                            } else {
+                                output.append(".")
+                            }
                         }
                     }
                     else => {
-                        output.append(".")
+                        if not is_optional and .expr_codegens_to_this_pointer(expr) {
+                            output.append("this->")
+                        } else {
+                            .codegen_expression(expr, output, syntactically_self_contained: true)
+                            output.append(".")
+                        }
                     }
                 }
                 if is_optional {
@@ -2851,22 +2868,33 @@ struct CodeGenerator {
                 }
             }
             IndexedCommonEnumMember(expr, index, is_optional) => {
-                .codegen_expression(expression: expr, output, syntactically_self_contained: true)
 
                 match .program.get_type(expr.type()) {
                     RawPtr => {
+                        .codegen_expression(expr, output, syntactically_self_contained: true)
                         output.append("->")
                     }
                     Enum(id) | GenericEnumInstance(id) => {
-                        let structure = .program.get_enum(id)
-                        if structure.record_type is SumEnum(is_boxed) and is_boxed and not .expr_codegens_to_this_pointer(expr) {
-                            output.append("->common.init_common.")
+                        let expr_is_thisptr = .expr_codegens_to_this_pointer(expr)
+                        if not is_optional and expr_is_thisptr {
+                            output.append("this->common.init_common.")
                         } else {
-                            output.append(".common.init_common.")
+                            .codegen_expression(expr, output, syntactically_self_contained: true)
+                            let structure = .program.get_enum(id)
+                            if structure.record_type is SumEnum(is_boxed) and is_boxed and not .expr_codegens_to_this_pointer(expr) {
+                                output.append("->common.init_common.")
+                            } else {
+                                output.append(".common.init_common.")
+                            }
                         }
                     }
                     else => {
-                        output.append(".")
+                        if not is_optional and .expr_codegens_to_this_pointer(expr) {
+                            output.append("this->")
+                        } else {
+                            .codegen_expression(expr, output, syntactically_self_contained: true)
+                            output.append(".")
+                        }
                     }
                 }
                 if is_optional {
@@ -3010,7 +3038,6 @@ struct CodeGenerator {
                         if syntactically_self_contained { output.append('(') }
                         defer if syntactically_self_contained { output.append(')') }
 
-                        .codegen_expression(expr, output, syntactically_self_contained: true)
 
                         let name = enum_variant.name()
                         let enum_id = match .program.get_type(enum_type_id) {
@@ -3025,10 +3052,15 @@ struct CodeGenerator {
                             SumEnum => {
                                 let is_boxed = enum_.is_boxed
 
-                                if is_boxed and not .expr_codegens_to_this_pointer(expr) {
-                                    output.append("->")
+                                if .expr_codegens_to_this_pointer(expr) {
+                                    output.append("this->")
                                 } else {
-                                    output.append(".")
+                                    .codegen_expression(expr, output, syntactically_self_contained: true)
+                                    if is_boxed {
+                                        output.append("->")
+                                    } else {
+                                        output.append(".")
+                                    }
                                 }
 
                                 // FIXME: This should be a call to find(), but we do not yet provide the needed operator== for that
@@ -3042,6 +3074,7 @@ struct CodeGenerator {
                                 output.appendff("__jakt_init_index() == {} /* {} */", variant_index, name)
                             }
                             ValueEnum => {
+                                .codegen_expression(expr, output, syntactically_self_contained: true)
                                 output.appendff("== {}{}::{}", .codegen_namespace_qualifier(scope_id: enum_.scope_id, is_prelude: .program.get_module(enum_id.module).is_prelude()), enum_.name, name)
                             }
                             else => {
@@ -4344,8 +4377,15 @@ struct CodeGenerator {
         defer if needs_wrapping_parens { output.append(')') }
 
         if is_called_as_method {
-            generate_object(output, syntactically_self_contained: true)
-            output.append(field_accessor)
+            if object_is_this
+                and not name is Operator
+                and match expression_type { Struct | GenericInstance | Enum | GenericEnumInstance => true, else => false }
+            {
+                output.append("this->")
+            } else {
+                generate_object(output, syntactically_self_contained: true)
+                output.append(field_accessor)
+            }
         } else {
             // object.method(...) -> method(object, ...)
             generate_method_name()

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2736,14 +2736,18 @@ struct CodeGenerator {
                     }
 
                     let name = .program.get_function(ids![0]).name_for_codegen().as_name_for_use()
+
                     let error_handler = match val.may_throw { true => .current_error_handler(forward_error_with_try), else => "" }
+
+                    output.append(error_handler)
+                    if not error_handler.is_empty() { output.append('(') }
                     output.appendff(
-                        "{}({}::{}(\"{}\"sv))"
-                        error_handler
+                        "{}::{}(\"{}\"sv)"
                         .codegen_type_possibly_as_namespace(type_id: val.type_id, as_namespace: true)
                         name
                         escaped_value
                     )
+                    if not error_handler.is_empty() { output.append(')') }
                 }
             }
             ByteConstant(val) => {
@@ -3409,14 +3413,9 @@ struct CodeGenerator {
                     .control_flow_state = last_control_flow
                 }
 
-                // FIXME: This could use smarter codegen that disables error
-                // propagation for the expression codegen, instead of wrapping
-                // it inside an IIFE and a macro.
-                output.append("MUST(([&]() -> ErrorOr<")
-                output.append(.codegen_type(type_id))
-                output.append("> { return ")
-                .codegen_expression(expr, &mut output)
-                output.append("; })())")
+                output.append("MUST((")
+                .codegen_expression(expr, &mut output, forward_error_with_try: false)
+                output.append("))")
             }
             Garbage(span) => {
                 todo(format("codegen_expression of bad AST node in {} at {}..{}", this.compiler.get_file_path(span.file_id), span.start, span.end))
@@ -4209,11 +4208,24 @@ struct CodeGenerator {
         forward_error_with_try: bool = true
         syntactically_self_contained: bool
     ) throws {
-        if call.callee_throws {
-            output.append(.current_error_handler(forward_error_with_try))
-            output.append("((")
+        let error_handler = match call.callee_throws { true => .current_error_handler(forward_error_with_try), false => "" }
+        if not error_handler.is_empty() {
+            output.appendff("{}((", error_handler)
         }
+        .codegen_method_call_unwrapped(expr, call, is_optional, output, syntactically_self_contained: syntactically_self_contained and error_handler.is_empty())
+        if not error_handler.is_empty() {
+            output.append("))")
+        }
+    }
 
+    fn codegen_method_call_unwrapped(
+        mut this
+        expr: CheckedExpression
+        call: CheckedCall
+        is_optional: bool
+        output: &mut StringBuilder
+        syntactically_self_contained: bool
+    ) throws {
         let generate_object = fn[this, &expr](output: &mut StringBuilder, syntactically_self_contained: bool) throws {
             .codegen_expression_and_deref_if_generic_and_needed(expr, output, syntactically_self_contained)
         }
@@ -4280,9 +4292,6 @@ struct CodeGenerator {
                 .codegen_expression(arg, &mut output)
             }
             output.append(")")
-            if call.callee_throws {
-                output.append("))")
-            }
             return
         }
 
@@ -4385,13 +4394,20 @@ struct CodeGenerator {
         if is_optional {
             output.append("; })")
         }
+    }
 
-        if call.callee_throws {
+    fn codegen_call(mut this, call: CheckedCall, output: &mut StringBuilder, forward_error_with_try: bool = true) throws {
+        let error_handler = match call.callee_throws { true => .current_error_handler(forward_error_with_try), false => "" }
+        if not error_handler.is_empty() {
+            output.appendff("{}((", error_handler)
+        }
+        .codegen_call_unwrapped(call, output)
+        if not error_handler.is_empty() {
             output.append("))")
         }
     }
 
-    fn codegen_call(mut this, call: CheckedCall, output: &mut StringBuilder, forward_error_with_try: bool = true) throws {
+    fn codegen_call_unwrapped(mut this, call: CheckedCall, output: &mut StringBuilder) throws {
         if call.function_id.has_value() and .program.get_function(call.function_id!).is_comptime {
             output.appendff(
                 "fail_comptime_call<{}, \"Comptime function {} called outside Jakt compiler\">()"
@@ -4401,10 +4417,6 @@ struct CodeGenerator {
             return
         }
 
-        if call.callee_throws {
-            output.append(.current_error_handler(forward_error_with_try))
-            output.append("((")
-        }
         match call.name {
             "print" | "println" | "eprintln" | "eprint" | "format" => {
                 let helper = match call.name {
@@ -4530,10 +4542,6 @@ struct CodeGenerator {
 
                 output.appendff("({})", join(arguments, separator: ","))
             }
-        }
-
-        if call.callee_throws {
-            output.append("))")
         }
     }
 

--- a/selfhost/error.jakt
+++ b/selfhost/error.jakt
@@ -152,11 +152,23 @@ fn print_source_line(severity: MessageSeverity, file_contents: [u8], file_span: 
     eprint(" │ ")
 
     while index <= file_span.1 {
-        mut c = b' '
-        if index < file_span.1 {
-            c = file_contents[index]
-        } else if error_span.start == error_span.end and index == error_span.start {
-            c = b'_'
+        mut builder = StringBuilder::create()
+
+        loop {
+            mut c = b' '
+            if index < file_span.1 {
+                c = file_contents[index]
+            } else if error_span.start == error_span.end and index == error_span.start {
+                c = b'_'
+            }
+
+            builder.append(c)
+
+            if c > 127 {
+                index += 1
+                continue
+            }
+            break
         }
 
         if (index == error_span.start) {
@@ -166,7 +178,7 @@ fn print_source_line(severity: MessageSeverity, file_contents: [u8], file_span: 
             eprint("\u001b[0m")
         }
 
-        eprint("{:c}", c)
+        eprint("{}", builder.to_string())
 
         ++index
     }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -80,7 +80,7 @@ enum NumericConstant {
 // to be either f32 or f64.
 // FIXME: Remove when a more general conversion is in place
 fn u64_to_float<T>(anon number: u64) -> T {
-    mut float_value: T = 0
+    mut float_value: T = 0f64
 
     unsafe {
         cpp {
@@ -93,7 +93,7 @@ fn u64_to_float<T>(anon number: u64) -> T {
 
 // FIXME: Remove when a more general conversion is in place
 fn f64_to_f32(anon number: f64) -> f32 {
-    mut f32_value: f32 = 0
+    mut f32_value: f32 = 0f32
 
     unsafe {
         cpp {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -14,6 +14,11 @@ enum StructOrEnumId {
     Enum(EnumId)
 }
 
+import extern "AK/Format.h" {
+    [[name="ByteString::formatted"]]
+    extern fn runtime_format(anon format: String, ..) -> String
+}
+
 enum StructLikeId {
     generic_arguments: [TypeId]? = None
 
@@ -3484,9 +3489,9 @@ fn format_value_impl(anon format_string: String, anon value: Value, program: &Ch
     | CInt(v)
     | JaktString(v)
     | StringView(v)
-    => format(format_string, v)
+    => runtime_format(format_string, v)
 
-    Void => format(format_string, "(void)")
+    Void => runtime_format(format_string, "(void)")
 
     Struct(fields, struct_id, constructor)
     | Class(fields, struct_id, constructor)
@@ -3560,7 +3565,7 @@ fn format_value_impl(anon format_string: String, anon value: Value, program: &Ch
         value
         program
     )
-    OptionalNone => format(format_string, "None")
+    OptionalNone => runtime_format(format_string, "None")
 
     JaktTuple(fields)
     | JaktArray(values: fields)

--- a/tests/parser/missing_return_type_arrow.jakt
+++ b/tests/parser/missing_return_type_arrow.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Expected ‘throws’, ‘->’, ‘=>’ or ‘{’"
+/// - error: "Expected '{'\n"
 fn foo() i64 {
     return 5
 }

--- a/tests/parser/missing_return_type_arrow_after_throws.jakt
+++ b/tests/parser/missing_return_type_arrow_after_throws.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Expected ‘->’, ‘=>’ or ‘{’"
+/// - error: "Expected '{'\n"
 fn foo() throws i64 {
     return 5
 }

--- a/tests/typechecker/generic_function_with_function_param_wrong_return_type.jakt
+++ b/tests/typechecker/generic_function_with_function_param_wrong_return_type.jakt
@@ -12,6 +12,6 @@ fn find<T>(anon arr: [T], anon cb: fn(a: T, b: T) -> bool) -> T? {
 
 fn main() {
     mut arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    
+
     println("{}", find(arr, fn(a: i64, b: i64) -> i32 => a == 5).value_or(-1))
 }

--- a/tests/typechecker/none_coalescing_assign_to_immutable.jakt
+++ b/tests/typechecker/none_coalescing_assign_to_immutable.jakt
@@ -4,5 +4,5 @@
 fn main() {
     let i: String? = None
     i ??= "mayb"
-    println(i ?? "hello")
+    println("{}", i ?? "hello")
 }


### PR DESCRIPTION
- codegen: Hint when parentheses are needed in codegen_expression
- codegen: Avoid generating extra parentheses with error handlers
- codegen: Use `this->` on accessors when appropiate

Codegen added a lot of extra opening parentheses that made expressions inside `while`/`if` hard to parse visually due to a large number of opening parentheses. Now codegen does not emit parentheses on most cases that it doesn't need to, it's only missing cases that are based on binary operator precedence.
These commits removed ~2000 parentheses and ~100kB worth of selfhost C++ code.

- runtime: Make integral comparisons use C++ operators

Due to the inlined comparison functions that used `.compare` with a cast, any Jakt expression that had a `<` (e.g the condition for `while bytes_written < writes_read`) would emit two nested IIFEs because it had two infallible conversions to and from `Ordering` plus a comparison to the `Ordering` enum. Now the integral comparisons are explicitly overloaded to use `<` and the like so the compiler doesn't generate the IIFEs that make the conditions in `while` and `if` unreadable.
This commit alone manages to suppress another ~100kB worth of selfhost C++ code.

The new compile times are within the noise threshold of the old ones.
The new generated code does not affect the C++ parser, but the resulting C++ code is smaller, easier to read and more intuitive to search through. This in turn makes checking whether a modification in codegen.jakt was successful or not faster, since the code is more greppable.
