### PR TITLE
typechecker+codegen: Emit new bodies for bindings with different types

### DIFF
--- a/documentation/pattern-match-avoid-duplication.md
+++ b/documentation/pattern-match-avoid-duplication.md
@@ -1,0 +1,293 @@
+# How Jakt avoids code duplication in pattern matching codegen
+
+## Current solution
+
+Typechecker walks the patterns to get the type information out of them as it
+did before, but instead of adding binding variables to a scope, it adds
+them to a `BindingKeyBuilder`. Typechecker "submits" bindings to the builder,
+which then produces a `BindingKey` that tells us whether the set of bindings
+that were declared already exist within the same pattern group.
+
+Since we don't want to be passing a lot of state regarding the match to helper
+functions like `.typecheck_match_variant`, `BindingKeyBuilder` only contains a
+reference to the slice of cases that have been declared and refer to the same
+`ParsedMatchBody`. Remember that it could be multiple due to Constraint 1.
+
+To enforce that the set of cases checked by `BindingKeyBuilder` are the correct
+set, and that context is not lost when reading through the long loop bodies of
+`.typecheck_match`, all the state regarding match typecheck is in
+`MatchBuilder`. This struct has two functionalities:
+
+1.  It will not let us create a `BindingKeyBuilder` until we provide a proof
+    that we have started a case. Such proof tracks the start of the case
+    slice that `BindingKeyBuilder` should use. This is in place to avoid copy-paste
+    mishaps, since the logic for traversing the matches is big and changes depending on
+    the type to be matched.
+
+2.  When finishing a pattern, we give it a `BindingKey` along a match body and
+    said pattern, and it will register the pattern into the `CheckedMatchCase`
+    that the `BindingKey` tells it to. The parsed body will be (re-)typechecked
+    against the bindings for this finished pattern only when the bindings of the
+    new pattern have different types than the rest of the previously checked
+    patterns.
+
+`BindingKeyBuilder` keeps track of what bindings were declared by the
+typechecker, in case we have to generate a new `CheckedMatchBody`, and the set
+of candidates that could match the set of bindings that have been submitted.
+
+Since `BindingKeyBuilder` works in a binding-per-binding basis, we could have
+multiple sets that match the partial set of bindings. The `finish()` method is
+called when the build is done, so we know that there are no more bindings
+flying in and we can make a final pass on our candidates, selecting only the
+`CheckedMatchCase` that has the same amount of bindings as what we've gathered
+so far.
+
+The usage of `BindingKeyBuilder` helps us reduce the amount of dictionaries
+that are created and deleted during the typechecking phase, since builders that
+stay in their `Empty` state do not contain references to empty
+dictionaries.
+
+
+## Constraints
+
+The solution above is designed to feed codegen with more information on the
+structure of matches, avoid duplicate work whenever possible and keep
+correctness while doing so.
+
+We can summarize these features in two constraints, discussed in this section
+after a brief on pattern matching terminology.
+
+### Terminology
+
+
+```jakt
+match <expr> {
+    <pat1>(<binding1>...) | <pat2>(<binding2>...) => <body1>
+    <pat3> => <body2>
+}
+```
+
+- `expr` is the "matched value", or "value". It is the value we wish to branch
+on.
+- `pat1`, `pat2` and `pat3` are "patterns". They are different structures that
+the matched value may conform to.
+- `binding1` and `binding2` are "bindings". They are variables that extract
+different parts of the structure that the value is checked to conform to. We
+can then use those variables inside `<body1>`.
+- `body1` and `body2` are "bodies". They are the pieces of code that we want to
+execute on certain cases.
+- `pat1` and `pat2` form a "pattern group". Matching either of them will branch
+to the code specified in `<body1>`.
+- Pattern groups and bodies together form a "case". Each case has a single body
+and a group of patterns.
+
+
+### Constraint 1: Multiple binding types
+
+Jakt allows us to use bindings of different types in the same pattern group, as
+long as the body typechecks against both "versions" of the bindings. For an
+illustration, take this valid Jakt sample:
+
+```jakt
+enum TypedPair {
+    I32(a: i32, b: i32)
+    U64(a: u64, b: u64)
+}
+
+
+fn get_pair() -> TypedPair { ... }
+
+fn main() {
+    match get_pair() {
+        I32(a, b) | U64(a, b) => {
+            let result = a + b
+            eprintln("result: {}", result)
+        }
+    }
+}
+```
+
+Notice that the first body of the match accepts both types of `a` and `b`
+(`i32` and `u64`):
+
+- `a + b` typechecks as long as the type of `a` implements `Add` with `b` as its RHS.
+- `eprintln` accepts both result types.
+
+According to the rule above, this sample should typecheck and always print the
+added result.
+
+We want to generate the minimal amount of code that contains both versions of
+the branching, meaning that paths for both `I32` and `U64` should get their
+`result` to be `i32` and `u64` respectively.
+
+When generating the code for that to work, even though we're lenient on the
+user, we still have to separate the code path that uses `u64` from the code
+path that uses `i32`. Since we generate C++ code, we can rely on C++'s
+substitution power for things like calls to overloaded functions, but wherever
+we have to fully specify the type of `a`, `b` or `result` we will have to
+generate two versions of the bodies.
+
+### Constraint 2: Multiple patterns, same binding types, only one body
+
+Take the following samples:
+
+#### Constraint 2.1: Multiple patterns with bindings
+```jakt
+enum Foo {
+    Bar(i32)
+    Baz
+}
+
+fn get_foo() -> Foo { ... }
+
+fn main() {
+    match get_foo() {
+        Bar(x) | Baz default(x = 1i32) {
+            // ... long code using `x`
+        }
+    }
+}
+```
+
+#### Constraint 2.2: Multiple patterns with no bindings
+```jakt
+enum Answer {
+    Is42
+    IsNot42(actual_value: u32)
+    IsNot42AndNoValue
+}
+
+fn get_answer() -> Answer { ... }
+
+fn main() {
+    match get_answer() {
+        Is42 => {
+            // long body 1
+        }
+        IsNot42 | IsNot42AndNoValue => {
+            // long body 2
+        }
+    }
+}
+```
+
+In both cases, we want Jakt to ideally only generate the long bodies once.
+
+## Previous solutions
+
+This is not the first iteration of pattern matching codegen, and the
+constraints above are modelled against features and problems of previous
+iterations. In this section we explain how each iteration works at a high level
+and how they motivate the constraints.
+
+### First solution
+
+The first implementation ran through all of the cases, typechecking the body
+for each of the patterns and submitting a new case per pattern, with their
+respective body.
+
+When generating code for a `match`, codegen sees a `CheckedExpression::Match`
+containing a list of `CheckedMatchCase`s. Each `CheckedMatchCase` contains exactly one
+pattern and one body that uses the bindings declared within said pattern.
+
+The problem with this solution is that it effectively duplicates the body as
+many times as patterns exist in the same group. However, the overhead on
+typechecking the body was not the main issue: Codegen would receive the bodies
+already duplicated, severely limiting what could be done at the codegen stage.
+Take into account that the codegen stage has the most complete version of the
+program that Jakt can have, since it needs all the concrete types that are used
+in order to generate working C++.
+In #1597 we can see that a ~300 line Jakt function
+(`typecheck_binary_operation`) is compiled to ~5500 lines of C++ code! That
+happened because the bodies for each case are large, and the bodies were
+duplicated many times.
+
+Constraint 2 ensures that similar functions to `typecheck_binary_operation` do
+not make the C++ compiler sift through repeating bodies if it's not
+necessary.
+
+### A partial improvement (#1597)
+
+PR #1597 addressed Constraint 2.1 by keeping the shared relationship between
+the patterns inside a pattern group and the body they jump to. This enables
+codegen to find pattern groups that have no bindings on them and easily group
+them by concatenating `case` labels or concatenating boolean expressions with
+`||`.
+
+Now each `CheckedMatchCase` contains a list of `CheckedMatchPattern` and one
+body that uses the bindings declared within said pattern. The implementation
+typechecks all bodies like the last version, but only selects the last checked
+body.
+
+The problem with this approach is that now the typechecker portion of this
+solution does not respect Constraint 1, since the last checked body is not
+enough to represent the case if bindings from the same parsed pattern group
+have different binding types.
+
+This causes `tests/codegen/match_enum_same_body_different_impl.jakt` to fail,
+since it codegens a call to `maybe_templated<JaktArray<i32>>` on all cases, when
+the first two cases of the enum should use the overloaded versions of
+`maybe_templated`.
+
+### Latest solution
+
+With this iteration, Constraint 2.1 is not addressed yet, but it satisfies
+Constraint 1 and Constraint 2.2. Typechecker now keeps the grouping, but
+re-generates the bodies when the types don't match.
+
+Each `CheckedMatchCase` contains a list of `CheckedMatchPattern`, a set of
+bindings `[String:VarId]` and a body where those bindings are used. All the
+patterns in this `CheckedMatchCase` are known to have the same set of bindings
+as the case.
+
+#### Why is this solution better?
+
+From the typechecker's side, it's obvious: it avoids creating `Scope`s and
+`CheckedMatchBody`s and `CheckedExpressions` and you name it. A quick glance to
+performance counters while typechecking selfhost [^1] reveals that this
+solution has a memory usage peak that is 20 MB lower than the previous
+solution, and is around ~14% faster.
+The memory usage improvement happens partly because `Scope`s are refcounted
+(`class`) and they are eternally stored in their respective `Module.scopes`
+array. Since we don't create them, they don't linger anymore.
+
+From codegen's side, it's certainly better than #1597 since it addresses
+Constraint 1, which is more important than Constraint 2 because now codegen is
+correct. As discussed below, this solution will generate "false duplicates"
+because it backs off without analyzing the exact problem at hand. The amount of
+duplicates that it will generate with respect to #1597 due to having to comply
+with Constraint 1 is not easy to estimate.
+
+#### Why is it not ideal?
+
+The reason Constraint 1 fails with #1597's solution is very specific: The types
+of the bindings are mentioned inside the body.
+
+An ideal solution would not duplicate bodies that don't mention the types
+inside the body implementation when driving them into codegen, or at least
+avoid duplicating the parts that don't depend on the binding types
+syntactically. That will generate even less C++ code, although the final result
+will still have to go through code duplication through template instantiations
+or overloads.
+
+This solution would require a lot of machinery that is not yet in place to
+typecheck the body and extract what variables (external to the body) each
+statement depends on, and decide how much of it has to be duplicated in either
+codegen or typechecker, or a mix of both. I didn't go with this solution
+because it seemed too complex of a change with not that big of a benefit.
+Perhaps we can place it in the backburner and take its potential into account
+when doing a similar extraction system in other places.
+
+I still haven't measured or calculated how many "false duplicates" the
+non-ideal algorithm will generate, but I can estimate that whatever amount that
+is it will not be very different from the ideal solution, since the difference
+boils down to the cases that have patterns with different binding types but
+could use some method of overloading in codegen (`auto` in lambda and/or
+function overloading) that is significant to the compile time of that piece of
+code, meaning that the separation made things worse.
+
+---
+
+[^1]: Used the program from https://github.com/andrewrk/poop with the following command:
+    `poop -d 15000 './stage1_main -R runtime selfhost/main.jakt' './build/bin/jakt_stage2 -R runtime selfhost/main.jakt'`.
+    `./stage1_main` is stage1 from https://github.com/SerenityOS/jakt/commit/d65f014cc54b986f629fe676d914af01d442b9f7

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -3669,7 +3669,7 @@ struct CodeGenerator {
         mut first = true
 
         mut cases_with_bindings: [CheckedMatchCase] = []
-        mut deferred_catch_all: ([CheckedStatement], CheckedMatchBody)? = None // (defaults, body)?
+        mut deferred_catch_all: ([String:CheckedExpression], [String:VarId], CheckedMatchBody)? = None // (defaults, variables, body)?
 
         for case_index in 0..cases.size() {
             let match_case = cases[case_index]
@@ -3680,7 +3680,7 @@ struct CodeGenerator {
                 guard not has_arguments else {
                     panic("Bindings should not be present in a generic else")
                 }
-                deferred_catch_all = (match_case.patterns[0].defaults, match_case.body)
+                deferred_catch_all = (match_case.patterns[0].defaults, match_case.bindings, match_case.body)
                 continue
             }
 
@@ -3723,7 +3723,7 @@ struct CodeGenerator {
                 defer output.append('}')
 
                 match pattern {
-                    EnumVariant(name, args, subject_type_id, index: variant_index, scope_id) => {
+                    EnumVariant(name, args, subject_type_id, index: variant_index) => {
                         let enum_ = .program.get_enum(match .program.get_type(subject_type_id) {
                             Enum(enum_id) => enum_id
                             GenericEnumInstance(id) => id
@@ -3775,23 +3775,19 @@ struct CodeGenerator {
                         }
                     }
                 }
-                for default_ in defaults {
-                    .codegen_statement(statement: default_, &mut output)
-                }
+                .declare_pattern_defaults(&defaults, variables: &case_.bindings, &mut output)
                 .codegen_match_body(body, return_type_id, &mut output)
             }
         }
 
         if deferred_catch_all is Some(catch_all_case) {
-            let (defaults, body) = catch_all_case
+            let (defaults, variables, body) = catch_all_case
 
             if not first { output.append("else ") }
 
             output.append('{')
 
-            for default_ in defaults {
-                .codegen_statement(statement: default_, &mut output)
-            }
+            .declare_pattern_defaults(&defaults, &variables, &mut output)
 
             .codegen_match_body(body, return_type_id, &mut output)
             output.append('}')
@@ -3874,7 +3870,7 @@ struct CodeGenerator {
                         continue
                     }
                     match pattern {
-                        EnumVariant(name, args, subject_type_id, index, scope_id) => {
+                        EnumVariant(name, args, subject_type_id, index) => {
                             let enum_type = .program.get_type(subject_type_id)
                             let enum_id = match enum_type {
                                 Enum(id) | GenericEnumInstance(id) => id
@@ -3896,7 +3892,7 @@ struct CodeGenerator {
                                         )
 
                                         let arg = args[0]
-                                        let var = .program.find_var_in_scope(scope_id, var: arg.binding)!
+                                        let var = .program.get_variable(match_case.bindings[arg.binding])
                                         output.append(.codegen_type(var.type_id))
                                         if not var.is_mutable {
                                             output.append(" const")
@@ -3913,7 +3909,7 @@ struct CodeGenerator {
                                             name)
 
                                         for arg in args {
-                                            let var = .program.find_var_in_scope(scope_id, var: arg.binding)!
+                                            let var = .program.get_variable(match_case.bindings[arg.binding])
                                             output.append(.codegen_type(var.type_id))
                                             if not var.is_mutable {
                                                 output.append(" const")
@@ -3948,9 +3944,7 @@ struct CodeGenerator {
                                 }
                             }
 
-                            for default_ in pattern.defaults {
-                                .codegen_statement(statement: default_, &mut output)
-                            }
+                            .declare_pattern_defaults(&pattern.defaults, variables: &match_case.bindings, &mut output)
 
                             .codegen_match_body(body, return_type_id: type_id, &mut output)
                             output.append("};/*case end*/\n")
@@ -3959,9 +3953,8 @@ struct CodeGenerator {
                             has_default = true
 
                             output.append("default: {\n")
-                            for default_ in pattern.defaults {
-                                .codegen_statement(statement: default_, &mut output)
-                            }
+
+                            .declare_pattern_defaults(&pattern.defaults, variables: &match_case.bindings, &mut output)
 
                             .codegen_match_body(body, return_type_id: type_id, &mut output)
                             output.append("};/*case end*/\n")
@@ -4028,6 +4021,13 @@ struct CodeGenerator {
                 // Here all `break`s and `continue`s should have used `LoopBreak` and `LoopContinue` from EVOCF.
                 ReturnExplicitValue => {}
             }
+        }
+    }
+
+    fn declare_pattern_defaults(mut this, anon defaults: &[String:CheckedExpression], variables: &[String:VarId], output: &mut StringBuilder) throws {
+        for (name, init) in defaults {
+            let var_id = variables[name]
+            .codegen_var_decl(var_id, init, &mut output)
         }
     }
 
@@ -4920,19 +4920,7 @@ struct CodeGenerator {
                     .codegen_statement(statement: v, &mut output)
                 }
             }
-            VarDecl(var_id, init) => {
-                let var = .program.get_variable(var_id)
-                let var_type = .program.get_type(var.type_id)
-                output.append(.codegen_type(var.type_id))
-                output.append(" ")
-                if not var.is_mutable and not (var_type is Reference or var_type is MutableReference) {
-                    output.append("const ")
-                }
-                output.append(var.name_for_codegen().as_name_for_use())
-                output.append(" = ")
-                .codegen_expression(init, &mut output)
-                output.append(";")
-            }
+            VarDecl(var_id, init) => .codegen_var_decl(var_id, init, &mut output)
             InlineCpp(lines) => {
                 for line in lines {
                     mut escaped_line = line
@@ -4998,6 +4986,20 @@ struct CodeGenerator {
         if add_newline {
             output.append("\n")
         }
+    }
+
+    fn codegen_var_decl(mut this, var_id: VarId, init: CheckedExpression, output: &mut StringBuilder) throws {
+        let var = .program.get_variable(var_id)
+        let var_type = .program.get_type(var.type_id)
+        output.append(.codegen_type(var.type_id))
+        output.append(" ")
+        if not var.is_mutable and not (var_type is Reference or var_type is MutableReference) {
+            output.append("const ")
+        }
+        output.append(var.name_for_codegen().as_name_for_use())
+        output.append(" = ")
+        .codegen_expression(init, &mut output)
+        output.append(";")
     }
 
     fn codegen_return(mut this, anon val: CheckedExpression?, output: &mut StringBuilder) throws -> void => match val.has_value() {

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -746,7 +746,7 @@ fn find_span_in_expression(program: CheckedProgram, expr: CheckedExpression, spa
                 let body = match_case.body
                 for pattern in match_case.patterns {
                     let found = match pattern {
-                        EnumVariant(name, args, subject_type_id, index, scope_id, marker_span) => {
+                        EnumVariant(name, args, subject_type_id, index, marker_span) => {
                             if marker_span.contains(span) {
                                 // FIXME: return Some(get_enum_variant_usage_from_type_id_and_name(program, type_id: subject_type_id, variant_index))
                                 return Some(get_enum_variant_usage_from_type_id_and_name(

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -5279,15 +5279,15 @@ struct Typechecker {
 
         match lhs_type {
             TypeVariable => {
-				// Unpack one layer of inference at a time
+                // Unpack one layer of inference at a time
                 let maybe_resolved_inference = generic_inferences.get(lhs_type_id)
                 if maybe_resolved_inference is Some(resolved_inference) {
-					return .check_types_for_compat(
-						lhs_type_id: resolved_inference
-						rhs_type_id
-						generic_inferences
-						span
-					)
+                    return .check_types_for_compat(
+                        lhs_type_id: resolved_inference
+                        rhs_type_id
+                        generic_inferences
+                        span
+                    )
                 } else {
                     generic_inferences.set(key: lhs_type_id, value: rhs_type_id)
                 }
@@ -6736,7 +6736,7 @@ struct Typechecker {
         While(condition, block, span) => .typecheck_while(condition, block, scope_id, safety_mode, span)
         Continue(span) => .typecheck_continue(span)
         Break(span) => .typecheck_break(span)
-        VarDecl(var, init, span) => .typecheck_var_decl(var, init, scope_id, safety_mode, span)
+        VarDecl(var, init, span) => .typecheck_and_register_var_decl(var, init, scope_id, safety_mode, span)
         DestructuringAssignment(vars, var_decl, span) => .typecheck_destructuring_assignment(vars, var_decl, scope_id, safety_mode, span)
         If(condition, then_block, else_statement, span) => .typecheck_if(condition, then_block, else_statement, scope_id, safety_mode, span)
         Garbage(span) => CheckedStatement::Garbage(span)
@@ -6826,19 +6826,21 @@ struct Typechecker {
                     match_cases: [
                         CheckedMatchCase(
                             patterns: [CheckedMatchPattern::Expression(
-                                defaults: []
-                                expression: CheckedExpression::Boolean(val: true, span)
+                                defaults: [:]
                                 marker_span: span
+                                expression: CheckedExpression::Boolean(val: true, span)
                             )]
                             body: CheckedMatchBody::Expression(CheckedExpression::Block(block: checked_block, span, type_id: checked_block.yielded_type!))
+                            bindings: [:]
                         )
                         CheckedMatchCase(
                             patterns: [CheckedMatchPattern::CatchAll(
-                                defaults: []
-                                has_arguments: false
+                                defaults: [:]
                                 marker_span: span
+                                has_arguments: false
                             )]
                             body: CheckedMatchBody::Block(checked_else_block)
+                            bindings: [:]
                         )
                     ]
                     span
@@ -7278,7 +7280,7 @@ struct Typechecker {
                     index: i
                     is_optional: false
                     span)
-                var_decls.push(.typecheck_var_decl(var: vars[i], init, scope_id, safety_mode, span))
+                var_decls.push(.typecheck_and_register_var_decl(var: vars[i], init, scope_id, safety_mode, span))
             }
         } else {
             .error("Tuple inner types sould have same size as tuple members", span)
@@ -7492,9 +7494,9 @@ struct Typechecker {
         Garbage => (None, expr)
     }
 
-    fn typecheck_var_decl(mut this, var: ParsedVarDecl, init: ParsedExpression, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
+    fn typecheck_var_decl(mut this, var: ParsedVarDecl, init: ParsedExpression, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> (CheckedVariable, CheckedExpression)? {
         mut lhs_type_id = .typecheck_typename(parsed_type: var.parsed_type, scope_id, name: var.name)
-        mut checked_expr = .typecheck_expression(expr: init, scope_id, safety_mode, type_hint: TypeHint::MustBe(type_id: lhs_type_id))
+        let checked_expr = .typecheck_expression(expr: init, scope_id, safety_mode, type_hint: TypeHint::MustBe(type_id: lhs_type_id))
         let rhs_type_id = checked_expr.type()
 
         if rhs_type_id.equals(void_type_id()) {
@@ -7577,7 +7579,7 @@ struct Typechecker {
 
             if not (.is_numeric(lhs_type_id) and is_rhs_zero) and (.is_integer(lhs_type_id) ^ .is_integer(rhs_type_id)) {
                 .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id)), checked_expr.span())
-                return CheckedStatement::Garbage(span)
+                return None
             }
         } else {
             if not lhs_type_id.equals(rhs_type_id) and not rhs_type_id.equals(unknown_type_id())
@@ -7586,18 +7588,25 @@ struct Typechecker {
             }
         }
 
-        let checked_var = CheckedVariable(
+        if .dump_type_hints and var.inlay_span is Some(inlay_span) {
+            .dump_type_hint(type_id: lhs_type_id, span: inlay_span)
+        }
+
+        return (CheckedVariable(
             name: var.name
             type_id: lhs_type_id
             is_mutable: var.is_mutable
             definition_span: var.span
             type_span: None
             visibility: CheckedVisibility::Public
-        )
+        ), checked_expr)
+    }
 
-        if .dump_type_hints and var.inlay_span.has_value() {
-            .dump_type_hint(type_id: lhs_type_id, span: var.inlay_span!)
+    fn typecheck_and_register_var_decl(mut this, var: ParsedVarDecl, init: ParsedExpression, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
+        guard .typecheck_var_decl(var, init, scope_id, safety_mode, span) is Some(checked_var_and_init) else {
+            return CheckedStatement::Garbage(span)
         }
+        let (checked_var, checked_expr) = checked_var_and_init
 
         mut module = .current_module()
         let var_id = module.add_variable(checked_var)
@@ -9912,26 +9921,59 @@ struct Typechecker {
         )
     }
 
+    // Typechecks defaults from patterns and pushes them into the given key builder.
+    // As this is always used as the last step, it consumes the builder and yields the final key.
+    fn typecheck_pattern_defaults(
+        mut this
+        default_bindings: &[String:ParsedPatternDefault]
+        scope_id: ScopeId //  init expression will be checked against this scope
+        safety_mode: SafetyMode
+        mut key_builder: BindingKeyBuilder
+    ) throws -> ([String:CheckedExpression], BindingKey) {
+        mut defaults: [String:CheckedExpression] = [:]
+        defaults.ensure_capacity(default_bindings.size())
+
+        mut module = .current_module()
+        for (name, default_) in default_bindings {
+            guard .typecheck_var_decl(
+                var: default_.variable
+                init: default_.value
+                scope_id
+                safety_mode
+                span: default_.variable.span
+            ) is Some(checked_var_and_init) else {
+                // error has already been registered, so it's okay
+                // to not have all defaults registered
+                continue
+            }
+            let (variable, init) = checked_var_and_init
+            let var_id = module.add_variable(variable)
+            key_builder = key_builder.submit(name, var_id, program: .program)
+            defaults[name] = init
+        }
+        return (defaults, key_builder.finish())
+    }
+
+
+    // Prepares `.generic_inferences` and a new scope with the inferences for
+    // the bindings from the pattern. Returns the name for the covered variant
+    // (if found), the resulting match pattern and the binding key to know
+    // whether the body is already typechecked against this pattern.
     fn typecheck_match_variant(
         mut this
         case_: &ParsedMatchCase
         subject_type_id: TypeId
         variant_index: usize
-        final_result_type: TypeId?
         variant: CheckedEnumVariant
         variant_arguments: [EnumVariantPatternArgument]
         default_bindings: [String:ParsedPatternDefault]
         arguments_span: Span
         scope_id: ScopeId
         safety_mode: SafetyMode
-    ) throws -> (String?, CheckedMatchPattern, CheckedMatchBody, TypeId?, bool) {
+        mut key_builder: BindingKeyBuilder
+    ) throws -> (String?, CheckedMatchPattern, BindingKey) {
         mut covered_name: String? = None
 
-        let new_scope_id = .create_scope(
-            parent_scope_id: scope_id
-            can_throw: .get_scope(scope_id).can_throw
-            debug_name: format("catch-enum-variant({})", variant.name())
-        )
         mut module = .current_module()
         match variant {
             Untyped(name) => {
@@ -9961,7 +10003,7 @@ struct Typechecker {
                             type_span: None
                             visibility: CheckedVisibility::Public
                         ))
-                        .add_var_to_scope(scope_id: new_scope_id, name: variant_argument.binding, var_id, span)
+                        key_builder = key_builder.submit(variant_argument.binding, var_id, program: .program)
                     }
                 }
             }
@@ -10028,7 +10070,7 @@ struct Typechecker {
                             type_span: None
                             visibility: CheckedVisibility::Public
                         ))
-                        .add_var_to_scope(scope_id: new_scope_id, name: arg.binding, var_id, span: matched_span)
+                        key_builder = key_builder.submit(arg.binding, var_id, program: .program)
                     } else {
                         .error(format("Match case argument '{}' does not exist in struct-like enum variant '{}'", arg_name, name), arg.span)
                     }
@@ -10039,38 +10081,19 @@ struct Typechecker {
             }
         }
 
-        mut defaults: [CheckedStatement] = []
-        for (_, default_) in default_bindings {
-            let checked_var_decl = .typecheck_var_decl(
-                var: default_.variable
-                init: default_.value
-                scope_id: new_scope_id
-                safety_mode
-                span: default_.variable.span
-            )
-            defaults.push(checked_var_decl)
-        }
+        let (defaults, key) = .typecheck_pattern_defaults(&default_bindings, scope_id, safety_mode, key_builder)
 
-        let (checked_body, result_type, seen_none) = .typecheck_match_body(
-            body: case_.body
-            scope_id: new_scope_id
-            safety_mode
-            generic_inferences: &mut .generic_inferences
-            final_result_type
-            span: case_.marker_span
-        )
 
         let checked_match_pattern = CheckedMatchPattern::EnumVariant(
             defaults
+            marker_span: case_.marker_span
             name: variant.name()
             args: variant_arguments
             subject_type_id
             index: variant_index
-            scope_id: new_scope_id
-            marker_span: case_.marker_span
         )
 
-        return (covered_name, checked_match_pattern, checked_body, result_type, seen_none)
+        return (covered_name, checked_match_pattern, key)
     }
 
     fn typecheck_match(
@@ -10085,16 +10108,22 @@ struct Typechecker {
         let checked_expr = .typecheck_expression_and_dereference_if_needed(expr, scope_id, safety_mode, type_hint: None, span)
         let subject_type_id = checked_expr.type()
         let type_to_match_on = .get_type(subject_type_id)
-        mut checked_cases: [CheckedMatchCase] = []
 
         let old_generic_inferences = .generic_inferences.perform_checkpoint(reset: false)
         defer {
             .generic_inferences.restore(old_generic_inferences)
         }
 
-        mut final_result_type: TypeId? = None
+        // NOTE: Separating the cases by the types of their bindings gets
+        // better results than cloning all the bodies, specially since it
+        // avoids re-typechecking when not necessary, but it still is not the
+        // perfect solution. The section "Why is this not ideal" in
+        // documentation/pattern-match-avoid-duplication.md explains why.
+
+
+        mut match_builder = MatchBuilder()
         if type_hint.has_value() and not type_hint!.type_id.equals(unknown_type_id()) and not .get_type(type_hint!.type_id) is TypeVariable {
-            final_result_type = type_hint!.type_id
+            match_builder.final_result_type = type_hint!.type_id
         }
 
         if type_to_match_on is GenericEnumInstance(id, args) {
@@ -10108,8 +10137,6 @@ struct Typechecker {
             }
         }
 
-        mut yielded_none = false
-
         match type_to_match_on {
             Enum(enum_id) | GenericEnumInstance(id: enum_id) => {
                 let enum_ = .get_enum(enum_id)
@@ -10121,15 +10148,8 @@ struct Typechecker {
                 let case_count = cases.size()
                 mut current_case_index = 0uz
                 for case_ in cases {
-                    mut checked_patterns: [CheckedMatchPattern] = []
-                    mut last_checked_body: CheckedMatchBody? = None
-                    // if the input is malformed, there will be cases with empty patterns.
-                    defer if not checked_patterns.is_empty() {
-                        checked_cases.push(CheckedMatchCase(
-                            patterns: checked_patterns
-                            body: last_checked_body!
-                        ))
-                    }
+                    let case_proof = match_builder.start_case()
+
                     for pattern in case_.patterns {
                         match pattern {
                             EnumVariant(variant_names, variant_arguments, arguments_span) => {
@@ -10152,46 +10172,49 @@ struct Typechecker {
                                     continue
                                 }
 
-                                mut i = 0uz
-                                mut matched_variant: CheckedEnumVariant? = None
-                                mut variant_index: usize? = None
-                                for v in enum_.variants {
-                                    if v.name() == variant_names_[1].0 {
-                                        matched_variant = v
-                                        variant_index = i
+                                mut maybe_variant_index: usize? = None
+                                for i in 0..enum_.variants.size() {
+                                    if enum_.variants[i].name() == variant_names_[1].0 {
+                                        maybe_variant_index = i
                                     }
-                                    i++
                                 }
 
-                                if not matched_variant.has_value() {
+                                guard maybe_variant_index is Some(variant_index) else {
                                     .error(format("Enum '{}' does not contain a variant named '{}'", enum_.name, variant_names_[1].0), case_.marker_span)
 
                                     return CheckedExpression::Match(expr: checked_expr, match_cases: [], span, type_id: unknown_type_id(), all_variants_constant: false)
                                 }
 
-                                let (covered_name, checked_match_case, checked_body, result_type, seen_none) = .typecheck_match_variant(
+                                let variant = enum_.variants[variant_index]
+
+
+                                let (covered_name, pattern, key) = .typecheck_match_variant(
                                     &case_
                                     subject_type_id
-                                    variant_index: variant_index!
-                                    final_result_type
-                                    variant: matched_variant!
+                                    variant_index
+                                    variant
                                     variant_arguments
                                     default_bindings: pattern.defaults
                                     arguments_span
                                     scope_id
                                     safety_mode
+                                    key_builder: match_builder.start_pattern(&case_proof)
                                 )
 
-                                last_checked_body = checked_body
-                                yielded_none |= seen_none
-
-                                if covered_name.has_value() {
-                                    covered_variants.add(covered_name!)
+                                if covered_name is Some(name) {
+                                    covered_variants.add(name)
                                 }
 
-                                final_result_type = result_type
-
-                                checked_patterns.push(checked_match_case)
+                                match_builder.register_pattern(
+                                    &case_proof
+                                    body: &case_.body
+                                    safety_mode
+                                    key
+                                    scope_id
+                                    pattern
+                                    typechecker: &mut this
+                                    &fn[variant]() -> String => format("catch-enum-variant({})", variant.name())
+                                )
                             }
                             CatchAll(variant_arguments, arguments_span) => {
                                 if current_case_index != case_count - 1 {
@@ -10210,70 +10233,58 @@ struct Typechecker {
                                         if not covered_variants.contains(variant.name()) {
                                             expanded_catch_all = true
 
-                                            let (covered_name, checked_match_pattern, checked_body, result_type, seen_none) = .typecheck_match_variant(
+                                            let (covered_name, checked_match_pattern, key) = .typecheck_match_variant(
                                                 &case_
                                                 subject_type_id
                                                 variant_index
-                                                final_result_type
                                                 variant
                                                 variant_arguments
                                                 default_bindings: pattern.defaults
                                                 arguments_span
                                                 scope_id
                                                 safety_mode
+                                                key_builder: match_builder.start_pattern(&case_proof)
                                             )
 
-                                            last_checked_body = checked_body
-                                            yielded_none |= seen_none
 
-                                            if covered_name.has_value() {
-                                                covered_variants.add(covered_name!)
+                                            if covered_name is Some(name) {
+                                                covered_variants.add(name)
                                             }
 
-                                            final_result_type = result_type
-
-                                            checked_patterns.push(checked_match_pattern)
+                                            match_builder.register_pattern(
+                                                &case_proof
+                                                body: &case_.body
+                                                safety_mode
+                                                key
+                                                scope_id
+                                                pattern: checked_match_pattern
+                                                typechecker: &mut this
+                                                &fn[variant]() -> String => format("catch-enum-variant({})", variant.name())
+                                            )
                                         }
 
                                         variant_index++
                                     }
                                 } else {
-                                    let new_scope_id = .create_scope(
-                                        parent_scope_id: scope_id
-                                        can_throw: .get_scope(scope_id).can_throw
-                                        debug_name: "catch-all"
-                                    )
-                                    mut defaults: [CheckedStatement] = []
-                                    for (_, default_) in pattern.defaults {
-                                        let checked_var_decl = .typecheck_var_decl(
-                                            var: default_.variable
-                                            init: default_.value
-                                            scope_id: new_scope_id
-                                            safety_mode
-                                            span: default_.variable.span
-                                        )
-                                        defaults.push(checked_var_decl)
-                                    }
+                                    let (defaults, key) = .typecheck_pattern_defaults(default_bindings: &pattern.defaults, scope_id, safety_mode, key_builder: match_builder.start_pattern(&case_proof))
 
-                                    let (checked_body, result_type, seen_none) = .typecheck_match_body(
-                                        body: case_.body
-                                        scope_id: new_scope_id
-                                        safety_mode
-                                        generic_inferences: &mut .generic_inferences
-                                        final_result_type
-                                        span: case_.marker_span
-                                    )
-                                    last_checked_body = checked_body
-                                    yielded_none |= seen_none
-                                    final_result_type = result_type
 
                                     let checked_match_pattern = CheckedMatchPattern::CatchAll(
                                         defaults
-                                        has_arguments: false
                                         marker_span: case_.marker_span
+                                        has_arguments: false
                                     )
 
-                                    checked_patterns.push(checked_match_pattern)
+                                    match_builder.register_pattern(
+                                        &case_proof
+                                        body: &case_.body
+                                        safety_mode
+                                        key
+                                        scope_id
+                                        pattern: checked_match_pattern
+                                        typechecker: &mut this
+                                        &fn() -> String => "catch-all"
+                                    )
                                 }
                             }
                             else => {}
@@ -10321,14 +10332,8 @@ struct Typechecker {
                     mut covered_cases: {StructId} = {}
 
                     for case_ in cases {
-                        mut checked_patterns: [CheckedMatchPattern] = []
-                        mut last_checked_body: CheckedMatchBody? = None
-                        defer if not checked_patterns.is_empty() {
-                            checked_cases.push(CheckedMatchCase(
-                                patterns: checked_patterns
-                                body: last_checked_body!
-                            ))
-                        }
+                        let case_proof = match_builder.start_case()
+
                         for pattern in case_.patterns {
                             match pattern {
                                 EnumVariant(variant_names, variant_arguments, arguments_span) => {
@@ -10437,13 +10442,11 @@ struct Typechecker {
                                         }
                                     }
 
-                                    let new_scope_id = .create_scope(
-                                        parent_scope_id: scope_id
-                                        can_throw: .get_scope(scope_id).can_throw
-                                        debug_name: format("class-variant({})", names)
-                                    )
 
                                     mut rebind_name: ClassInstanceRebind? = None
+
+                                    mut key_builder = match_builder.start_pattern(&case_proof)
+
                                     if not variant_arguments.is_empty() {
                                         if variant_arguments.size() != 1 {
                                             .error(
@@ -10451,53 +10454,39 @@ struct Typechecker {
                                                 arguments_span
                                             )
                                         }
-                                        let arg = variant_arguments[0]
+                                        let arg = &variant_arguments[0]
+                                        if arg.is_mutable and not checked_expr.is_mutable(program: .program) {
+                                            .error("Cannot call mutating method on an immutable object instance", span)
+                                        }
                                         rebind_name = ClassInstanceRebind(
                                             name: arg.name_in_enum()
                                             name_span: arg.name_in_enum_span()
                                             is_mutable: arg.is_mutable
                                             is_reference: arg.is_reference
                                         )
-
+                                        let rebind = rebind_name!
                                         mut module = .current_module()
                                         let variable_id = module.add_variable(checked_variable: CheckedVariable(
-                                            name: rebind_name!.name
+                                            name: rebind.name
                                             type_id: type
-                                            is_mutable: rebind_name!.is_mutable
-                                            definition_span: rebind_name!.name_span
+                                            is_mutable: rebind.is_mutable
+                                            definition_span: rebind.name_span
                                             type_span: case_.marker_span
                                             visibility: CheckedVisibility::Public
                                         ))
-
-                                        if rebind_name!.is_mutable and not checked_expr.is_mutable(program: .program) {
-                                            .error("Cannot call mutating method on an immutable object instance", span)
-                                        }
-                                        .add_var_to_scope(
-                                            scope_id: new_scope_id
-                                            name: rebind_name!.name
-                                            var_id: variable_id
-                                            span: rebind_name!.name_span
-                                        )
+                                        key_builder = key_builder.submit(rebind.name, variable_id, program: .program)
                                     }
 
-                                    let (checked_body, result_type, seen_none) = .typecheck_match_body(
-                                        body: case_.body
-                                        scope_id: new_scope_id
+                                    match_builder.register_pattern(
+                                        &case_proof
+                                        body: &case_.body
                                         safety_mode
-                                        generic_inferences: &mut .generic_inferences
-                                        final_result_type
-                                        span: case_.marker_span
+                                        key: key_builder.finish()
+                                        scope_id
+                                        pattern: CheckedMatchPattern::ClassInstance(defaults: [:], marker_span: case_.marker_span,  type, rebind_name)
+                                        typechecker: &mut this
+                                        &fn[names]() -> String => format("class-variant({})", names)
                                     )
-                                    last_checked_body = checked_body
-                                    yielded_none |= seen_none
-                                    final_result_type = result_type
-
-                                    checked_patterns.push(CheckedMatchPattern::ClassInstance(
-                                        defaults: []
-                                        type
-                                        rebind_name
-                                        marker_span: case_.marker_span
-                                    ))
                                 }
                                 CatchAll(variant_arguments, arguments_span) => {
                                     if seen_catch_all {
@@ -10506,11 +10495,6 @@ struct Typechecker {
                                         seen_catch_all = true
                                         catch_all_marker_span = case_.marker_span
 
-                                        let new_scope_id = .create_scope(
-                                            parent_scope_id: scope_id
-                                            can_throw: .get_scope(scope_id).can_throw
-                                            debug_name: "class-variant(else)"
-                                        )
 
                                         if not variant_arguments.is_empty() {
                                             .error(
@@ -10519,23 +10503,16 @@ struct Typechecker {
                                             )
                                         }
 
-                                        let (checked_body, result_type, seen_none) = .typecheck_match_body(
-                                            body: case_.body
-                                            scope_id: new_scope_id
+                                        match_builder.register_pattern(
+                                            &case_proof
+                                            body: &case_.body
                                             safety_mode
-                                            generic_inferences: &mut .generic_inferences
-                                            final_result_type
-                                            span: case_.marker_span
+                                            key: BindingKey::New([:])
+                                            scope_id
+                                            pattern: CheckedMatchPattern::CatchAll(defaults: [:], marker_span: case_.marker_span, has_arguments: false)
+                                            typechecker: &mut this
+                                            &fn() -> String => "class-variant(else)"
                                         )
-                                        last_checked_body = checked_body
-                                        yielded_none |= seen_none
-                                        final_result_type = result_type
-
-                                        checked_patterns.push(CheckedMatchPattern::CatchAll(
-                                            defaults: []
-                                            has_arguments: false
-                                            marker_span: case_.marker_span
-                                        ))
                                     }
                                 }
                                 else => {
@@ -10589,14 +10566,8 @@ struct Typechecker {
                     let case_count = cases.size()
                     mut current_case_index = 0uz
                     for case_ in cases {
-                        mut checked_patterns: [CheckedMatchPattern] = []
-                        mut last_checked_body: CheckedMatchBody? = None
-                        defer if not checked_patterns.is_empty() {
-                            checked_cases.push(CheckedMatchCase(
-                                patterns: checked_patterns
-                                body: last_checked_body!
-                            ))
-                        }
+                        let case_proof = match_builder.start_case()
+
                         for pattern in case_.patterns {
                             match pattern {
                                 EnumVariant(variant_names, variant_arguments, arguments_span) => {
@@ -10615,41 +10586,34 @@ struct Typechecker {
 
                                     // We don't know what the enum type is, but we have the type var for it, so generate a generic enum match.
                                     // note that this will be fully checked when this match expression is actually instantiated.
-                                    let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw, debug_name: format("catch-enum-variant({})", variant_names))
-                                    mut defaults: [CheckedStatement] = []
-                                    for (_, default_) in pattern.defaults {
-                                        let checked_var_decl = .typecheck_var_decl(
-                                            var: default_.variable
-                                            init: default_.value
-                                            scope_id: new_scope_id
-                                            safety_mode
-                                            span: default_.variable.span
-                                        )
-                                        defaults.push(checked_var_decl)
-                                    }
 
-                                    let (checked_body, result_type, seen_none) = .typecheck_match_body(
-                                        body: case_.body
-                                        scope_id: new_scope_id
+                                    let (defaults, key) = .typecheck_pattern_defaults(
+                                        default_bindings: &pattern.defaults
+                                        scope_id
                                         safety_mode
-                                        generic_inferences: &mut .generic_inferences
-                                        final_result_type
-                                        span: case_.marker_span
+                                        key_builder: match_builder.start_pattern(&case_proof)
                                     )
-                                    last_checked_body = checked_body
-                                    yielded_none |= seen_none
-                                    final_result_type = result_type
 
                                     let checked_match_pattern = CheckedMatchPattern::EnumVariant(
                                         defaults
+                                        marker_span: case_.marker_span
                                         name: variant_names.last()!.0
                                         args: variant_arguments
                                         subject_type_id
                                         index: 0
-                                        scope_id: new_scope_id
-                                        marker_span: case_.marker_span
                                     )
-                                    checked_patterns.push(checked_match_pattern)
+
+
+                                    match_builder.register_pattern(
+                                        &case_proof
+                                        body: &case_.body
+                                        safety_mode
+                                        key
+                                        scope_id
+                                        pattern: checked_match_pattern
+                                        typechecker: &mut this
+                                        &fn[variant_names]() -> String => format("catch-enum-variant({})", variant_names)
+                                    )
                                 }
                                 CatchAll(variant_arguments) => {
                                     if current_case_index != case_count - 1 {
@@ -10671,38 +10635,30 @@ struct Typechecker {
                                         ))
                                     }
 
-                                    let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw, debug_name: "catch-all")
-                                    mut defaults: [CheckedStatement] = []
-                                    for (_, default_) in pattern.defaults {
-                                        let checked_var_decl = .typecheck_var_decl(
-                                            var: default_.variable
-                                            init: default_.value
-                                            scope_id: new_scope_id
-                                            safety_mode
-                                            span: default_.variable.span
-                                        )
-                                        defaults.push(checked_var_decl)
-                                    }
 
-                                    let (checked_body, result_type, seen_none) = .typecheck_match_body(
-                                        body: case_.body
-                                        scope_id: new_scope_id
+                                    let (defaults, key) = .typecheck_pattern_defaults(
+                                        default_bindings: &pattern.defaults
+                                        scope_id
                                         safety_mode
-                                        generic_inferences: &mut .generic_inferences
-                                        final_result_type
-                                        span: case_.marker_span
+                                        key_builder: match_builder.start_pattern(&case_proof)
                                     )
-                                    last_checked_body = checked_body
-                                    yielded_none |= seen_none
-                                    final_result_type = result_type
 
                                     let checked_match_pattern = CheckedMatchPattern::CatchAll(
                                         defaults
-                                        has_arguments: variant_arguments.size() != 0
                                         marker_span: case_.marker_span
+                                        has_arguments: variant_arguments.size() != 0
                                     )
 
-                                    checked_patterns.push(checked_match_pattern)
+                                    match_builder.register_pattern(
+                                        &case_proof
+                                        body: &case_.body
+                                        safety_mode
+                                        key
+                                        scope_id
+                                        pattern: checked_match_pattern
+                                        typechecker: &mut this
+                                        &fn() -> String => "catch-all"
+                                    )
                                 }
                                 Expression(expr) => {
                                     if is_enum_match {
@@ -10768,25 +10724,16 @@ struct Typechecker {
                                         .error("Expression patterns cannot have default bindings", case_.marker_span)
                                     }
 
-                                    let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw, debug_name: format("catch-expression({})", expr))
-                                    let (checked_body, result_type, seen_none) = .typecheck_match_body(
-                                        body: case_.body
-                                        scope_id: new_scope_id
+                                    match_builder.register_pattern(
+                                        &case_proof
+                                        body: &case_.body
                                         safety_mode
-                                        generic_inferences: &mut .generic_inferences
-                                        final_result_type
-                                        span: case_.marker_span
+                                        key: match_builder.empty_binding_key(&case_proof)
+                                        scope_id
+                                        pattern: CheckedMatchPattern::Expression(defaults: [:], marker_span: case_.marker_span, expression: checked_expression)
+                                        typechecker: &mut this
+                                        &fn[expr]() -> String => format("catch-expression({})", expr)
                                     )
-                                    last_checked_body = checked_body
-                                    yielded_none |= seen_none
-                                    final_result_type = result_type
-
-                                    let checked_match_pattern = CheckedMatchPattern::Expression(
-                                        defaults: []
-                                        expression: checked_expression
-                                        marker_span: case_.marker_span
-                                    )
-                                    checked_patterns.push(checked_match_pattern)
                                 }
                                 else => {}
                             }
@@ -10810,26 +10757,47 @@ struct Typechecker {
         }
 
         // FIXME: These errors should probably point at the case that returns None, all maybe even all the cases that do (but that could be excessive).
-        if yielded_none and final_result_type.has_value() {
-            if .get_type(final_result_type!) is GenericInstance(id, args) {
+        if match_builder.yielded_none and match_builder.final_result_type is Some(final_result_type) {
+            if .get_type(final_result_type) is GenericInstance(id, args) {
                 if not id.equals(.find_struct_in_prelude("Optional")) and not id.equals(.find_struct_in_prelude("WeakPtr")) {
                     .error(
-                        message: format("Type mismatch: expected ‘{}’, but got None", .type_name(final_result_type!))
+                        message: format("Type mismatch: expected ‘{}’, but got None", .type_name(final_result_type))
                         span: span
                     )
                 }
             } else {
                 .error(
-                    message: format("Type mismatch: expected ‘{}’, but got None", .type_name(final_result_type!))
+                    message: format("Type mismatch: expected ‘{}’, but got None", .type_name(final_result_type))
                     span: span
                 )
             }
         }
 
-        return CheckedExpression::Match(expr: checked_expr, match_cases: checked_cases, span, type_id: final_result_type ?? void_type_id(), all_variants_constant: true)
+        return CheckedExpression::Match(expr: checked_expr, match_cases: match_builder.all_cases, span, type_id: match_builder.final_result_type ?? void_type_id(), all_variants_constant: true)
     }
 
-    fn typecheck_match_body(mut this, body: ParsedMatchBody, scope_id: ScopeId, safety_mode: SafetyMode, generic_inferences: &mut GenericInferences, final_result_type: TypeId?, span: Span) throws -> (CheckedMatchBody, TypeId?, bool) {
+    restricted(MatchBuilder::register_pattern) fn typecheck_match_body(
+        mut this
+        body: ParsedMatchBody
+        parent_scope_id: ScopeId
+        bindings: [String:VarId]
+        body_scope_debug_name: String
+        safety_mode: SafetyMode
+        final_result_type: TypeId?
+        span: Span
+    ) throws -> (CheckedMatchBody, TypeId?, bool) {
+
+        let scope_id = .create_scope(
+            parent_scope_id
+            can_throw: .get_scope(parent_scope_id).can_throw
+            debug_name: body_scope_debug_name
+        )
+
+        for (name, var_id) in bindings {
+            .add_var_to_scope(scope_id, name, var_id, span: .program.get_variable(var_id).definition_span)
+        }
+
+
         mut result_type = final_result_type
         mut seen_none = false
         let checked_match_body = match body {
@@ -10852,7 +10820,7 @@ struct Typechecker {
                         result_type = .choose_broader_type_id(
                             original_type_id: result_type_hint!.type_id
                             potential_type_id: block_type_id
-                            generic_inferences
+                            generic_inferences: &mut .generic_inferences
                             span: yield_span
                         )
                     } else {
@@ -10862,7 +10830,7 @@ struct Typechecker {
                     .check_types_for_compat(
                         lhs_type_id: result_type!
                         rhs_type_id: block_type_id
-                        generic_inferences
+                        generic_inferences: &mut .generic_inferences
                         span: yield_span
                     )
                 }
@@ -10896,7 +10864,7 @@ struct Typechecker {
                     result_type = .choose_broader_type_id(
                         original_type_id: result_type_hint!.type_id
                         potential_type_id: checked_expression.type()
-                        generic_inferences
+                        generic_inferences: &mut .generic_inferences
                         span
                     )
                 } else {
@@ -10906,7 +10874,7 @@ struct Typechecker {
                 .check_types_for_compat(
                     lhs_type_id: result_type!
                     rhs_type_id: checked_expression.type()
-                    generic_inferences
+                    generic_inferences: &mut .generic_inferences
                     span
                 )
 
@@ -12679,5 +12647,161 @@ fn dump_scope(anon scope_id: ScopeId, anon program: &CheckedProgram, indent: i64
     eprintln("{: >{}}Children:", "", cindent)
     for id in scope.children {
         dump_scope(id, program, indent: cindent + 2)
+    }
+}
+
+enum BindingKey {
+    Found(usize) // found equivalent pattern at an index
+    New([String:VarId]) // need to make a new case.
+}
+
+fn search_empty_pattern(cases: ArraySlice<CheckedMatchCase>) -> BindingKey {
+    for idx in 0..cases.size() {
+        if cases[idx].bindings.is_empty() {
+            return BindingKey::Found(idx)
+        }
+    }
+    return BindingKey::New([:])
+}
+
+// The state that is kept while discovering bindings from a pattern inside a
+// match, which discards possible aliasing cases on each binding discovery. It
+// is used by the typechecker to detect when the body of a case must be
+// typechecked with new types for a certain pattern. The `cases` slice is the
+// subset of cases that the pattern can refer to, which are the checked cases
+// from previous patterns that share the same body. This invariant is easy to
+// miss, but `MatchBuilder` (below) helps in enforcing it.
+// NOTE: The `correct` set may be implemented with a bit array with size cases.size()
+enum BindingKeyBuilder {
+    Empty(cases: ArraySlice<CheckedMatchCase>)
+    Known(built: [String:VarId], correct: {usize}, cases: ArraySlice<CheckedMatchCase>)
+    New(built: [String:VarId])
+
+    fn finish(this) -> BindingKey => match this {
+        Empty(cases) => search_empty_pattern(cases)
+        Known(built, correct, cases) => {
+            // From the remaining possibilities, find one that is exactly the
+            // size of the binding list.
+            for idx in correct {
+                if cases[idx].bindings.size() == built.size() {
+                    return BindingKey::Found(idx)
+                }
+            }
+            yield BindingKey::New(built)
+        }
+        New(built) => BindingKey::New(built)
+    }
+
+    fn submit(
+        mut this
+        anon name: String
+        anon var_id: VarId
+        program: CheckedProgram
+    ) -> BindingKeyBuilder => match this {
+        Empty(cases) => {
+            let correct = build_correct_set(0..cases.size(), name, var_id, cases, program)
+            yield BindingKeyBuilder::from_set(correct, built: [name:var_id], cases)
+        }
+        Known(built: built_, correct, cases) => {
+            mut built = built_
+            built[name] = var_id
+
+            let next_correct = build_correct_set(correct.iterator(), name, var_id, cases, program)
+
+            yield BindingKeyBuilder::from_set(correct: next_correct, built, cases)
+        }
+        New(built: built_) => {
+            mut built = built_
+            built[name] = var_id
+            yield BindingKeyBuilder::New(built)
+        }
+    }
+
+    // FIXME: This could require IntoIterator, but Range (0..cases.size() in Empty case above) is Iterable, not IntoIterator.
+    fn build_correct_set<Src requires(Iterable<usize>)>(
+        anon src: Src
+        name: String
+        var_id: VarId
+        cases: ArraySlice<CheckedMatchCase>
+        program: CheckedProgram
+    ) -> {usize} {
+        mut correct: {usize} = {}
+        let wanted_type = program.get_variable(var_id).type_id
+
+        for idx in src {
+            if cases[idx].bindings.get(name) is Some(var) and program.get_variable(var).type_id == wanted_type {
+                correct.add(idx)
+            }
+        }
+
+        return correct
+    }
+
+    fn from_set(
+        correct: {usize}
+        built: [String:VarId]
+        cases: ArraySlice<CheckedMatchCase>
+    ) -> BindingKeyBuilder => match correct.is_empty() {
+        true => BindingKeyBuilder::New(built)
+        false => BindingKeyBuilder::Known(built, correct, cases)
+    }
+}
+
+// Since we have to keep state per case loop, it is pretty easy to forget to
+// update the state every loop, specially with different loops scattered across
+// Typechecker.typecheck_match. This acts as a key that is also used to
+// remember where the checked cases for the current case body starts.
+struct CaseStartedProof {
+    restricted(MatchBuilder)
+    start_of_case: usize
+}
+
+// Centralized state for Typechecker.typecheck_match. It tracks the necessary
+// state when typechecking a whole match. It is in charge of grouping patterns
+// with their respective checked body & bindings, as discovered by
+// `BindingKeyBuilder`. It also helps in enforcing that the `cases` array that
+// `BindingKeyBuilder` inspects only contains cases referring to the same
+// parsed body.
+struct MatchBuilder {
+    all_cases: [CheckedMatchCase] = []
+    yielded_none: bool = false
+    final_result_type: TypeId? = None
+
+    fn start_case(mut this) -> CaseStartedProof => CaseStartedProof(start_of_case: .all_cases.size())
+
+    fn start_pattern(this, anon proof: &CaseStartedProof) -> BindingKeyBuilder => BindingKeyBuilder::Empty(cases: .all_cases[proof.start_of_case..])
+    // skips the builder step for patterns that don't have bindings
+    fn empty_binding_key(this, anon proof: &CaseStartedProof) -> BindingKey => search_empty_pattern(cases: .all_cases[proof.start_of_case..])
+
+    fn register_pattern(
+        mut this
+        anon proof: &CaseStartedProof
+        body: &ParsedMatchBody
+        safety_mode: SafetyMode
+        key: BindingKey
+        scope_id: ScopeId // scope id where the match is located
+        pattern: CheckedMatchPattern // the pattern to register
+        typechecker: &mut Typechecker
+        anon scope_debug_name: &fn() -> String // when a scope id is required
+    ) throws -> void => match key {
+        Found(index) => {
+            // add this pattern to the checked cases, since it was found
+            let case_index = index + proof.start_of_case
+            .all_cases[case_index].patterns.push(pattern)
+        }
+        New(built) => {
+            let (body, result_type, seen_none) = typechecker.typecheck_match_body(
+                body: *body
+                parent_scope_id: scope_id
+                bindings: built
+                body_scope_debug_name: scope_debug_name()
+                safety_mode
+                final_result_type: .final_result_type
+                span: pattern.marker_span
+            )
+            .final_result_type = result_type
+            .yielded_none |= seen_none
+            .all_cases.push(CheckedMatchCase(patterns: [pattern], body, bindings: built))
+        }
     }
 }

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -1614,15 +1614,19 @@ struct ClassInstanceRebind {
 struct CheckedMatchCase {
     patterns: [CheckedMatchPattern]
     body: CheckedMatchBody
+    // All of the patterns in each case have these bindings, which are referenced
+    // in the shared body.
+    bindings: [String:VarId]
 }
 
 enum CheckedMatchPattern {
-    defaults: [CheckedStatement]
+    defaults: [String:CheckedExpression]
+    marker_span: Span
 
-    EnumVariant(name: String, args: [EnumVariantPatternArgument], subject_type_id: TypeId, index: usize, scope_id: ScopeId, marker_span: Span)
-    Expression(expression: CheckedExpression, marker_span: Span)
-    ClassInstance(type: TypeId, rebind_name: ClassInstanceRebind?, marker_span: Span)
-    CatchAll(has_arguments: bool, marker_span: Span)
+    EnumVariant(name: String, args: [EnumVariantPatternArgument], subject_type_id: TypeId, index: usize)
+    Expression(expression: CheckedExpression)
+    ClassInstance(type: TypeId, rebind_name: ClassInstanceRebind?)
+    CatchAll(has_arguments: bool)
 }
 
 struct OperatorTraitImplementation {

--- a/tests/codegen/match_enum_same_body_different_impl.jakt
+++ b/tests/codegen/match_enum_same_body_different_impl.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - output: "I have i32\n"
+
+
+// When a function is templated, the C++ for the match body will be different,
+// because it will also have the template arguments.
+//
+// The behavior from PR #1597 will make the generated C++ not compile, because
+// it assumes all bodies will codegen the same.
+
+fn may_be_templated<T>(anon t: T) { println("I have T") }
+fn may_be_templated(anon val: i32) { println("I have i32") }
+fn may_be_templated(anon val: f64) { println("I have f64") }
+
+enum Foo { Bar(i32), Baz(f64), Bork([i32]) }
+
+fn main() {
+    let foo = Foo::Bar(12)
+
+    match foo {
+        Bar(i) | Baz(i) | Bork(i) => may_be_templated(i)
+    }
+}


### PR DESCRIPTION
Fixes cases where the body is not duplicated when it should,
specially with instantiations that are inferred inside the body for
functions that support both instantiations and overloading. C++ can deal
with overloading, but we add the template parameters ourselves, which
makes the typing wrong for at least one pattern.

Introduces `BindingKey`, `MatchBuilder` and `BindingKeyBuilder`, which
together help keep match body code duplication at a low rate while being
as least intrusive as possible to the logic for each match typecheck:
`typecheck_match` has three big `for` loops with bodies that walk the
match cases in very different ways, and the deduplication system is
orthogonal to all of them. Most of it is implemented between
`MatchBuilder` and `BindingKeyBuilder`.

These builder states avoid creating scopes and duplicate typechecker
work, resulting in ~14% performance increase and 20MB less peak memory
usage when typechecking selfhost:

![image](https://github.com/user-attachments/assets/d2a5cc47-244a-4995-9ee3-43765ab6e879)

`poop` is https://github.com/andrewrk/poop .
`stage1_main` is the result of compiling stage1 from d65f014cc54b986f629fe676d914af01d442b9f7.
