### PR TITLE
codegen: Use ExplicitValueOrControlFlow sparingly

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -3518,21 +3518,24 @@ struct CodeGenerator {
         builder.append(.codegen_function_return_type(function: .current_function!))
         builder.append(">{\n")
 
-        if expr_type is Enum(enum_id) {
-            .codegen_enum_match(
-                enum_: .program.get_enum(enum_id)
-                expr
-                match_cases
-                type_id
-                output: &mut builder
-            )
-        } else {
-            .codegen_generic_match(
-                expr
-                cases: match_cases
-                return_type_id: type_id
-                output: &mut builder
-            )
+        match expr_type {
+            Enum(enum_id) | GenericEnumInstance(id: enum_id) => {
+                .codegen_enum_match(
+                    enum_: .program.get_enum(enum_id)
+                    expr
+                    match_cases
+                    type_id
+                    output: &mut builder
+                )
+            }
+            else => {
+                .codegen_generic_match(
+                    expr
+                    cases: match_cases
+                    return_type_id: type_id
+                    output: &mut builder
+                )
+            }
         }
         builder.append("}()\n)")
 
@@ -3551,17 +3554,6 @@ struct CodeGenerator {
         return_type_id: TypeId
         output: &mut StringBuilder
     ) throws {
-        mut is_generic_enum: bool = false
-        for case_ in cases {
-            for pattern in case_.patterns {
-                if pattern is EnumVariant {
-                    is_generic_enum = true
-                    break
-                }
-            }
-            if is_generic_enum { break }
-        }
-
         let byte_string_type_id = .program.find_or_add_type_id(
             type: Type::Struct(.program.find_struct_in_prelude("String"))
             module_id: .program.prelude_module_id()
@@ -3569,13 +3561,9 @@ struct CodeGenerator {
 
         // TODO: Use switch statement if all values are constant
 
-        if is_generic_enum {
-            output.append("auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer(")
-        } else {
-            output.append("auto __jakt_enum_value = (")
-        }
+        output.append("auto __jakt_enum_value = ")
         .codegen_expression(expr, &mut output)
-        output.append(");\n")
+        output.append(";\n")
 
         mut first = true
 
@@ -3789,7 +3777,7 @@ struct CodeGenerator {
                         EnumVariant(name, args, subject_type_id, index, scope_id) => {
                             let enum_type = .program.get_type(subject_type_id)
                             let enum_id = match enum_type {
-                                Enum(id) => id
+                                Enum(id) | GenericEnumInstance(id) => id
                                 else => {
                                     panic("Expected enum type")
                                 }

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -3512,14 +3512,18 @@ struct CodeGenerator {
         .yield_method = YieldMethod::ReturnExplicitValue(ctor: format("JaktInternal::ExplicitValue<{}>", cpp_match_result_type))
         defer .yield_method = old_yield_method
 
+        builder.append("([&]() -> JaktInternal::ExplicitValueOrControlFlow<")
+        builder.append(cpp_match_result_type)
+        builder.append(", ")
+        builder.append(.codegen_function_return_type(function: .current_function!))
+        builder.append(">{\n")
+
         if expr_type is Enum(enum_id) {
             .codegen_enum_match(
                 enum_: .program.get_enum(enum_id)
                 expr
                 match_cases
                 type_id
-                cpp_match_result_type
-                all_variants_constant
                 output: &mut builder
             )
         } else {
@@ -3527,11 +3531,11 @@ struct CodeGenerator {
                 expr
                 cases: match_cases
                 return_type_id: type_id
-                cpp_match_result_type
-                all_variants_constant
                 output: &mut builder
             )
         }
+        builder.append("}()\n)")
+
         .control_flow_state = last_control_flow
         output.append(.control_flow_state.apply_control_flow_macro(
             builder.to_string()
@@ -3545,8 +3549,6 @@ struct CodeGenerator {
         expr: CheckedExpression
         cases: [CheckedMatchCase]
         return_type_id: TypeId
-        cpp_match_result_type: String
-        all_variants_constant: bool
         output: &mut StringBuilder
     ) throws {
         mut is_generic_enum: bool = false
@@ -3559,7 +3561,6 @@ struct CodeGenerator {
             }
             if is_generic_enum { break }
         }
-        let match_values_all_constant = all_variants_constant and not is_generic_enum
 
         let byte_string_type_id = .program.find_or_add_type_id(
             type: Type::Struct(.program.find_struct_in_prelude("String"))
@@ -3567,11 +3568,6 @@ struct CodeGenerator {
         )
 
         // TODO: Use switch statement if all values are constant
-        output.appendff(
-            "([&]() -> JaktInternal::ExplicitValueOrControlFlow<{},{}> {{\n"
-            cpp_match_result_type,
-            .codegen_function_return_type(function: .current_function!)
-        )
 
         if is_generic_enum {
             output.append("auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer(")
@@ -3716,8 +3712,6 @@ struct CodeGenerator {
         } else if deferred_catch_all is None {
             output.append("VERIFY_NOT_REACHED();\n")
         }
-
-        output.append("}())")
     }
 
     fn codegen_generic_pattern_condition(mut this, pattern: &CheckedMatchPattern, is_parenthesized: bool, output: &mut StringBuilder) throws {
@@ -3764,8 +3758,6 @@ struct CodeGenerator {
         expr: CheckedExpression
         match_cases: [CheckedMatchCase]
         type_id: TypeId
-        cpp_match_result_type: String
-        all_variants_constant: bool
         output: &mut StringBuilder
     ) throws {
         mut subject_builder = StringBuilder::create()
@@ -3774,11 +3766,6 @@ struct CodeGenerator {
         let needs_deref = enum_.is_boxed and subject != "*this"
 
         if enum_.underlying_type_id == void_type_id() {
-            output.append("([&]() -> JaktInternal::ExplicitValueOrControlFlow<")
-            output.append(cpp_match_result_type)
-            output.append(", ")
-            output.append(.codegen_function_return_type(function: .current_function!))
-            output.append(">{\n")
             output.append("auto&& __jakt_match_variant = ")
             if needs_deref {
                 output.append("*")
@@ -3920,13 +3907,7 @@ struct CodeGenerator {
                 output.append("default: VERIFY_NOT_REACHED();")
             }
             output.append("}/*switch end*/\n")
-            output.append("}()\n)")
         } else {
-            output.append("([&]() -> JaktInternal::ExplicitValueOrControlFlow<")
-            output.append(cpp_match_result_type)
-            output.append(", ")
-            output.append(.codegen_function_return_type(function: .current_function!))
-            output.append(">{\n")
             output.append("switch (")
             .codegen_expression(expr, &mut output)
             output.append(") {\n")
@@ -3948,7 +3929,6 @@ struct CodeGenerator {
                 .codegen_match_body(body: match_case.body, return_type_id: type_id, &mut output)
             }
             output.append("}/*switch end*/\n")
-            output.append("}()\n)")
         }
     }
 

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -204,6 +204,8 @@ enum YieldMethod {
     // the template is for JaktInternal::Explicit
     ReturnExplicitValue(ctor: String)
     AssignAndGoto(name: String, label: String)
+    // act as if `yield` == `return`
+    Return
 }
 
 
@@ -3518,25 +3520,7 @@ struct CodeGenerator {
         builder.append(.codegen_function_return_type(function: .current_function!))
         builder.append(">{\n")
 
-        match expr_type {
-            Enum(enum_id) | GenericEnumInstance(id: enum_id) => {
-                .codegen_enum_match(
-                    enum_: .program.get_enum(enum_id)
-                    expr
-                    match_cases
-                    type_id
-                    output: &mut builder
-                )
-            }
-            else => {
-                .codegen_generic_match(
-                    expr
-                    cases: match_cases
-                    return_type_id: type_id
-                    output: &mut builder
-                )
-            }
-        }
+        .codegen_inner_match(expr, match_cases, type_id, output: &mut builder)
         builder.append("}()\n)")
 
         .control_flow_state = last_control_flow
@@ -3545,6 +3529,48 @@ struct CodeGenerator {
             func_return_type: .current_function!.return_type_id
             func_can_throw: .current_function!.can_throw
         ))
+    }
+
+    fn codegen_inner_match(
+        mut this
+        expr: CheckedExpression
+        match_cases: [CheckedMatchCase]
+        type_id: TypeId
+        output: &mut StringBuilder
+    ) throws -> void => match .program.get_type(expr.type()) {
+        Enum(enum_id) | GenericEnumInstance(id: enum_id) => {
+            .codegen_enum_match(
+                enum_: .program.get_enum(enum_id)
+                expr
+                match_cases
+                type_id
+                &mut output
+            )
+        }
+        else => {
+            .codegen_generic_match(
+                expr
+                cases: match_cases
+                return_type_id: type_id
+                &mut output
+            )
+        }
+    }
+
+    fn codegen_returned_match(
+        mut this
+        expr: CheckedExpression
+        match_cases: [CheckedMatchCase]
+        type_id: TypeId
+        output: &mut StringBuilder
+    ) throws {
+        let old_yield_method = .yield_method
+        defer .yield_method = old_yield_method
+        .yield_method = YieldMethod::Return
+
+        output.append('{')
+        .codegen_inner_match(expr, match_cases, type_id, output)
+        output.append('}')
     }
 
     fn codegen_generic_match(
@@ -3695,7 +3721,7 @@ struct CodeGenerator {
             .codegen_match_body(body, return_type_id, &mut output)
             output.append('}')
         }
-        if return_type_id == void_type_id() or return_type_id == unknown_type_id() {
+        if not has_cpp_value(return_type_id) and .yield_method! is ReturnExplicitValue {
             output.append("return JaktInternal::ExplicitValue<void>();\n")
         } else if deferred_catch_all is None {
             output.append("VERIFY_NOT_REACHED();\n")
@@ -3918,6 +3944,13 @@ struct CodeGenerator {
             }
             output.append("}/*switch end*/\n")
         }
+
+        if .yield_method! is Return and are_loop_exits_allowed(.control_flow_state.allowed_exits) {
+            // Any `break` statements inside the switch will go here. This
+            // enables any `break` inside any nested `switch` to eventually
+            // find its way to break the loop it refers to.
+            output.append(.break_statement())
+        }
     }
 
     fn codegen_match_body(
@@ -3930,7 +3963,7 @@ struct CodeGenerator {
             Block(block) => {
                 .codegen_block(block, output)
 
-                if return_type_id == void_type_id() or return_type_id == unknown_type_id() {
+                if not has_cpp_value(return_type_id) and .yield_method! is ReturnExplicitValue {
                     output.append("return JaktInternal::ExplicitValue<void>();\n")
                 }
             }
@@ -3940,17 +3973,28 @@ struct CodeGenerator {
                     .codegen_block(block, output)
                     // NOTE: should not need any guarding
                     output.append("VERIFY_NOT_REACHED();\n")
-                } else if expr.type() == void_type_id() or expr.type() == never_type_id() or (
-                    expr.type() == unknown_type_id() and
-                    not expr is OptionalNone
-                ) {
-                    output.append("return ({")
-                    .codegen_expression(expr, &mut output)
-                    output.append(";}), JaktInternal::ExplicitValue<void>();\n")
                 } else {
-                    output.append("return JaktInternal::ExplicitValue(")
-                    .codegen_expression(expr, &mut output)
-                    output.append(");\n")
+
+                    match .yield_method! {
+                        Return => .codegen_value_return(expr, &mut output)
+                        ReturnExplicitValue => {
+                            if expr.type() == void_type_id() or expr.type() == never_type_id() or (
+                                expr.type() == unknown_type_id() and
+                                not expr is OptionalNone
+                            ) {
+                                output.append("return ({")
+                                .codegen_expression(expr, &mut output)
+                                output.append(";}), JaktInternal::ExplicitValue<void>();\n")
+                            } else {
+                                output.append("return JaktInternal::ExplicitValue(")
+                                .codegen_expression(expr, &mut output)
+                                output.append(");\n")
+                            }
+                        }
+                        else => {
+                            panic("yield method inside match is expected to be one of ReturnExplicitValue or Return")
+                        }
+                    }
                 }
             }
         }
@@ -4699,6 +4743,11 @@ struct CodeGenerator {
         output.append("}\n")
     }
 
+    fn break_statement(this) -> StringView => match .control_flow_state.directly_inside_match {
+        true => "return JaktInternal::LoopBreak{};"
+        false => "break;"
+    }
+
     fn codegen_statement(
         mut this
         statement: CheckedStatement
@@ -4722,10 +4771,7 @@ struct CodeGenerator {
                 })
             }
             Break => {
-                output.append(match .control_flow_state.directly_inside_match {
-                    true => "return JaktInternal::LoopBreak{};"
-                    false => "break;"
-                })
+                output.append(.break_statement())
             }
             Expression(expr) => {
                 .codegen_expression(expr, &mut output)
@@ -4748,35 +4794,7 @@ struct CodeGenerator {
                 .control_flow_state = last_control_flow
                 .inside_defer = old_inside_defer
             }
-            Return(val) => match val.has_value() {
-                true => match .current_function!.can_throw {
-                    true => {
-                        let type = .program.get_type(val!.type())
-                        mut result = ""
-                        if type is Void or type is Never {
-                            .codegen_expression(val!, &mut output)
-                            output.append("; return {}")
-                        } else {
-                            // Disable forwarding with TRY because we're returning an ErrorOr<Ret> too!
-                            output.append("return ")
-                            .codegen_expression(val!, &mut output, forward_error_with_try: false)
-                        }
-
-                        output.append(";")
-                    }
-                    false => {
-                        output.append("return ")
-                        .codegen_expression(val!, &mut output)
-                        output.append(";")
-                    }
-                }
-                false => {
-                    output.append(match .current_function!.can_throw or .control_flow_state.indirectly_inside_match {
-                        true => "return {};"
-                        false => "return;"
-                    })
-                }
-            }
+            Return(val) => .codegen_return(val, &mut output)
             Loop(block) => {
                 if .debug_info.statement_span_comments and statement.span().has_value() {
                     output.appendff("\n#line {}\n", .debug_info.span_to_source_location(statement.span()!))
@@ -4858,6 +4876,9 @@ struct CodeGenerator {
             Yield(expr, span) => {
                 let is_void = expr.has_value() and expr!.type() == void_type_id()
                 match .yield_method! {
+                    Return => {
+                        .codegen_return(expr, &mut output)
+                    }
                     ReturnExplicitValue(ctor) => {
                         if is_void {
                             .codegen_statement(statement: CheckedStatement::Expression(expr: expr!, span), &mut output)
@@ -4890,6 +4911,40 @@ struct CodeGenerator {
         }
     }
 
+    fn codegen_return(mut this, anon val: CheckedExpression?, output: &mut StringBuilder) throws -> void => match val.has_value() {
+        true => .codegen_value_return(val!, &mut output)
+        false => {
+            output.append(match .current_function!.can_throw or .control_flow_state.indirectly_inside_match {
+                true => "return {};"
+                false => "return;"
+            })
+        }
+    }
+
+    fn codegen_value_return(mut this, anon val: CheckedExpression, output: &mut StringBuilder) throws -> void => match val {
+        Match(expr, match_cases, type_id) => .codegen_returned_match(expr, match_cases, type_id, &mut output)
+        else => match .current_function!.can_throw {
+            true => {
+                let type = .program.get_type(val.type())
+                mut result = ""
+                if type is Void or type is Never {
+                    .codegen_expression(val, &mut output)
+                    output.append("; return {}")
+                } else {
+                    // Disable forwarding with TRY because we're returning an ErrorOr<Ret> too!
+                    output.append("return ")
+                    .codegen_expression(val, &mut output, forward_error_with_try: false)
+                }
+
+                output.append(";")
+            }
+            false => {
+                output.append("return ")
+                .codegen_expression(val, &mut output)
+                output.append(";")
+            }
+        }
+    }
 
     fn codegen_type(mut this, anon type_id: TypeId) throws -> String {
         return .codegen_type_possibly_as_namespace(type_id, as_namespace: false)
@@ -5783,3 +5838,5 @@ fn count_match_cases(anon cases: &[CheckedMatchCase]) -> usize {
     }
     return count
 }
+
+fn has_cpp_value(anon type_id: TypeId) -> bool => type_id != void_type_id() and type_id != never_type_id()

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -3503,6 +3503,11 @@ struct CodeGenerator {
         all_variants_constant: bool
         output: &mut StringBuilder
     ) throws {
+
+        if not has_cpp_value(type_id) {
+            return .codegen_void_match(expr, match_cases, type_id, output)
+        }
+
         mut builder = StringBuilder::create()
         let last_control_flow = .control_flow_state
         .control_flow_state = .control_flow_state.enter_match()
@@ -3555,6 +3560,28 @@ struct CodeGenerator {
                 &mut output
             )
         }
+    }
+
+
+    fn codegen_void_match(
+        mut this
+        expr: CheckedExpression
+        match_cases: [CheckedMatchCase]
+        type_id: TypeId
+        output: &mut StringBuilder
+    ) throws {
+        let old_yield_method = .yield_method
+        let label = .fresh_label()
+        defer .yield_method = old_yield_method
+        .yield_method = YieldMethod::AssignAndGoto(name: "__VOID_MATCH_HAS_NO_VALUE", label)
+
+        output.append('{')
+        .codegen_inner_match(expr, match_cases, type_id, output)
+        output.append('}')
+
+        // This `goto` is here so that the label is used at least once.
+        // We could be smarter here and track goto usage.
+        output.appendff("goto {0}; {0}:;", label)
     }
 
     fn codegen_returned_match(
@@ -3721,9 +3748,8 @@ struct CodeGenerator {
             .codegen_match_body(body, return_type_id, &mut output)
             output.append('}')
         }
-        if not has_cpp_value(return_type_id) and .yield_method! is ReturnExplicitValue {
-            output.append("return JaktInternal::ExplicitValue<void>();\n")
-        } else if deferred_catch_all is None {
+
+        if (has_cpp_value(return_type_id) or not .yield_method! is ReturnExplicitValue) and deferred_catch_all is None {
             output.append("VERIFY_NOT_REACHED();\n")
         }
     }
@@ -3945,11 +3971,15 @@ struct CodeGenerator {
             output.append("}/*switch end*/\n")
         }
 
-        if .yield_method! is Return and are_loop_exits_allowed(.control_flow_state.allowed_exits) {
-            // Any `break` statements inside the switch will go here. This
-            // enables any `break` inside any nested `switch` to eventually
-            // find its way to break the loop it refers to.
-            output.append(.break_statement())
+        if are_loop_exits_allowed(.control_flow_state.allowed_exits) {
+            match .yield_method! {
+                // Any `break` statements inside the switch will go here. This
+                // enables any `break` inside any nested `switch` to eventually
+                // find its way to break the loop it refers to.
+                Return | AssignAndGoto => output.append(.break_statement())
+                // Here all `break`s and `continue`s should have used `LoopBreak` and `LoopContinue` from EVOCF.
+                ReturnExplicitValue => {}
+            }
         }
     }
 
@@ -3963,8 +3993,12 @@ struct CodeGenerator {
             Block(block) => {
                 .codegen_block(block, output)
 
-                if not has_cpp_value(return_type_id) and .yield_method! is ReturnExplicitValue {
-                    output.append("return JaktInternal::ExplicitValue<void>();\n")
+                if not has_cpp_value(return_type_id) {
+                    match .yield_method! {
+                        Return => .codegen_return(None, &mut output)
+                        ReturnExplicitValue => { panic("Void match should not be using ExplicitValue") }
+                        AssignAndGoto(label) => output.appendff("goto {};", label)
+                    }
                 }
             }
             Expression(expr) => {
@@ -3982,17 +4016,19 @@ struct CodeGenerator {
                                 expr.type() == unknown_type_id() and
                                 not expr is OptionalNone
                             ) {
-                                output.append("return ({")
-                                .codegen_expression(expr, &mut output)
-                                output.append(";}), JaktInternal::ExplicitValue<void>();\n")
+                                panic("Void match should not be using ExplicitValue")
                             } else {
                                 output.append("return JaktInternal::ExplicitValue(")
                                 .codegen_expression(expr, &mut output)
                                 output.append(");\n")
                             }
                         }
-                        else => {
-                            panic("yield method inside match is expected to be one of ReturnExplicitValue or Return")
+                        AssignAndGoto(label) => {
+                            guard not has_cpp_value(expr.type()) else {
+                                panic("Only matches yielding void can use AssignAndGoto")
+                            }
+                            .codegen_expression(expr, &mut output)
+                            output.appendff(";goto {};", label)
                         }
                     }
                 }
@@ -4892,11 +4928,15 @@ struct CodeGenerator {
                         output.append(");")
                     }
                     AssignAndGoto(name, label) => {
-                        if not is_void and expr.has_value() {
-                            output.append(name)
-                            output.append(" = ")
-                            .codegen_expression(expr!, &mut output)
-                            output.append("; ")
+                        if expr is Some(val) {
+                            if is_void {
+                                .codegen_expression(val, &mut output)
+                                output.append(';')
+                            } else {
+                                output.appendff("{}.emplace(", name)
+                                .codegen_expression(val, &mut output)
+                                output.append(");")
+                            }
                         }
                         output.append("goto ")
                         output.append(label)

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -204,7 +204,7 @@ enum YieldMethod {
     // the template is for JaktInternal::Explicit
     ReturnExplicitValue(ctor: String)
     AssignAndGoto(name: String, label: String)
-    // act as if `yield` == `return`
+    // act as if `yield` == `return`.
     Return
 }
 
@@ -228,10 +228,12 @@ struct CodeGenerator {
     // Modules that this generation depends on, detected from type definitions
     used_modules: {ModuleId} = {}
     yield_method: YieldMethod? = None
+    // Whether the latest output needs to use ErrorOr as return value.
+    restricted(codegen_value_match, current_error_handler, codegen_statement) yields_erroror: bool = false
 
     // `forward_error_with_try` controls whether errors are handled through the TRY() macro or through an external mechanism put by the caller.
     // noreturn functions may not throw, so let them crash instead.
-    fn current_error_handler(this, forward_error_with_try: bool = true) -> String {
+    fn current_error_handler(mut this, forward_error_with_try: bool = true) -> String {
         if .inside_defer or (
             .current_function.has_value() and
             .current_function!.return_type_id == never_type_id() and
@@ -241,6 +243,7 @@ struct CodeGenerator {
             return "MUST"
         }
 
+        .yields_erroror = true
         if forward_error_with_try {
             if .control_flow_state.indirectly_inside_try_block {
                 // We can't use TRY() as that would return errors instead of forwarding them to the corresponding catch block.
@@ -3150,7 +3153,7 @@ struct CodeGenerator {
                 output.append(var.name_for_codegen().as_name_for_use())
             }
             Match(expr, match_cases, type_id, all_variants_constant) => {
-                .codegen_match(expr, match_cases, type_id, all_variants_constant, &mut output)
+                .codegen_match(expr, match_cases, type_id, all_variants_constant, forward_error_with_try, &mut output)
             }
             EnumVariantArg(expr, arg, enum_variant) => {
                 let variant_name = enum_variant.name()
@@ -3501,11 +3504,16 @@ struct CodeGenerator {
         match_cases: [CheckedMatchCase]
         type_id: TypeId
         all_variants_constant: bool
+        forward_error_with_try: bool
         output: &mut StringBuilder
     ) throws {
 
         if not has_cpp_value(type_id) {
             return .codegen_void_match(expr, match_cases, type_id, output)
+        }
+
+        if not has_control_flow(match_cases) {
+            return .codegen_value_match(expr, match_cases, type_id, forward_error_with_try, output)
         }
 
         mut builder = StringBuilder::create()
@@ -3534,6 +3542,46 @@ struct CodeGenerator {
             func_return_type: .current_function!.return_type_id
             func_can_throw: .current_function!.can_throw
         ))
+    }
+
+    fn codegen_value_match(
+        mut this
+        expr: CheckedExpression
+        match_cases: [CheckedMatchCase]
+        type_id: TypeId
+        forward_error_with_try: bool
+        output: &mut StringBuilder
+    ) throws {
+        let old_yields_erroror = .yields_erroror
+        .yields_erroror = false
+
+
+        mut inner = StringBuilder::create()
+        {
+            let old_yield_method = .yield_method
+            let old_cf = .control_flow_state
+            defer .yield_method = old_yield_method
+            defer .control_flow_state = old_cf
+            .control_flow_state = .control_flow_state.enter_match()
+            // we know that there is no control flow inside this match so inside the IIFE it should just be able to return.
+            .control_flow_state.allowed_exits = AllowedControlExits::JustReturn
+            .yield_method = YieldMethod::Return
+
+            .codegen_inner_match(expr, match_cases, type_id, output: &mut inner)
+        }
+
+
+        let handler = match .yields_erroror { true => .current_error_handler(forward_error_with_try), false => "" }
+        .yields_erroror |= old_yields_erroror
+
+
+        // The newlines in between help clang-format disambiguate and prevent
+        // it from bailing out and leaving things unformatted.
+        if not handler.is_empty() {
+            output.appendff("{}(([&]() -> ErrorOr<{}> {{ {} \n}}()))", handler, .codegen_type(type_id), inner.to_string())
+        } else {
+            output.appendff("[&]() -> {} {{ {} \n}}()", .codegen_type(type_id), inner.to_string())
+        }
     }
 
     fn codegen_inner_match(
@@ -4796,6 +4844,7 @@ struct CodeGenerator {
 
         match statement {
             Throw(expr) => {
+                .yields_erroror = true
                 output.append("return ")
                 .codegen_expression(expr, &mut output)
                 output.append(";")
@@ -5880,3 +5929,81 @@ fn count_match_cases(anon cases: &[CheckedMatchCase]) -> usize {
 }
 
 fn has_cpp_value(anon type_id: TypeId) -> bool => type_id != void_type_id() and type_id != never_type_id()
+
+fn has_control_flow<T>(anon any_of: [T], include_loop_control_flow: bool = true) -> bool {
+    for t in any_of {
+        if has_control_flow(t, include_loop_control_flow) { return true }
+    }
+    return false
+}
+
+fn has_control_flow<T>(anon maybe_v: T?, include_loop_control_flow: bool = true) -> bool => maybe_v is Some and has_control_flow(maybe_v!, include_loop_control_flow)
+
+fn has_control_flow(anon match_case: CheckedMatchCase, include_loop_control_flow: bool = true) -> bool => match match_case.body {
+    Block(t) | Expression(t) => has_control_flow(t, include_loop_control_flow)
+}
+
+fn has_control_flow(anon block: CheckedBlock, include_loop_control_flow: bool = true) -> bool => has_control_flow(block.statements, include_loop_control_flow)
+
+fn has_control_flow(anon stmt: CheckedStatement, include_loop_control_flow: bool = true) -> bool => match stmt {
+    Expression(expr) => has_control_flow(expr, include_loop_control_flow)
+    // throw is not considered control flow because it uses the return value to forward errors, which is declared by the surrounding IIFE.
+    Defer | Throw | Yield | Garbage => false
+    DestructuringAssignment(var_decl) => has_control_flow(var_decl, include_loop_control_flow)
+    VarDecl(init) => has_control_flow(init, include_loop_control_flow)
+    If(condition, then_block, else_statement) => has_control_flow(condition, include_loop_control_flow) or has_control_flow(then_block, include_loop_control_flow) or has_control_flow(else_statement, include_loop_control_flow)
+    Block(block) => has_control_flow(block, include_loop_control_flow)
+    Loop(block) => has_control_flow(block, include_loop_control_flow: false)
+    While(condition, block) => has_control_flow(condition, include_loop_control_flow) or has_control_flow(block, include_loop_control_flow: false)
+    // we want to keep `InlineCpp` as flexible as possible, so we'll assume that it could have control flow. As long as it knows that it's inside a match
+    // and it has to forward things through EVOCF it can get the behavior it wants.
+    Return | InlineCpp => true
+    Break | Continue => include_loop_control_flow
+}
+fn has_control_flow(anon expr: CheckedExpression, include_loop_control_flow: bool = true) -> bool => match expr {
+    Boolean
+        | NumericConstant
+        | QuotedString
+        | ByteConstant
+        | CharacterConstant
+        | CCharacterConstant
+        | NamespacedVar
+        | Var
+        | OptionalNone
+        | Function
+        | DependentFunction
+        | Reflect
+        | Garbage
+        => false
+
+    UnaryOp(expr)
+        | IndexedTuple(expr)
+        | IndexedStruct(expr)
+        | IndexedCommonEnumMember(expr)
+        | EnumVariantArg(expr)
+        | OptionalSome(expr)
+        | ForcedUnwrap(expr)
+        | Must(expr)
+        => has_control_flow(expr, include_loop_control_flow)
+
+    BinaryOp(lhs, rhs)
+        | IndexedExpression(expr: lhs, index: rhs)
+        | IndexedDictionary(expr: lhs, index: rhs)
+        | ComptimeIndex(expr: lhs, index: rhs)
+        => has_control_flow(lhs, include_loop_control_flow) or has_control_flow(rhs, include_loop_control_flow)
+
+    JaktTuple(vals) | JaktArray(vals) | JaktSet(vals) => has_control_flow(vals, include_loop_control_flow)
+    Range(from, to) => has_control_flow(from, include_loop_control_flow) or has_control_flow(to, include_loop_control_flow)
+    JaktDictionary(vals) => has_control_flow(vals, include_loop_control_flow)
+    // We want to force loop control flow checks on inner matches because that means that they will use EVOCF, which use `return` to forward a possible
+    // request to return from the Jakt function, independent of what control flow the inner IIFE actually produces.
+    Match(expr, match_cases) => has_control_flow(expr, include_loop_control_flow) or has_control_flow(match_cases, include_loop_control_flow: true)
+    Call(call) => has_control_flow(call.args, include_loop_control_flow)
+    MethodCall(expr, call) => has_control_flow(expr, include_loop_control_flow) or has_control_flow(call.args, include_loop_control_flow)
+    Block(block) => has_control_flow(block, include_loop_control_flow)
+    Try(expr, catch_block) => has_control_flow(expr, include_loop_control_flow) or has_control_flow(catch_block, include_loop_control_flow)
+    TryBlock(stmt, catch_block) => has_control_flow(stmt, include_loop_control_flow) or has_control_flow(catch_block, include_loop_control_flow)
+}
+
+fn has_control_flow(anon dict_pair: (CheckedExpression, CheckedExpression), include_loop_control_flow: bool = true) -> bool => has_control_flow(dict_pair.0, include_loop_control_flow) or has_control_flow(dict_pair.1, include_loop_control_flow)
+fn has_control_flow(anon call_arg: (String, CheckedExpression), include_loop_control_flow: bool = true) -> bool => has_control_flow(call_arg.1, include_loop_control_flow)


### PR DESCRIPTION
ExplicitValueOrControlFlow (from now EVOCF) is only required when using control
flow features like `return`(ing from a function), `continue` or `break` inside
a match that yields a value, because yielding a value requires usage of an
IIFE. If those features aren't used, or the match doesn't yield a value, there
is no need to forward any control flow through the return channel.

This removes EVOCF instantiations from the clang -ftime-trace profile, since
most matches don't require `AK::Variant`s.
