### PR TITLE
codegen: Avoid duplicating match bodies

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -3537,10 +3537,13 @@ struct CodeGenerator {
     ) throws {
         mut is_generic_enum: bool = false
         for case_ in cases {
-            if case_ is EnumVariant {
-                is_generic_enum = true
-                break
+            for pattern in case_.patterns {
+                if pattern is EnumVariant {
+                    is_generic_enum = true
+                    break
+                }
             }
+            if is_generic_enum { break }
         }
         let match_values_all_constant = all_variants_constant and not is_generic_enum
 
@@ -3567,150 +3570,153 @@ struct CodeGenerator {
         mut has_default = false
         mut first = true
         for case_ in cases {
-            let defaults = case_.defaults
+            let body = case_.body
+            for pattern in case_.patterns {
+                let defaults = pattern.defaults
 
-            match case_ {
-                EnumVariant(name, args, subject_type_id, scope_id, body) => {
-                    let enum_ = .program.get_enum(match .program.get_type(subject_type_id) {
-                        Enum(enum_id) => enum_id
-                        GenericEnumInstance(id) => id
-                        else => {
-                            panic(format("Unexpected type in IsEnumVariant: {}", .program.get_type(subject_type_id)))
+                match pattern {
+                    EnumVariant(name, args, subject_type_id, scope_id) => {
+                        let enum_ = .program.get_enum(match .program.get_type(subject_type_id) {
+                            Enum(enum_id) => enum_id
+                            GenericEnumInstance(id) => id
+                            else => {
+                                panic(format("Unexpected type in IsEnumVariant: {}", .program.get_type(subject_type_id)))
+                            }
+                        })
+                        // FIXME: This should be a call to find(), but we do not yet provide the needed operator== for that
+                        mut variant_index = 0;
+                        for variant in enum_.variants {
+                            if variant.name() == name {
+                                break
+                            }
+                            variant_index++
                         }
-                    })
-                    // FIXME: This should be a call to find(), but we do not yet provide the needed operator== for that
-                    mut variant_index = 0;
-                    for variant in enum_.variants {
-                        if variant.name() == name {
-                            break
+
+                        output.appendff("if (__jakt_enum_value.__jakt_init_index() == {} /* {} */) {{\n", variant_index, name)
+
+                        mut variant_type_name = ""
+                        let qualifier = .codegen_type_possibly_as_namespace(type_id: subject_type_id, as_namespace: true)
+                        if not qualifier.is_empty() {
+                            variant_type_name += "typename JaktInternal::RemoveRefPtr<"
+                            variant_type_name += qualifier
+                            variant_type_name += ">::"
                         }
-                        variant_index++
-                    }
+                        variant_type_name += name
 
-                    output.appendff("if (__jakt_enum_value.__jakt_init_index() == {} /* {} */) {{\n", variant_index, name)
+                        if not args.is_empty() {
+                            output.append("auto& __jakt_match_value = __jakt_enum_value.as.")
+                            output.append(enum_.variants[variant_index].name())
+                            output.append(";\n")
 
-                    mut variant_type_name = ""
-                    let qualifier = .codegen_type_possibly_as_namespace(type_id: subject_type_id, as_namespace: true)
-                    if not qualifier.is_empty() {
-                        variant_type_name += "typename JaktInternal::RemoveRefPtr<"
-                        variant_type_name += qualifier
-                        variant_type_name += ">::"
-                    }
-                    variant_type_name += name
+                            for arg in args {
+                                output.append("auto& ")
+                                output.append(arg.binding)
 
-                    if not args.is_empty() {
-                        output.append("auto& __jakt_match_value = __jakt_enum_value.as.")
-                        output.append(enum_.variants[variant_index].name())
-                        output.append(";\n")
-
-                        for arg in args {
-                            output.append("auto& ")
-                            output.append(arg.binding)
-
-                            mut is_common_member = false
-                            if arg.name is Some(name) {
-                                for field in enum_.fields {
-                                    let var = .program.get_variable(field.variable_id)
-                                    if var.name == name {
-                                        is_common_member = true
-                                        break
+                                mut is_common_member = false
+                                if arg.name is Some(name) {
+                                    for field in enum_.fields {
+                                        let var = .program.get_variable(field.variable_id)
+                                        if var.name == name {
+                                            is_common_member = true
+                                            break
+                                        }
                                     }
                                 }
+
+                                if is_common_member {
+                                    output.append(" = __jakt_enum_value.common.init_common.")
+                                    output.append(arg.name!)
+                                } else {
+                                    output.append(" = __jakt_match_value.")
+                                    output.append(arg.name ?? "value")
+                                }
+                                output.append(";\n")
                             }
-
-                            if is_common_member {
-                                output.append(" = __jakt_enum_value.common.init_common.")
-                                output.append(arg.name!)
-                            } else {
-                                output.append(" = __jakt_match_value.")
-                                output.append(arg.name ?? "value")
-                            }
-                            output.append(";\n")
-                        }
-                    }
-
-                    for default_ in defaults {
-                        .codegen_statement(statement: default_, &mut output)
-                    }
-
-                    .codegen_match_body(body, return_type_id, &mut output)
-                    output.append("}\n")
-                }
-                CatchAll(has_arguments, body, marker_span) => {
-                    if has_arguments {
-                        panic("Bindings should not be present in a generic else")
-                    }
-
-                    // TODO: Use default statement if all values are constant
-                    has_default = true
-
-                    if first {
-                        output.append("{")
-                    } else {
-                        output.append("else {\n")
-                    }
-
-                    for default_ in defaults {
-                        .codegen_statement(statement: default_, &mut output)
-                    }
-
-                    .codegen_match_body(body, return_type_id, &mut output)
-                    output.append("}\n")
-                }
-                Expression(expression, body, marker_span) => {
-                    // TODO: Use case statement if all values are constant
-                    if not first {
-                        output.append("else ")
-                    }
-                    if expression is Range(from, to) {
-                        output.append("if (__jakt_enum_value")
-                        if from.has_value() {
-                            output.append(" >= ")
-                            .codegen_expression(from!, &mut output, syntactically_self_contained: true)
                         }
 
-                        if to.has_value() {
-                            if from.has_value() {
-                                output.append("&& __jakt_enum_value ")
-                            }
-                            output.append("< ")
-                            .codegen_expression(to!, &mut output, syntactically_self_contained: true)
+                        for default_ in defaults {
+                            .codegen_statement(statement: default_, &mut output)
                         }
-                    } else {
-                        output.append("if (__jakt_enum_value == ")
-                        if expression is QuotedString(val)
-                            and (val.type_id == byte_string_type_id or val.type_id == builtin(BuiltinType::JaktString)) {
-                            let original_string = val.to_string()
-                            let escaped_value = escape_for_quotes(original_string)
-                            output.append("\"")
-                            output.append(escaped_value)
-                            output.append("\"sv")
+
+                        .codegen_match_body(body, return_type_id, &mut output)
+                        output.append("}\n")
+                    }
+                    CatchAll(has_arguments, marker_span) => {
+                        if has_arguments {
+                            panic("Bindings should not be present in a generic else")
+                        }
+
+                        // TODO: Use default statement if all values are constant
+                        has_default = true
+
+                        if first {
+                            output.append("{")
                         } else {
-                            .codegen_expression(expression, &mut output, syntactically_self_contained: true)
+                            output.append("else {\n")
                         }
-                    }
-                    output.append(") {\n")
-                    .codegen_match_body(body, return_type_id, &mut output)
-                    output.append("}\n")
-                }
-                ClassInstance(type, body, rebind_name, marker_span) => {
-                    let type_name = .codegen_type_possibly_as_namespace(type_id: type, as_namespace: true)
-                    output.appendff("if (is<{}>(__jakt_enum_value.ptr())) {{\n", type_name)
-                    output.appendff(
-                        "auto {} = NonnullRefPtr {{ *static_cast<RawPtr<{}>>(__jakt_enum_value.ptr()) }};\n"
-                        (rebind_name?.name ?? "__jakt_match_value")
-                        type_name
-                    )
 
-                    for default_ in defaults {
-                        .codegen_statement(statement: default_, &mut output)
-                    }
+                        for default_ in defaults {
+                            .codegen_statement(statement: default_, &mut output)
+                        }
 
-                    .codegen_match_body(body, return_type_id, &mut output)
-                    output.append("}\n")
+                        .codegen_match_body(body, return_type_id, &mut output)
+                        output.append("}\n")
+                    }
+                    Expression(expression, marker_span) => {
+                        // TODO: Use case statement if all values are constant
+                        if not first {
+                            output.append("else ")
+                        }
+                        if expression is Range(from, to) {
+                            output.append("if (__jakt_enum_value")
+                            if from.has_value() {
+                                output.append(" >= ")
+                                .codegen_expression(from!, &mut output, syntactically_self_contained: true)
+                            }
+
+                            if to.has_value() {
+                                if from.has_value() {
+                                    output.append("&& __jakt_enum_value ")
+                                }
+                                output.append("< ")
+                                .codegen_expression(to!, &mut output, syntactically_self_contained: true)
+                            }
+                        } else {
+                            output.append("if (__jakt_enum_value == ")
+                            if expression is QuotedString(val)
+                                and (val.type_id == byte_string_type_id or val.type_id == builtin(BuiltinType::JaktString)) {
+                                let original_string = val.to_string()
+                                let escaped_value = escape_for_quotes(original_string)
+                                output.append("\"")
+                                output.append(escaped_value)
+                                output.append("\"sv")
+                            } else {
+                                .codegen_expression(expression, &mut output, syntactically_self_contained: true)
+                            }
+                        }
+                        output.append(") {\n")
+                        .codegen_match_body(body, return_type_id, &mut output)
+                        output.append("}\n")
+                    }
+                    ClassInstance(type, rebind_name, marker_span) => {
+                        let type_name = .codegen_type_possibly_as_namespace(type_id: type, as_namespace: true)
+                        output.appendff("if (is<{}>(__jakt_enum_value.ptr())) {{\n", type_name)
+                        output.appendff(
+                            "auto {} = NonnullRefPtr {{ *static_cast<RawPtr<{}>>(__jakt_enum_value.ptr()) }};\n"
+                            (rebind_name?.name ?? "__jakt_match_value")
+                            type_name
+                        )
+
+                        for default_ in defaults {
+                            .codegen_statement(statement: default_, &mut output)
+                        }
+
+                        .codegen_match_body(body, return_type_id, &mut output)
+                        output.append("}\n")
+                    }
                 }
+                first = false
             }
-            first = false
         }
         if return_type_id == void_type_id() or return_type_id == unknown_type_id() {
             output.append("return JaktInternal::ExplicitValue<void>();\n")
@@ -3752,46 +3758,31 @@ struct CodeGenerator {
 
             mut has_default = false
             for match_case in match_cases {
-                match match_case {
-                    EnumVariant(name, args, subject_type_id, index, scope_id, body) => {
-                        let enum_type = .program.get_type(subject_type_id)
-                        let enum_id = match enum_type {
-                            Enum(id) => id
-                            else => {
-                                panic("Expected enum type")
-                            }
-                        }
-                        let match_case_enum = .program.get_enum(enum_id)
-                        let variant = match_case_enum.variants[index]
-                        output.appendff("case {} /* {} */: {{\n", index, variant.name())
-                        match variant {
-                            Untyped(name) => {
-                            }
-                            Typed(name, type_id) => {
-                                if not args.is_empty() {
-                                    output.appendff(
-                                        "auto&& __jakt_match_value = __jakt_match_variant.as.{};",
-                                        name
-                                    )
-
-                                    let arg = args[0]
-                                    let var = .program.find_var_in_scope(scope_id, var: arg.binding)!
-                                    output.append(.codegen_type(var.type_id))
-                                    if not var.is_mutable {
-                                        output.append(" const")
-                                    }
-                                    output.append("& ")
-                                    output.append(arg.binding)
-                                    output.append(" = __jakt_match_value.value;\n")
+                let body = match_case.body
+                for pattern in match_case.patterns {
+                    match pattern {
+                        EnumVariant(name, args, subject_type_id, index, scope_id) => {
+                            let enum_type = .program.get_type(subject_type_id)
+                            let enum_id = match enum_type {
+                                Enum(id) => id
+                                else => {
+                                    panic("Expected enum type")
                                 }
                             }
-                            StructLike(name, fields) => {
-                                if not args.is_empty() {
-                                    output.appendff(
-                                        "auto&& __jakt_match_value = __jakt_match_variant.as.{};",
-                                        name)
+                            let match_case_enum = .program.get_enum(enum_id)
+                            let variant = match_case_enum.variants[index]
+                            output.appendff("case {} /* {} */: {{\n", index, variant.name())
+                            match variant {
+                                Untyped(name) => {
+                                }
+                                Typed(name, type_id) => {
+                                    if not args.is_empty() {
+                                        output.appendff(
+                                            "auto&& __jakt_match_value = __jakt_match_variant.as.{};",
+                                            name
+                                        )
 
-                                    for arg in args {
+                                        let arg = args[0]
                                         let var = .program.find_var_in_scope(scope_id, var: arg.binding)!
                                         output.append(.codegen_type(var.type_id))
                                         if not var.is_mutable {
@@ -3799,59 +3790,77 @@ struct CodeGenerator {
                                         }
                                         output.append("& ")
                                         output.append(arg.binding)
-
-
-                                        let accessor = arg.name ?? arg.binding
-                                        mut is_common_member = false
-                                        for field in enum_.fields {
-                                            let var = .program.get_variable(field.variable_id)
-                                            if var.name == accessor {
-                                                is_common_member = true
-                                                break
-                                            }
-                                        }
-
-                                        if is_common_member {
-                                            output.append(" = __jakt_match_variant.common.init_common.")
-                                            output.append(accessor)
-                                        } else {
-                                            output.append(" = __jakt_match_value.")
-                                            output.append(accessor)
-                                        }
-                                        output.append(";\n")
+                                        output.append(" = __jakt_match_value.value;\n")
                                     }
                                 }
+                                StructLike(name, fields) => {
+                                    if not args.is_empty() {
+                                        output.appendff(
+                                            "auto&& __jakt_match_value = __jakt_match_variant.as.{};",
+                                            name)
+
+                                        for arg in args {
+                                            let var = .program.find_var_in_scope(scope_id, var: arg.binding)!
+                                            output.append(.codegen_type(var.type_id))
+                                            if not var.is_mutable {
+                                                output.append(" const")
+                                            }
+                                            output.append("& ")
+                                            output.append(arg.binding)
+
+
+                                            let accessor = arg.name ?? arg.binding
+                                            mut is_common_member = false
+                                            for field in enum_.fields {
+                                                let var = .program.get_variable(field.variable_id)
+                                                if var.name == accessor {
+                                                    is_common_member = true
+                                                    break
+                                                }
+                                            }
+
+                                            if is_common_member {
+                                                output.append(" = __jakt_match_variant.common.init_common.")
+                                                output.append(accessor)
+                                            } else {
+                                                output.append(" = __jakt_match_value.")
+                                                output.append(accessor)
+                                            }
+                                            output.append(";\n")
+                                        }
+                                    }
+                                }
+                                else => {
+                                    todo(format("codegen_enum_match match variant else: {}", variant))
+                                }
                             }
-                            else => {
-                                todo(format("codegen_enum_match match variant else: {}", variant))
+
+                            for default_ in pattern.defaults {
+                                .codegen_statement(statement: default_, &mut output)
                             }
+
+                            .codegen_match_body(body, return_type_id: type_id, &mut output)
+                            output.append("};/*case end*/\n")
                         }
+                        CatchAll => {
+                            has_default = true
 
-                        for default_ in match_case.defaults {
-                            .codegen_statement(statement: default_, &mut output)
+                            output.append("default: {\n")
+                            for default_ in pattern.defaults {
+                                .codegen_statement(statement: default_, &mut output)
+                            }
+
+                            .codegen_match_body(body, return_type_id: type_id, &mut output)
+                            output.append("};/*case end*/\n")
                         }
-
-                        .codegen_match_body(body, return_type_id: type_id, &mut output)
-                        output.append("};/*case end*/\n")
-                    }
-                    CatchAll(body) => {
-                        has_default = true
-
-                        output.append("default: {\n")
-                        for default_ in match_case.defaults {
-                            .codegen_statement(statement: default_, &mut output)
+                        else => {
+                            panic("Matching enum subject with non-enum value")
                         }
-
-                        .codegen_match_body(body, return_type_id: type_id, &mut output)
-                        output.append("};/*case end*/\n")
-                    }
-                    else => {
-                        panic("Matching enum subject with non-enum value")
                     }
                 }
             }
             if not has_default {
-                if enum_.variants.size() != match_cases.size() {
+                if enum_.variants.size() != count_match_cases(&match_cases) {
                     panic("Inexhaustive match statement")
                 }
                 output.append("default: VERIFY_NOT_REACHED();")
@@ -3869,19 +3878,22 @@ struct CodeGenerator {
             output.append(") {\n")
 
             for match_case in match_cases {
-                match match_case {
-                    EnumVariant(name, body) => {
-                        output.append("case " + enum_.name + "::" + name + ": {\n")
-                        .codegen_match_body(body, return_type_id: type_id, &mut output)
-                        output.append("}\n")
-                    }
-                    CatchAll(body) => {
-                        output.append("default: {\n")
-                        .codegen_match_body(body, return_type_id: type_id, &mut output)
-                        output.append("}\n")
-                    }
-                    else => {
-                        todo(format("underlying type enum match, match_case: {}", match_case))
+                let body = match_case.body
+                for pattern in match_case.patterns {
+                    match pattern {
+                        EnumVariant(name) => {
+                            output.append("case " + enum_.name + "::" + name + ": {\n")
+                            .codegen_match_body(body, return_type_id: type_id, &mut output)
+                            output.append("}\n")
+                        }
+                        CatchAll => {
+                            output.append("default: {\n")
+                            .codegen_match_body(body, return_type_id: type_id, &mut output)
+                            output.append("}\n")
+                        }
+                        else => {
+                            todo(format("underlying type enum match, match_case: {}", match_case))
+                        }
                     }
                 }
             }
@@ -5710,4 +5722,12 @@ struct CodeGenerator {
 
         output.append("}\n")
     }
+}
+
+fn count_match_cases(anon cases: &[CheckedMatchCase]) -> usize {
+    mut count = 0uz
+    for case_ in cases {
+        count += case_.patterns.size()
+    }
+    return count
 }

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -8,7 +8,7 @@
 import parser { BinaryOperator, FunctionLinkage, ParsedBlock }
 import typechecker {
     BuiltinType, CheckedBinaryOperator, CheckedBlock, CheckedCall, CheckedEnum, CheckedExpression, CheckedFunction
-    CheckedMatchBody, CheckedMatchCase, CheckedProgram, CheckedStatement, CheckedStruct, CheckedVariable
+    CheckedMatchBody, CheckedMatchCase, CheckedMatchPattern, CheckedProgram, CheckedStatement, CheckedStruct, CheckedVariable
     CheckedVisibility, EnumId, FunctionId, Module, ModuleId, Scope, ScopeId, StructId, Type, TypeId, VarId, builtin
     never_type_id, unknown_type_id, void_type_id
 }
@@ -3567,15 +3567,64 @@ struct CodeGenerator {
         .codegen_expression(expr, &mut output)
         output.append(");\n")
 
-        mut has_default = false
         mut first = true
-        for case_ in cases {
+
+        mut cases_with_bindings: [CheckedMatchCase] = []
+        mut deferred_catch_all: ([CheckedStatement], CheckedMatchBody)? = None // (defaults, body)?
+
+        for case_index in 0..cases.size() {
+            let match_case = cases[case_index]
+
+            if match_case.patterns.size() == 1 and match_case.patterns[0] is CatchAll(has_arguments) {
+                // as an exception to the rule, CatchAll is deferred to the
+                // last thing because it must be the last prong.
+                guard not has_arguments else {
+                    panic("Bindings should not be present in a generic else")
+                }
+                deferred_catch_all = (match_case.patterns[0].defaults, match_case.body)
+                continue
+            }
+
+            guard not case_has_bindings(&match_case) else {
+                cases_with_bindings.push(match_case)
+                continue
+            }
+
+            if not first {
+                output.append("else ")
+            }
+            first = false
+            output.append("if (")
+            mut first_pat = true
+            for pattern in match_case.patterns {
+                defer first_pat = false
+                if not first_pat {
+                    output.append("||")
+                }
+
+                .codegen_generic_pattern_condition(&pattern, is_parenthesized: match_case.patterns.size() == 1, output)
+            }
+            output.append(") {")
+            .codegen_match_body(body: match_case.body, return_type_id, &mut output)
+            output.append('}')
+        }
+
+        for case_ in cases_with_bindings {
             let body = case_.body
             for pattern in case_.patterns {
                 let defaults = pattern.defaults
 
+                defer first = false
+                if not first { output.append("else ") }
+
+
+                output.append("if (")
+                .codegen_generic_pattern_condition(&pattern, is_parenthesized: true, &mut output)
+                output.append(") {")
+                defer output.append('}')
+
                 match pattern {
-                    EnumVariant(name, args, subject_type_id, scope_id) => {
+                    EnumVariant(name, args, subject_type_id, index: variant_index, scope_id) => {
                         let enum_ = .program.get_enum(match .program.get_type(subject_type_id) {
                             Enum(enum_id) => enum_id
                             GenericEnumInstance(id) => id
@@ -3583,25 +3632,6 @@ struct CodeGenerator {
                                 panic(format("Unexpected type in IsEnumVariant: {}", .program.get_type(subject_type_id)))
                             }
                         })
-                        // FIXME: This should be a call to find(), but we do not yet provide the needed operator== for that
-                        mut variant_index = 0;
-                        for variant in enum_.variants {
-                            if variant.name() == name {
-                                break
-                            }
-                            variant_index++
-                        }
-
-                        output.appendff("if (__jakt_enum_value.__jakt_init_index() == {} /* {} */) {{\n", variant_index, name)
-
-                        mut variant_type_name = ""
-                        let qualifier = .codegen_type_possibly_as_namespace(type_id: subject_type_id, as_namespace: true)
-                        if not qualifier.is_empty() {
-                            variant_type_name += "typename JaktInternal::RemoveRefPtr<"
-                            variant_type_name += qualifier
-                            variant_type_name += ">::"
-                        }
-                        variant_type_name += name
 
                         if not args.is_empty() {
                             output.append("auto& __jakt_match_value = __jakt_enum_value.as.")
@@ -3633,98 +3663,85 @@ struct CodeGenerator {
                                 output.append(";\n")
                             }
                         }
-
-                        for default_ in defaults {
-                            .codegen_statement(statement: default_, &mut output)
-                        }
-
-                        .codegen_match_body(body, return_type_id, &mut output)
-                        output.append("}\n")
                     }
-                    CatchAll(has_arguments, marker_span) => {
-                        if has_arguments {
-                            panic("Bindings should not be present in a generic else")
-                        }
-
-                        // TODO: Use default statement if all values are constant
-                        has_default = true
-
-                        if first {
-                            output.append("{")
-                        } else {
-                            output.append("else {\n")
-                        }
-
-                        for default_ in defaults {
-                            .codegen_statement(statement: default_, &mut output)
-                        }
-
-                        .codegen_match_body(body, return_type_id, &mut output)
-                        output.append("}\n")
-                    }
-                    Expression(expression, marker_span) => {
-                        // TODO: Use case statement if all values are constant
-                        if not first {
-                            output.append("else ")
-                        }
-                        if expression is Range(from, to) {
-                            output.append("if (__jakt_enum_value")
-                            if from.has_value() {
-                                output.append(" >= ")
-                                .codegen_expression(from!, &mut output, syntactically_self_contained: true)
-                            }
-
-                            if to.has_value() {
-                                if from.has_value() {
-                                    output.append("&& __jakt_enum_value ")
-                                }
-                                output.append("< ")
-                                .codegen_expression(to!, &mut output, syntactically_self_contained: true)
-                            }
-                        } else {
-                            output.append("if (__jakt_enum_value == ")
-                            if expression is QuotedString(val)
-                                and (val.type_id == byte_string_type_id or val.type_id == builtin(BuiltinType::JaktString)) {
-                                let original_string = val.to_string()
-                                let escaped_value = escape_for_quotes(original_string)
-                                output.append("\"")
-                                output.append(escaped_value)
-                                output.append("\"sv")
-                            } else {
-                                .codegen_expression(expression, &mut output, syntactically_self_contained: true)
-                            }
-                        }
-                        output.append(") {\n")
-                        .codegen_match_body(body, return_type_id, &mut output)
-                        output.append("}\n")
-                    }
+                    CatchAll => { panic("unreachable") }
+                    Expression => { }
                     ClassInstance(type, rebind_name, marker_span) => {
-                        let type_name = .codegen_type_possibly_as_namespace(type_id: type, as_namespace: true)
-                        output.appendff("if (is<{}>(__jakt_enum_value.ptr())) {{\n", type_name)
-                        output.appendff(
-                            "auto {} = NonnullRefPtr {{ *static_cast<RawPtr<{}>>(__jakt_enum_value.ptr()) }};\n"
-                            (rebind_name?.name ?? "__jakt_match_value")
-                            type_name
-                        )
-
-                        for default_ in defaults {
-                            .codegen_statement(statement: default_, &mut output)
+                        if rebind_name is Some(rebind) {
+                            output.appendff(
+                                "auto {} = NonnullRefPtr {{ *static_cast<RawPtr<{}>>(__jakt_enum_value.ptr()) }};\n"
+                                rebind.name
+                                .codegen_type_possibly_as_namespace(type_id: type, as_namespace: true)
+                            )
                         }
-
-                        .codegen_match_body(body, return_type_id, &mut output)
-                        output.append("}\n")
                     }
                 }
-                first = false
+                for default_ in defaults {
+                    .codegen_statement(statement: default_, &mut output)
+                }
+                .codegen_match_body(body, return_type_id, &mut output)
             }
+        }
+
+        if deferred_catch_all is Some(catch_all_case) {
+            let (defaults, body) = catch_all_case
+
+            if not first { output.append("else ") }
+
+            output.append('{')
+
+            for default_ in defaults {
+                .codegen_statement(statement: default_, &mut output)
+            }
+
+            .codegen_match_body(body, return_type_id, &mut output)
+            output.append('}')
         }
         if return_type_id == void_type_id() or return_type_id == unknown_type_id() {
             output.append("return JaktInternal::ExplicitValue<void>();\n")
-        } else if not has_default {
+        } else if deferred_catch_all is None {
             output.append("VERIFY_NOT_REACHED();\n")
         }
 
         output.append("}())")
+    }
+
+    fn codegen_generic_pattern_condition(mut this, pattern: &CheckedMatchPattern, is_parenthesized: bool, output: &mut StringBuilder) throws {
+        match pattern {
+            EnumVariant(name, index: variant_index) => {
+                output.appendff("__jakt_enum_value.__jakt_init_index() == {} /* {} */", variant_index, name)
+            }
+            Expression(expression: expr) => match expr {
+                Range(from, to) => {
+                    let has_and = from is Some and to is Some
+                    if has_and and not is_parenthesized { output.append('(') }
+                    if from is Some(expr) {
+                        output.append("__jakt_enum_value >= ")
+                        .codegen_expression(expr, output, syntactically_self_contained: true)
+                    }
+                    if has_and { output.append("&&") }
+                    if to is Some(expr) {
+                        output.append("__jakt_enum_value < ")
+                        .codegen_expression(expr, output, syntactically_self_contained: true)
+                    }
+                    if has_and and not is_parenthesized { output.append(')') }
+                }
+                Boolean(val) => {
+                    if not val { output.append('!') }
+                    output.append("__jakt_enum_value")
+                }
+                else => {
+                    if not is_parenthesized { output.append('(') }
+                    output.append("__jakt_enum_value == ")
+                    .codegen_expression(expr, output, syntactically_self_contained: true)
+                    if not is_parenthesized { output.append(')') }
+                }
+            }
+            ClassInstance(type: type_id) => {
+                output.appendff("is<{}>(__jakt_enum_value.ptr())", .codegen_type_possibly_as_namespace(type_id, as_namespace: true))
+            }
+            CatchAll => { .compiler.panic("catch all has no condition, should be emitted separately") }
+        }
     }
 
     fn codegen_enum_match(
@@ -3759,7 +3776,14 @@ struct CodeGenerator {
             mut has_default = false
             for match_case in match_cases {
                 let body = match_case.body
+
+                mut patterns_without_bindings: [CheckedMatchPattern] = []
+
                 for pattern in match_case.patterns {
+                    if not pattern_has_bindings(&pattern) {
+                        patterns_without_bindings.push(pattern)
+                        continue
+                    }
                     match pattern {
                         EnumVariant(name, args, subject_type_id, index, scope_id) => {
                             let enum_type = .program.get_type(subject_type_id)
@@ -3858,6 +3882,22 @@ struct CodeGenerator {
                         }
                     }
                 }
+
+                if not patterns_without_bindings.is_empty() {
+                    for pattern in patterns_without_bindings {
+                        match pattern {
+                            EnumVariant(name, index) => { output.appendff("case {} /* {} */:", index, name) }
+                            CatchAll => {
+                                has_default = true
+                                output.append("default:")
+                            }
+                            else => {
+                                panic("Matching enum subject with non-enum value")
+                            }
+                        }
+                    }
+                    .codegen_match_body(body, return_type_id: type_id, &mut output)
+                }
             }
             if not has_default {
                 if enum_.variants.size() != count_match_cases(&match_cases) {
@@ -3878,24 +3918,20 @@ struct CodeGenerator {
             output.append(") {\n")
 
             for match_case in match_cases {
-                let body = match_case.body
                 for pattern in match_case.patterns {
                     match pattern {
                         EnumVariant(name) => {
-                            output.append("case " + enum_.name + "::" + name + ": {\n")
-                            .codegen_match_body(body, return_type_id: type_id, &mut output)
-                            output.append("}\n")
+                            output.appendff("case {}::{}:", enum_.name, name)
                         }
                         CatchAll => {
-                            output.append("default: {\n")
-                            .codegen_match_body(body, return_type_id: type_id, &mut output)
-                            output.append("}\n")
+                            output.append("default:")
                         }
                         else => {
                             todo(format("underlying type enum match, match_case: {}", match_case))
                         }
                     }
                 }
+                .codegen_match_body(body: match_case.body, return_type_id: type_id, &mut output)
             }
             output.append("}/*switch end*/\n")
             output.append("}()\n)")
@@ -5722,6 +5758,25 @@ struct CodeGenerator {
 
         output.append("}\n")
     }
+}
+
+fn pattern_has_bindings(anon pattern: &CheckedMatchPattern) -> bool {
+    if not pattern.defaults.is_empty() { return true }
+    return match pattern {
+        EnumVariant(args) => not args.is_empty()
+        ClassInstance(rebind_name) => rebind_name is Some
+        CatchAll | Expression => false
+    }
+}
+
+fn case_has_bindings(anon match_case: &CheckedMatchCase) -> bool {
+    for pattern in match_case.patterns {
+        if pattern_has_bindings(&pattern) {
+            return true
+        }
+    }
+
+    return false
 }
 
 fn count_match_cases(anon cases: &[CheckedMatchCase]) -> usize {

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -743,84 +743,89 @@ fn find_span_in_expression(program: CheckedProgram, expr: CheckedExpression, spa
         }
         Match(expr, match_cases, span: match_span, type_id) => {
             for match_case in match_cases {
-                let found = match match_case {
-                    EnumVariant(name, args, subject_type_id, index, scope_id, body, marker_span) => {
-                        if marker_span.contains(span) {
-                            // FIXME: return Some(get_enum_variant_usage_from_type_id_and_name(program, type_id: subject_type_id, variant_index))
-                            return Some(get_enum_variant_usage_from_type_id_and_name(
-                                    program
-                                    type_id: subject_type_id
-                                    name))
-                        }
+                let body = match_case.body
+                for pattern in match_case.patterns {
+                    let found = match pattern {
+                        EnumVariant(name, args, subject_type_id, index, scope_id, marker_span) => {
+                            if marker_span.contains(span) {
+                                // FIXME: return Some(get_enum_variant_usage_from_type_id_and_name(program, type_id: subject_type_id, variant_index))
+                                return Some(get_enum_variant_usage_from_type_id_and_name(
+                                        program
+                                        type_id: subject_type_id
+                                        name))
+                            }
 
-                        yield match body {
-                            Block(block) => find_span_in_block(program, block, span)
-                            Expression(expr) => find_span_in_expression(program, expr, span)
+                            yield match body {
+                                Block(block) => find_span_in_block(program, block, span)
+                                Expression(expr) => find_span_in_expression(program, expr, span)
+                            }
                         }
-                    }
-                    Expression(expression: expr, body) => {
-                        let found = find_span_in_expression(program, expr, span)
-                        if found.has_value() {
-                            return found
+                        Expression(expression: expr) => {
+                            let found = find_span_in_expression(program, expr, span)
+                            if found.has_value() {
+                                return found
+                            }
+                            yield match body {
+                                Block(block) => find_span_in_block(program, block, span)
+                                Expression(expr) => find_span_in_expression(program, expr, span)
+                            }
                         }
-                        yield match body {
-                            Block(block) => find_span_in_block(program, block, span)
-                            Expression(expr) => find_span_in_expression(program, expr, span)
-                        }
-                    }
-                    CatchAll(body, marker_span) => match marker_span.contains(span) {
-                        true => {
-                            let all_cases = match program.get_type(type_id) {
-                                Enum(enum_id) | GenericEnumInstance(id: enum_id) => {
-                                    // NOTE: not sure why would we need a hashset if enum variants
-                                    // can't be duplicate, but I'll leave previous implementation from Rust based
-                                    mut names: {String} = {}
-                                    let enum_ = program.get_enum(enum_id)
-                                    for variant in enum_.variants {
-                                        names.add(variant.name())
+                        CatchAll(marker_span) => match marker_span.contains(span) {
+                            true => {
+                                let all_cases = match program.get_type(type_id) {
+                                    Enum(enum_id) | GenericEnumInstance(id: enum_id) => {
+                                        // NOTE: not sure why would we need a hashset if enum variants
+                                        // can't be duplicate, but I'll leave previous implementation from Rust based
+                                        mut names: {String} = {}
+                                        let enum_ = program.get_enum(enum_id)
+                                        for variant in enum_.variants {
+                                            names.add(variant.name())
+                                        }
+                                        yield names
                                     }
-                                    yield names
-                                }
-                                else => {
-                                    yield {format("else ({})", program.type_name(type_id))}
-                                }
-                            }
-
-                            mut remaining_cases = all_cases
-
-                            for other_case in match_cases {
-                                if other_case is EnumVariant(name) {
-                                    remaining_cases.remove(name)
-                                }
-                            }
-
-                            yield match remaining_cases.is_empty() {
-                                false => {
-                                    mut cases_array: [String] = []
-                                    cases_array.ensure_capacity(remaining_cases.size())
-                                    for name in remaining_cases {
-                                        cases_array.push(name)
+                                    else => {
+                                        yield {format("else ({})", program.type_name(type_id))}
                                     }
-                                    yield Some(Usage::NameSet(cases_array))
                                 }
-                                true => None
+
+                                mut remaining_cases = all_cases
+
+                                for other_case in match_cases {
+                                    for pattern in other_case.patterns {
+                                        if pattern is EnumVariant(name) {
+                                            remaining_cases.remove(name)
+                                        }
+                                    }
+                                }
+
+                                yield match remaining_cases.is_empty() {
+                                    false => {
+                                        mut cases_array: [String] = []
+                                        cases_array.ensure_capacity(remaining_cases.size())
+                                        for name in remaining_cases {
+                                            cases_array.push(name)
+                                        }
+                                        yield Some(Usage::NameSet(cases_array))
+                                    }
+                                    true => None
+                                }
+                            }
+                            else => match body {
+                                Block(block) => find_span_in_block(program, block, span)
+                                Expression(expr) => find_span_in_expression(program, expr, span)
                             }
                         }
-                        else => match body {
-                            Block(block) => find_span_in_block(program, block, span)
-                            Expression(expr) => find_span_in_expression(program, expr, span)
+                        ClassInstance(marker_span) => match marker_span.contains(span) {
+                            true => None // FIXME: Implement this
+                            else => match body {
+                                Block(block) => find_span_in_block(program, block, span)
+                                Expression(expr) => find_span_in_expression(program, expr, span)
+                            }
                         }
                     }
-                    ClassInstance(body, marker_span) => match marker_span.contains(span) {
-                        true => None // FIXME: Implement this
-                        else => match body {
-                            Block(block) => find_span_in_block(program, block, span)
-                            Expression(expr) => find_span_in_expression(program, expr, span)
-                        }
+                    if found.has_value() {
+                        return found
                     }
-                }
-                if found.has_value() {
-                    return found
                 }
             }
             yield find_span_in_expression(program, expr, span)

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -6852,27 +6852,30 @@ class Interpreter {
                     mut span: Span? = None
 
                     for match_case in match_cases {
-                        match match_case {
-                            EnumVariant(name, args, index, body, marker_span) => {
-                                if name != constructor_name {
+                        let body = match_case.body
+                        for pattern in match_case.patterns {
+                            match pattern {
+                                EnumVariant(name, args, index, marker_span) => {
+                                    if name != constructor_name {
+                                        continue
+                                    }
+
+                                    // A match!
+                                    found_body = body
+                                    found_args = args
+                                    found_variant_index = index
+                                    span = marker_span
+                                    break
+                                }
+                                ClassInstance(marker_span) | Expression(marker_span) => {
+                                    .error("Value matches are not allowed on enums", marker_span)
+                                    .compiler.panic("Invalid type")
+                                }
+                                CatchAll(marker_span) => {
+                                    catch_all_case = body
+                                    span = marker_span
                                     continue
                                 }
-
-                                // A match!
-                                found_body = body
-                                found_args = args
-                                found_variant_index = index
-                                span = marker_span
-                                break
-                            }
-                            ClassInstance(marker_span) | Expression(marker_span) => {
-                                .error("Value matches are not allowed on enums", marker_span)
-                                .compiler.panic("Invalid type")
-                            }
-                            CatchAll(body, marker_span) => {
-                                catch_all_case = body
-                                span = marker_span
-                                continue
                             }
                         }
                     }
@@ -6945,48 +6948,51 @@ class Interpreter {
                     mut span: Span? = None
 
                     for match_case in match_cases {
-                        match match_case {
-                            Expression(body, expression, marker_span) => {
-                                let value_to_match_against = match .execute_expression(expression, scope) {
-                                    Return(value) => {
-                                        return StatementResult::Return(value)
+                        let body = match_case.body
+                        for pattern in match_case.patterns {
+                            match pattern {
+                                Expression(expression, marker_span) => {
+                                    let value_to_match_against = match .execute_expression(expression, scope) {
+                                        Return(value) => {
+                                            return StatementResult::Return(value)
+                                        }
+                                        Throw(value) => {
+                                            return StatementResult::Throw(value)
+                                        }
+                                        JustValue(value) => value
+                                        Continue => {
+                                            return StatementResult::Continue
+                                        }
+                                        Break => {
+                                            return StatementResult::Break
+                                        }
+                                        Yield => {
+                                            panic("Invalid control flow")
+                                        }
                                     }
-                                    Throw(value) => {
-                                        return StatementResult::Throw(value)
-                                    }
-                                    JustValue(value) => value
-                                    Continue => {
-                                        return StatementResult::Continue
-                                    }
-                                    Break => {
-                                        return StatementResult::Break
-                                    }
-                                    Yield => {
-                                        panic("Invalid control flow")
-                                    }
-                                }
 
-                                if value_to_match_against.impl.equals(value.impl) {
-                                    found_body = Some(body)
-                                    span = Some(marker_span)
-                                    break
+                                    if value_to_match_against.impl.equals(value.impl) {
+                                        found_body = Some(body)
+                                        span = Some(marker_span)
+                                        break
+                                    }
                                 }
-                            }
-                            CatchAll(body, marker_span) => {
-                                catch_all_case = body
-                                span = marker_span
-                                continue
-                            }
-                            ClassInstance(marker_span) => {
-                                // FIXME: Implement this
-                                .error("Class instance matches are not implemented yet", marker_span)
-                                .compiler.panic("Invalid type")
-                            }
-                            EnumVariant(marker_span) => {
-                                .error(
-                                    format("Value matches cannot have enum variant arms (matching on {})", value.type_name()),
-                                    marker_span)
-                                .compiler.panic("Invalid type")
+                                CatchAll(marker_span) => {
+                                    catch_all_case = body
+                                    span = marker_span
+                                    continue
+                                }
+                                ClassInstance(marker_span) => {
+                                    // FIXME: Implement this
+                                    .error("Class instance matches are not implemented yet", marker_span)
+                                    .compiler.panic("Invalid type")
+                                }
+                                EnumVariant(marker_span) => {
+                                    .error(
+                                        format("Value matches cannot have enum variant arms (matching on {})", value.type_name()),
+                                        marker_span)
+                                    .compiler.panic("Invalid type")
+                                }
                             }
                         }
                     }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -6146,9 +6146,7 @@ struct Parser {
                 else => ParsedMatchBody::Expression(.parse_expression(allow_assignments: false, allow_newlines: true))
             }
 
-            for pattern in patterns {
-                cases.push(ParsedMatchCase(patterns: [pattern], marker_span, body))
-            }
+            cases.push(ParsedMatchCase(patterns, marker_span, body))
 
             if .index == pattern_start_index {
                 // Parser didn't advance, bail.

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -6763,17 +6763,21 @@ struct Typechecker {
                 expr: CheckedExpression::Match(
                     expr: checked_condition,
                     match_cases: [
-                        CheckedMatchCase::Expression(
-                            defaults: []
-                            expression: CheckedExpression::Boolean(val: true, span)
+                        CheckedMatchCase(
+                            patterns: [CheckedMatchPattern::Expression(
+                                defaults: []
+                                expression: CheckedExpression::Boolean(val: true, span)
+                                marker_span: span
+                            )]
                             body: CheckedMatchBody::Expression(CheckedExpression::Block(block: checked_block, span, type_id: checked_block.yielded_type!))
-                            marker_span: span
-                        ),
-                        CheckedMatchCase::CatchAll(
-                            defaults: []
-                            has_arguments: false
+                        )
+                        CheckedMatchCase(
+                            patterns: [CheckedMatchPattern::CatchAll(
+                                defaults: []
+                                has_arguments: false
+                                marker_span: span
+                            )]
                             body: CheckedMatchBody::Block(checked_else_block)
-                            marker_span: span
                         )
                     ]
                     span
@@ -9629,7 +9633,7 @@ struct Typechecker {
 
     fn typecheck_match_variant(
         mut this
-        case_: ParsedMatchCase
+        case_: &ParsedMatchCase
         subject_type_id: TypeId
         variant_index: usize
         final_result_type: TypeId?
@@ -9639,7 +9643,7 @@ struct Typechecker {
         arguments_span: Span
         scope_id: ScopeId
         safety_mode: SafetyMode
-    ) throws -> (String?, CheckedMatchCase, TypeId?, bool) {
+    ) throws -> (String?, CheckedMatchPattern, CheckedMatchBody, TypeId?, bool) {
         mut covered_name: String? = None
 
         let new_scope_id = .create_scope(
@@ -9775,18 +9779,17 @@ struct Typechecker {
             span: case_.marker_span
         )
 
-        let checked_match_case = CheckedMatchCase::EnumVariant(
+        let checked_match_pattern = CheckedMatchPattern::EnumVariant(
             defaults
             name: variant.name()
             args: variant_arguments
             subject_type_id
             index: variant_index
             scope_id: new_scope_id
-            body: checked_body
             marker_span: case_.marker_span
         )
 
-        return (covered_name, checked_match_case, result_type, seen_none)
+        return (covered_name, checked_match_pattern, checked_body, result_type, seen_none)
     }
 
     fn typecheck_match(
@@ -9837,6 +9840,15 @@ struct Typechecker {
                 let case_count = cases.size()
                 mut current_case_index = 0uz
                 for case_ in cases {
+                    mut checked_patterns: [CheckedMatchPattern] = []
+                    mut last_checked_body: CheckedMatchBody? = None
+                    // if the input is malformed, there will be cases with empty patterns.
+                    defer if not checked_patterns.is_empty() {
+                        checked_cases.push(CheckedMatchCase(
+                            patterns: checked_patterns
+                            body: last_checked_body!
+                        ))
+                    }
                     for pattern in case_.patterns {
                         match pattern {
                             EnumVariant(variant_names, variant_arguments, arguments_span) => {
@@ -9876,8 +9888,8 @@ struct Typechecker {
                                     return CheckedExpression::Match(expr: checked_expr, match_cases: [], span, type_id: unknown_type_id(), all_variants_constant: false)
                                 }
 
-                                let (covered_name, checked_match_case, result_type, seen_none) = .typecheck_match_variant(
-                                    case_
+                                let (covered_name, checked_match_case, checked_body, result_type, seen_none) = .typecheck_match_variant(
+                                    &case_
                                     subject_type_id
                                     variant_index: variant_index!
                                     final_result_type
@@ -9889,6 +9901,7 @@ struct Typechecker {
                                     safety_mode
                                 )
 
+                                last_checked_body = checked_body
                                 yielded_none |= seen_none
 
                                 if covered_name.has_value() {
@@ -9897,7 +9910,7 @@ struct Typechecker {
 
                                 final_result_type = result_type
 
-                                checked_cases.push(checked_match_case)
+                                checked_patterns.push(checked_match_case)
                             }
                             CatchAll(variant_arguments, arguments_span) => {
                                 if current_case_index != case_count - 1 {
@@ -9916,8 +9929,8 @@ struct Typechecker {
                                         if not covered_variants.contains(variant.name()) {
                                             expanded_catch_all = true
 
-                                            let (covered_name, checked_match_case, result_type, seen_none) = .typecheck_match_variant(
-                                                case_
+                                            let (covered_name, checked_match_pattern, checked_body, result_type, seen_none) = .typecheck_match_variant(
+                                                &case_
                                                 subject_type_id
                                                 variant_index
                                                 final_result_type
@@ -9929,6 +9942,7 @@ struct Typechecker {
                                                 safety_mode
                                             )
 
+                                            last_checked_body = checked_body
                                             yielded_none |= seen_none
 
                                             if covered_name.has_value() {
@@ -9937,7 +9951,7 @@ struct Typechecker {
 
                                             final_result_type = result_type
 
-                                            checked_cases.push(checked_match_case)
+                                            checked_patterns.push(checked_match_pattern)
                                         }
 
                                         variant_index++
@@ -9968,17 +9982,17 @@ struct Typechecker {
                                         final_result_type
                                         span: case_.marker_span
                                     )
+                                    last_checked_body = checked_body
                                     yielded_none |= seen_none
                                     final_result_type = result_type
 
-                                    let checked_match_case = CheckedMatchCase::CatchAll(
+                                    let checked_match_pattern = CheckedMatchPattern::CatchAll(
                                         defaults
                                         has_arguments: false
-                                        body: checked_body
                                         marker_span: case_.marker_span
                                     )
 
-                                    checked_cases.push(checked_match_case)
+                                    checked_patterns.push(checked_match_pattern)
                                 }
                             }
                             else => {}
@@ -10026,6 +10040,14 @@ struct Typechecker {
                     mut covered_cases: {StructId} = {}
 
                     for case_ in cases {
+                        mut checked_patterns: [CheckedMatchPattern] = []
+                        mut last_checked_body: CheckedMatchBody? = None
+                        defer if not checked_patterns.is_empty() {
+                            checked_cases.push(CheckedMatchCase(
+                                patterns: checked_patterns
+                                body: last_checked_body!
+                            ))
+                        }
                         for pattern in case_.patterns {
                             match pattern {
                                 EnumVariant(variant_names, variant_arguments, arguments_span) => {
@@ -10185,13 +10207,13 @@ struct Typechecker {
                                         final_result_type
                                         span: case_.marker_span
                                     )
+                                    last_checked_body = checked_body
                                     yielded_none |= seen_none
                                     final_result_type = result_type
 
-                                    checked_cases.push(CheckedMatchCase::ClassInstance(
+                                    checked_patterns.push(CheckedMatchPattern::ClassInstance(
                                         defaults: []
                                         type
-                                        body: checked_body
                                         rebind_name
                                         marker_span: case_.marker_span
                                     ))
@@ -10224,13 +10246,13 @@ struct Typechecker {
                                             final_result_type
                                             span: case_.marker_span
                                         )
+                                        last_checked_body = checked_body
                                         yielded_none |= seen_none
                                         final_result_type = result_type
 
-                                        checked_cases.push(CheckedMatchCase::CatchAll(
+                                        checked_patterns.push(CheckedMatchPattern::CatchAll(
                                             defaults: []
                                             has_arguments: false
-                                            body: checked_body
                                             marker_span: case_.marker_span
                                         ))
                                     }
@@ -10286,6 +10308,14 @@ struct Typechecker {
                     let case_count = cases.size()
                     mut current_case_index = 0uz
                     for case_ in cases {
+                        mut checked_patterns: [CheckedMatchPattern] = []
+                        mut last_checked_body: CheckedMatchBody? = None
+                        defer if not checked_patterns.is_empty() {
+                            checked_cases.push(CheckedMatchCase(
+                                patterns: checked_patterns
+                                body: last_checked_body!
+                            ))
+                        }
                         for pattern in case_.patterns {
                             match pattern {
                                 EnumVariant(variant_names, variant_arguments, arguments_span) => {
@@ -10325,20 +10355,20 @@ struct Typechecker {
                                         final_result_type
                                         span: case_.marker_span
                                     )
+                                    last_checked_body = checked_body
                                     yielded_none |= seen_none
                                     final_result_type = result_type
 
-                                    let checked_match_case = CheckedMatchCase::EnumVariant(
+                                    let checked_match_pattern = CheckedMatchPattern::EnumVariant(
                                         defaults
                                         name: variant_names.last()!.0
                                         args: variant_arguments
                                         subject_type_id
                                         index: 0
                                         scope_id: new_scope_id
-                                        body: checked_body
                                         marker_span: case_.marker_span
                                     )
-                                    checked_cases.push(checked_match_case)
+                                    checked_patterns.push(checked_match_pattern)
                                 }
                                 CatchAll(variant_arguments) => {
                                     if current_case_index != case_count - 1 {
@@ -10382,17 +10412,17 @@ struct Typechecker {
                                         final_result_type
                                         span: case_.marker_span
                                     )
+                                    last_checked_body = checked_body
                                     yielded_none |= seen_none
                                     final_result_type = result_type
 
-                                    let checked_match_case = CheckedMatchCase::CatchAll(
+                                    let checked_match_pattern = CheckedMatchPattern::CatchAll(
                                         defaults
                                         has_arguments: variant_arguments.size() != 0
-                                        body: checked_body
                                         marker_span: case_.marker_span
                                     )
 
-                                    checked_cases.push(checked_match_case)
+                                    checked_patterns.push(checked_match_pattern)
                                 }
                                 Expression(expr) => {
                                     if is_enum_match {
@@ -10467,16 +10497,16 @@ struct Typechecker {
                                         final_result_type
                                         span: case_.marker_span
                                     )
+                                    last_checked_body = checked_body
                                     yielded_none |= seen_none
                                     final_result_type = result_type
 
-                                    let checked_match_case = CheckedMatchCase::Expression(
+                                    let checked_match_pattern = CheckedMatchPattern::Expression(
                                         defaults: []
                                         expression: checked_expression
-                                        body: checked_body
                                         marker_span: case_.marker_span
                                     )
-                                    checked_cases.push(checked_match_case)
+                                    checked_patterns.push(checked_match_pattern)
                                 }
                                 else => {}
                             }

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -1581,13 +1581,18 @@ struct ClassInstanceRebind {
     is_reference: bool
 }
 
-enum CheckedMatchCase {
+struct CheckedMatchCase {
+    patterns: [CheckedMatchPattern]
+    body: CheckedMatchBody
+}
+
+enum CheckedMatchPattern {
     defaults: [CheckedStatement]
 
-    EnumVariant(name: String, args: [EnumVariantPatternArgument], subject_type_id: TypeId, index: usize, scope_id: ScopeId, body: CheckedMatchBody, marker_span: Span)
-    Expression(expression: CheckedExpression, body: CheckedMatchBody, marker_span: Span)
-    ClassInstance(type: TypeId, body: CheckedMatchBody, rebind_name: ClassInstanceRebind?, marker_span: Span)
-    CatchAll(has_arguments: bool, body: CheckedMatchBody, marker_span: Span)
+    EnumVariant(name: String, args: [EnumVariantPatternArgument], subject_type_id: TypeId, index: usize, scope_id: ScopeId, marker_span: Span)
+    Expression(expression: CheckedExpression, marker_span: Span)
+    ClassInstance(type: TypeId, rebind_name: ClassInstanceRebind?, marker_span: Span)
+    CatchAll(has_arguments: bool, marker_span: Span)
 }
 
 struct OperatorTraitImplementation {
@@ -1770,11 +1775,9 @@ boxed enum CheckedExpression {
         Match(expr, match_cases, span, type_id, all_variants_constant) => {
             mut control_flow: BlockControlFlow? = None
             for case_ in match_cases {
-                let case_control_flow = match case_ {
-                    else(body) => match body {
-                        Block(block) => block.control_flow
-                        Expression(expr) => expr.control_flow()
-                    }
+                let case_control_flow = match case_.body {
+                    Block(block) => block.control_flow
+                    Expression(expr) => expr.control_flow()
                 }
                 if control_flow.has_value() {
                     control_flow = control_flow!.branch_unify_with(case_control_flow)


### PR DESCRIPTION
Jakt now keeps the match patterns grouped by case because there are ways to avoid duplicating the code
once we know more about the types in codegen.

Typechecker still does the same amount of work as before since I haven't explored the consequences of not duplicating at the parser level.
Codegen does less work sometimes because joining multiple patterns also means generating the match body less times.

For selfhost, a big example of these kicking into action is
`typecheck_binary_operation`. I gathered the amount of lines of formatted C++
of the function on each output and time it takes to parse an unformatted
`typecheck_binary_operation`:

|Commit|Lines of formatted code|
|---|---|
|`main`        | 5518|
|This commit   | 349|


|Commit         |Time spent in `ParseFunctionDefinition`
|---      |      ---|
|`main`         |679.844 ms|
|This commit    |140.195 ms|

And this commit removes ~600 KB from selfhost C++ output.

|Commit         |KB of generated C++ code for selfhost|
|---            |---|
|`main`         |6173|
|This commit    |5534|

The command used to build the compiler into each dir is the following:

```sh
<compiler-binary> -B <test-builddir> -R runtime selfhost/main.jakt --extra-cpp-flag -ftime-trace -J16 --runtime-library-path $(realpath build/lib)
```

Where `<compiler-binary>` has been either `jakt_stage2` from this commit's build or `jakt_stage1`, built from `main`'s sources and copied into a binary separate from `build/bin`.
This command includes `-ftime-trace`, which generates `*.json` files in the build directory. Those files can be analyzed individually, e.g `typechecker.json` for `typecheck_binary_operation`,
or you can get a summary from `ClangBuildAnalyzer`:

- For individual analysis, I can't parse an X KB unformatted JSON visually, so I used `jq` to extract the information:
```sh
jq '.traceEvents.[] | select(.args?.detail == "typecheck_binary_operation")' <test-builddir>/typechecker.json
```
```json
{
  "pid": 111440,
  "tid": 111440,
  "ph": "X",
  "ts": 3883461,
  "dur": 907656,
  "name": "ParseFunctionDefinition",
  "args": {
    "detail": "typecheck_binary_operation"
  }
}
```

- For a summary, I just had to create the build dir previous to the Jakt command:
```sh
mkdir <test-builddir>
ClangBuildAnalyzer --start <test-builddir>
<compiler-binary> -B <test-builddir>  # ... (see above)
ClangBuildAnalyzer --stop <test-builddir> <test-buildir>/build.bin
ClangBuildAnalyzer --analyze <test-builddir>/build.bin
```

Note that the summaries include more or less the same information I displayed: a couple of functions that have patterns without bindings with the same match bodies are processed in substantially less time.

PD: on CI I saw that this is a nice PR for macOS users: 40% decrease on compilation time and 20% decrease on test time :P. GH's ubuntu did roughly the same time for testing and 14% less on test time :D. For Windows we only do stage1 so I can't make any comparisons.