### PR TITLE
selfhost: Gotta go fast(er)

### DIFF
--- a/bootstrap/stage0/build.cpp
+++ b/bootstrap/stage0/build.cpp
@@ -39,7 +39,7 @@ return id;
 JaktInternal::Optional<Jakt::jakt__platform__unknown_process::ExitPollResult> Jakt::build::ParallelExecutionPool::status(size_t const id) const {
 {
 if (this->completed.contains(id)){
-return this->completed.operator[](id);
+return this->completed[id];
 }
 return JaktInternal::OptionalNone();
 }
@@ -237,16 +237,9 @@ return {};
 
 ErrorOr<void> Jakt::build::Builder::link_into_archive(ByteString const archiver,ByteString const archive_filename,JaktInternal::DynamicArray<ByteString> const extra_arguments) {
 {
-JaktInternal::DynamicArray<ByteString> args = DynamicArray<ByteString>::create_with({archiver, ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (extra_arguments.size());
-if (__jakt_enum_value == static_cast<size_t>(0ULL)) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("cr"sv));
-}else {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("crT"sv));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}), archive_filename});
+JaktInternal::DynamicArray<ByteString> args = DynamicArray<ByteString>::create_with({archiver, [&]() -> ByteString { auto __jakt_enum_value = extra_arguments.size();
+if (__jakt_enum_value == static_cast<size_t>(0ULL)) {return ByteString::from_utf8_without_validation("cr"sv);}else {return ByteString::from_utf8_without_validation("crT"sv);} 
+}(), archive_filename});
 {
 JaktInternal::ArrayIterator<ByteString> _magic = this->linked_files.iterator();
 for (;;){

--- a/bootstrap/stage0/codegen.cpp
+++ b/bootstrap/stage0/codegen.cpp
@@ -22,26 +22,16 @@ bool pattern_has_bindings(Jakt::types::CheckedMatchPattern const& pattern) {
 if (!pattern.common.init_common.defaults.is_empty()){
 return true;
 }
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = pattern;
+{auto&& __jakt_match_variant = pattern;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* EnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(!args.is_empty());
-};/*case end*/
+return !args.is_empty();};/*case end*/
 case 2 /* ClassInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ClassInstance;JaktInternal::Optional<Jakt::types::ClassInstanceRebind> const& rebind_name = __jakt_match_value.rebind_name;
-return JaktInternal::ExplicitValue(rebind_name.has_value());
-};/*case end*/
-case 3 /* CatchAll */:case 1 /* Expression */:return JaktInternal::ExplicitValue(false);
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return rebind_name.has_value();};/*case end*/
+case 3 /* CatchAll */:case 1 /* Expression */:return false;default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
@@ -90,6 +80,173 @@ return count;
 }
 }
 
+bool has_cpp_value(Jakt::ids::TypeId const type_id) {
+{
+return [](Jakt::ids::TypeId const& self, Jakt::ids::TypeId rhs) -> bool {{
+return !self.equals(rhs);
+}
+}
+(type_id,Jakt::types::void_type_id()) && [](Jakt::ids::TypeId const& self, Jakt::ids::TypeId rhs) -> bool {{
+return !self.equals(rhs);
+}
+}
+(type_id,Jakt::types::never_type_id());
+}
+}
+
+bool has_control_flow(Jakt::types::CheckedMatchCase const match_case,bool const include_loop_control_flow) {
+{
+{auto&& __jakt_match_variant = match_case.body;
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 1 /* Block */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& t = __jakt_match_value.value;
+return Jakt::codegen::has_control_flow(t,include_loop_control_flow);};/*case end*/
+case 0 /* Expression */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& t = __jakt_match_value.value;
+return Jakt::codegen::has_control_flow(t,include_loop_control_flow);};/*case end*/
+default: VERIFY_NOT_REACHED();}/*switch end*/
+}
+}
+}
+
+bool has_control_flow(Jakt::types::CheckedBlock const block,bool const include_loop_control_flow) {
+{
+return Jakt::codegen::has_control_flow<NonnullRefPtr<typename Jakt::types::CheckedStatement>>(block.statements,include_loop_control_flow);
+}
+}
+
+bool has_control_flow(NonnullRefPtr<typename Jakt::types::CheckedStatement> const stmt,bool const include_loop_control_flow) {
+{
+{auto&& __jakt_match_variant = *stmt;
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Expression */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
+return Jakt::codegen::has_control_flow(expr,include_loop_control_flow);};/*case end*/
+case 1 /* Defer */:case 11 /* Throw */:case 12 /* Yield */:case 14 /* Garbage */:return false;case 2 /* DestructuringAssignment */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.DestructuringAssignment;NonnullRefPtr<typename Jakt::types::CheckedStatement> const& var_decl = __jakt_match_value.var_decl;
+return Jakt::codegen::has_control_flow(var_decl,include_loop_control_flow);};/*case end*/
+case 3 /* VarDecl */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.VarDecl;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& init = __jakt_match_value.init;
+return Jakt::codegen::has_control_flow(init,include_loop_control_flow);};/*case end*/
+case 4 /* If */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.If;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& condition = __jakt_match_value.condition;
+Jakt::types::CheckedBlock const& then_block = __jakt_match_value.then_block;
+JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const& else_statement = __jakt_match_value.else_statement;
+return (Jakt::codegen::has_control_flow(condition,include_loop_control_flow) || Jakt::codegen::has_control_flow(then_block,include_loop_control_flow)) || Jakt::codegen::has_control_flow<NonnullRefPtr<typename Jakt::types::CheckedStatement>>(else_statement,include_loop_control_flow);};/*case end*/
+case 5 /* Block */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
+return Jakt::codegen::has_control_flow(block,include_loop_control_flow);};/*case end*/
+case 6 /* Loop */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Loop;Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
+return Jakt::codegen::has_control_flow(block,false);};/*case end*/
+case 7 /* While */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.While;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& condition = __jakt_match_value.condition;
+Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
+return Jakt::codegen::has_control_flow(condition,include_loop_control_flow) || Jakt::codegen::has_control_flow(block,false);};/*case end*/
+case 8 /* Return */:case 13 /* InlineCpp */:return true;case 9 /* Break */:case 10 /* Continue */:return include_loop_control_flow;default: VERIFY_NOT_REACHED();}/*switch end*/
+}
+}
+}
+
+bool has_control_flow(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr,bool const include_loop_control_flow) {
+{
+{auto&& __jakt_match_variant = *expr;
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Boolean */:case 1 /* NumericConstant */:case 2 /* QuotedString */:case 3 /* ByteConstant */:case 4 /* CharacterConstant */:case 5 /* CCharacterConstant */:case 23 /* NamespacedVar */:case 24 /* Var */:case 25 /* OptionalNone */:case 29 /* Function */:case 30 /* DependentFunction */:case 34 /* Reflect */:case 35 /* Garbage */:return false;case 6 /* UnaryOp */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
+return Jakt::codegen::has_control_flow(expr,include_loop_control_flow);};/*case end*/
+case 15 /* IndexedTuple */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.IndexedTuple;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
+return Jakt::codegen::has_control_flow(expr,include_loop_control_flow);};/*case end*/
+case 16 /* IndexedStruct */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.IndexedStruct;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
+return Jakt::codegen::has_control_flow(expr,include_loop_control_flow);};/*case end*/
+case 17 /* IndexedCommonEnumMember */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.IndexedCommonEnumMember;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
+return Jakt::codegen::has_control_flow(expr,include_loop_control_flow);};/*case end*/
+case 20 /* EnumVariantArg */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariantArg;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
+return Jakt::codegen::has_control_flow(expr,include_loop_control_flow);};/*case end*/
+case 26 /* OptionalSome */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
+return Jakt::codegen::has_control_flow(expr,include_loop_control_flow);};/*case end*/
+case 27 /* ForcedUnwrap */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.ForcedUnwrap;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
+return Jakt::codegen::has_control_flow(expr,include_loop_control_flow);};/*case end*/
+case 31 /* Must */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Must;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
+return Jakt::codegen::has_control_flow(expr,include_loop_control_flow);};/*case end*/
+case 7 /* BinaryOp */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.BinaryOp;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& lhs = __jakt_match_value.lhs;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const& rhs = __jakt_match_value.rhs;
+return Jakt::codegen::has_control_flow(lhs,include_loop_control_flow) || Jakt::codegen::has_control_flow(rhs,include_loop_control_flow);};/*case end*/
+case 13 /* IndexedExpression */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.IndexedExpression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& lhs = __jakt_match_value.expr;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const& rhs = __jakt_match_value.index;
+return Jakt::codegen::has_control_flow(lhs,include_loop_control_flow) || Jakt::codegen::has_control_flow(rhs,include_loop_control_flow);};/*case end*/
+case 14 /* IndexedDictionary */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.IndexedDictionary;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& lhs = __jakt_match_value.expr;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const& rhs = __jakt_match_value.index;
+return Jakt::codegen::has_control_flow(lhs,include_loop_control_flow) || Jakt::codegen::has_control_flow(rhs,include_loop_control_flow);};/*case end*/
+case 18 /* ComptimeIndex */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.ComptimeIndex;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& lhs = __jakt_match_value.expr;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const& rhs = __jakt_match_value.index;
+return Jakt::codegen::has_control_flow(lhs,include_loop_control_flow) || Jakt::codegen::has_control_flow(rhs,include_loop_control_flow);};/*case end*/
+case 8 /* JaktTuple */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& vals = __jakt_match_value.vals;
+return Jakt::codegen::has_control_flow<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(vals,include_loop_control_flow);};/*case end*/
+case 10 /* JaktArray */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& vals = __jakt_match_value.vals;
+return Jakt::codegen::has_control_flow<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(vals,include_loop_control_flow);};/*case end*/
+case 11 /* JaktSet */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& vals = __jakt_match_value.vals;
+return Jakt::codegen::has_control_flow<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(vals,include_loop_control_flow);};/*case end*/
+case 9 /* Range */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Range;JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& from = __jakt_match_value.from;
+JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& to = __jakt_match_value.to;
+return Jakt::codegen::has_control_flow<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(from,include_loop_control_flow) || Jakt::codegen::has_control_flow<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(to,include_loop_control_flow);};/*case end*/
+case 12 /* JaktDictionary */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>> const& vals = __jakt_match_value.vals;
+return Jakt::codegen::has_control_flow<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>(vals,include_loop_control_flow);};/*case end*/
+case 19 /* Match */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Match;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
+JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const& match_cases = __jakt_match_value.match_cases;
+return Jakt::codegen::has_control_flow(expr,include_loop_control_flow) || Jakt::codegen::has_control_flow<Jakt::types::CheckedMatchCase>(match_cases,true);};/*case end*/
+case 21 /* Call */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::types::CheckedCall const& call = __jakt_match_value.call;
+return Jakt::codegen::has_control_flow<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>(call.args,include_loop_control_flow);};/*case end*/
+case 22 /* MethodCall */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.MethodCall;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
+Jakt::types::CheckedCall const& call = __jakt_match_value.call;
+return Jakt::codegen::has_control_flow(expr,include_loop_control_flow) || Jakt::codegen::has_control_flow<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>(call.args,include_loop_control_flow);};/*case end*/
+case 28 /* Block */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
+return Jakt::codegen::has_control_flow(block,include_loop_control_flow);};/*case end*/
+case 32 /* Try */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Try;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
+JaktInternal::Optional<Jakt::types::CheckedBlock> const& catch_block = __jakt_match_value.catch_block;
+return Jakt::codegen::has_control_flow(expr,include_loop_control_flow) || Jakt::codegen::has_control_flow<Jakt::types::CheckedBlock>(catch_block,include_loop_control_flow);};/*case end*/
+case 33 /* TryBlock */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.TryBlock;NonnullRefPtr<typename Jakt::types::CheckedStatement> const& stmt = __jakt_match_value.stmt;
+Jakt::types::CheckedBlock const& catch_block = __jakt_match_value.catch_block;
+return Jakt::codegen::has_control_flow(stmt,include_loop_control_flow) || Jakt::codegen::has_control_flow(catch_block,include_loop_control_flow);};/*case end*/
+default: VERIFY_NOT_REACHED();}/*switch end*/
+}
+}
+}
+
+bool has_control_flow(JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const dict_pair,bool const include_loop_control_flow) {
+{
+return Jakt::codegen::has_control_flow(dict_pair.template get<0>(),include_loop_control_flow) || Jakt::codegen::has_control_flow(dict_pair.template get<1>(),include_loop_control_flow);
+}
+}
+
+bool has_control_flow(JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const call_arg,bool const include_loop_control_flow) {
+{
+return Jakt::codegen::has_control_flow(call_arg.template get<1>(),include_loop_control_flow);
+}
+}
+
 ByteString Jakt::codegen::ControlFlowState::debug_description() const { auto builder = ByteStringBuilder::create();builder.append("ControlFlowState("sv);{
 JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};
 JaktInternal::PrettyPrint::must_output_indentation(builder);
@@ -130,47 +287,27 @@ return Jakt::codegen::ControlFlowState(this->allowed_exits.allow_return(),this->
 
 ErrorOr<ByteString> Jakt::codegen::ControlFlowState::apply_control_flow_macro(ByteString const x,Jakt::ids::TypeId const func_return_type,bool const func_can_throw) const {
 {
-ByteString const handle_loop_controls = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (Jakt::codegen::are_loop_exits_allowed(this->allowed_exits));
-if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}else if (__jakt_enum_value) {{
-JaktInternal::Tuple<ByteString,ByteString> const break_stmt_continue_stmt_ = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<ByteString,ByteString>,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (this->directly_inside_match);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Tuple{ByteString::from_utf8_without_validation("return JaktInternal::LoopBreak {}"sv), ByteString::from_utf8_without_validation("return JaktInternal::LoopContinue {}"sv)});
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Tuple{ByteString::from_utf8_without_validation("break"sv), ByteString::from_utf8_without_validation("continue"sv)});
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const handle_loop_controls = [&]() -> ByteString { auto __jakt_enum_value = Jakt::codegen::are_loop_exits_allowed(this->allowed_exits);
+if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation(""sv);}else if (__jakt_enum_value) {{
+JaktInternal::Tuple<ByteString,ByteString> const break_stmt_continue_stmt_ = [&]() -> JaktInternal::Tuple<ByteString,ByteString> { auto __jakt_enum_value = this->directly_inside_match;
+if (__jakt_enum_value) {return Tuple{ByteString::from_utf8_without_validation("return JaktInternal::LoopBreak {}"sv), ByteString::from_utf8_without_validation("return JaktInternal::LoopContinue {}"sv)};}else if (!__jakt_enum_value) {return Tuple{ByteString::from_utf8_without_validation("break"sv), ByteString::from_utf8_without_validation("continue"sv)};}VERIFY_NOT_REACHED();
+ 
+}();
 ByteString const break_stmt = break_stmt_continue_stmt_.template get<0>();
 ByteString const continue_stmt = break_stmt_continue_stmt_.template get<1>();
 
-return JaktInternal::ExplicitValue<ByteString>(__jakt_format(StringView::from_string_literal("if (_jakt_value.is_loop_break())\n        {};\n    if (_jakt_value.is_loop_continue())\n        {};\n    "sv),break_stmt,continue_stmt));
+return __jakt_format(StringView::from_string_literal("if (_jakt_value.is_loop_break())\n        {};\n    if (_jakt_value.is_loop_continue())\n        {};\n    "sv),break_stmt,continue_stmt);
 }
 VERIFY_NOT_REACHED();
 }VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 bool const cpp_func_returns_void = (!func_can_throw) && ((func_return_type.equals(Jakt::types::void_type_id()) || func_return_type.equals(Jakt::types::unknown_type_id())) || func_return_type.equals(Jakt::types::never_type_id()));
 bool const substitute_naked_return = this->indirectly_inside_match && cpp_func_returns_void;
-ByteString const forward_return_expr = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (substitute_naked_return);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("{}"sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("_jakt_value.release_return()"sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const forward_return_expr = [&]() -> ByteString { auto __jakt_enum_value = substitute_naked_return;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation("{}"sv);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation("_jakt_value.release_return()"sv);}VERIFY_NOT_REACHED();
+ 
+}();
 return __jakt_format(StringView::from_string_literal("({{\n    auto&& _jakt_value = {0};\n    if (_jakt_value.is_return())\n        return {1};\n    {2}_jakt_value.release_value();\n}})"sv),x,forward_return_expr,handle_loop_controls);
 }
 }
@@ -207,9 +344,9 @@ if (!this->line_spans.contains(file_idx)){
 return ByteString::from_utf8_without_validation(""sv);
 }
 size_t line_index = static_cast<size_t>(0ULL);
-while (line_index < this->line_spans.operator[](file_idx).size()){
-if ((span.start >= this->line_spans.operator[](file_idx).operator[](line_index).start) && (span.start <= this->line_spans.operator[](file_idx).operator[](line_index).end)){
-size_t const column_index = JaktInternal::checked_sub(span.start,this->line_spans.operator[](file_idx).operator[](line_index).start);
+while (line_index < this->line_spans[file_idx].size()){
+if ((span.start >= this->line_spans[file_idx][line_index].start) && (span.start <= this->line_spans[file_idx][line_index].end)){
+size_t const column_index = JaktInternal::checked_sub(span.start,this->line_spans[file_idx][line_index].start);
 return __jakt_format(StringView::from_string_literal("{} \"{}\""sv),JaktInternal::checked_add(line_index,static_cast<size_t>(1ULL)),this->compiler->get_file_path(span.file_id).value().to_string());
 }
 line_index += static_cast<size_t>(1ULL);
@@ -239,14 +376,14 @@ this->line_spans.set(file_idx,empty_array);
 size_t idx = static_cast<size_t>(0ULL);
 size_t start = idx;
 while (idx < this->compiler->current_file_contents.size()){
-if (this->compiler->current_file_contents.operator[](idx) == static_cast<u8>(u8'\n')){
-this->line_spans.operator[](file_idx).push(Jakt::codegen::LineSpan(start,idx));
+if (this->compiler->current_file_contents[idx] == static_cast<u8>(u8'\n')){
+this->line_spans[file_idx].push(Jakt::codegen::LineSpan(start,idx));
 start = JaktInternal::checked_add(idx,static_cast<size_t>(1ULL));
 }
 idx += static_cast<size_t>(1ULL);
 }
 if (start < idx){
-this->line_spans.operator[](file_idx).push(Jakt::codegen::LineSpan(start,idx));
+this->line_spans[file_idx].push(Jakt::codegen::LineSpan(start,idx));
 }
 }
 
@@ -290,14 +427,17 @@ builder.appendff("generic_inferences: {}, ", generic_inferences);
 JaktInternal::PrettyPrint::must_output_indentation(builder);
 builder.appendff("used_modules: {}, ", used_modules);
 JaktInternal::PrettyPrint::must_output_indentation(builder);
-builder.appendff("yield_method: {}", yield_method);
+builder.appendff("yield_method: {}, ", yield_method);
+JaktInternal::PrettyPrint::must_output_indentation(builder);
+builder.appendff("yields_erroror: {}", yields_erroror);
 }
 builder.append(")"sv);return builder.to_string(); }
-ByteString Jakt::codegen::CodeGenerator::current_error_handler(bool const forward_error_with_try) const {
+ByteString Jakt::codegen::CodeGenerator::current_error_handler(bool const forward_error_with_try) {
 {
 if (this->inside_defer || ((this->current_function.has_value() && this->current_function.value()->return_type_id.equals(Jakt::types::never_type_id())) && (!this->control_flow_state.passes_through_try))){
 return ByteString::from_utf8_without_validation("MUST"sv);
 }
+this->yields_erroror = true;
 if (forward_error_with_try){
 if (this->control_flow_state.indirectly_inside_try_block){
 return ByteString::from_utf8_without_validation("TRY_EXPLICIT"sv);
@@ -372,7 +512,7 @@ break;
 }
 NonnullRefPtr<Jakt::types::Module> module = _magic_value.value();
 {
-if (in_degrees.operator[](module->id.id) == static_cast<i64>(0LL)){
+if (in_degrees[module->id.id] == static_cast<i64>(0LL)){
 stack.push(module->id);
 }
 }
@@ -385,7 +525,7 @@ while (!stack.is_empty()){
 Jakt::ids::ModuleId const id = stack.pop().value();
 sorted_modules.push(id);
 {
-JaktInternal::ArrayIterator<Jakt::ids::ModuleId> _magic = this->program->modules.operator[](id.id)->imports.iterator();
+JaktInternal::ArrayIterator<Jakt::ids::ModuleId> _magic = this->program->modules[id.id]->imports.iterator();
 for (;;){
 JaktInternal::Optional<Jakt::ids::ModuleId> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
@@ -393,7 +533,7 @@ break;
 }
 Jakt::ids::ModuleId imported_module = _magic_value.value();
 {
-i64 const module_in_degrees = in_degrees.operator[](imported_module.id);
+i64 const module_in_degrees = in_degrees[imported_module.id];
 in_degrees.set(imported_module.id,JaktInternal::checked_sub(module_in_degrees,static_cast<i64>(1LL)));
 if (module_in_degrees == static_cast<i64>(1LL)){
 stack.push(Jakt::ids::ModuleId(imported_module.id));
@@ -413,7 +553,7 @@ Jakt::utility::panic(ByteString::from_utf8_without_validation("Cyclic module imp
 
 ErrorOr<JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<ByteString,ByteString>>> Jakt::codegen::CodeGenerator::generate(NonnullRefPtr<Jakt::compiler::Compiler> const compiler,NonnullRefPtr<Jakt::types::CheckedProgram> const program,bool const debug_info,JaktInternal::Dictionary<ByteString,ByteString>& exported_files) {
 {
-Jakt::codegen::CodeGenerator generator = Jakt::codegen::CodeGenerator(compiler,program,Jakt::codegen::ControlFlowState::no_control_flow(),DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>::create_with({}),ByteStringBuilder::create(),JaktInternal::OptionalNone(),false,Jakt::codegen::CodegenDebugInfo(compiler,Dictionary<size_t, JaktInternal::DynamicArray<Jakt::codegen::LineSpan>>::create_with_entries({}),debug_info),DynamicArray<ByteString>::create_with({}),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),Set<Jakt::ids::ModuleId>::create_with_values({}),JaktInternal::OptionalNone());
+Jakt::codegen::CodeGenerator generator = Jakt::codegen::CodeGenerator(compiler,program,Jakt::codegen::ControlFlowState::no_control_flow(),DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>::create_with({}),ByteStringBuilder::create(),JaktInternal::OptionalNone(),false,Jakt::codegen::CodegenDebugInfo(compiler,Dictionary<size_t, JaktInternal::DynamicArray<Jakt::codegen::LineSpan>>::create_with_entries({}),debug_info),DynamicArray<ByteString>::create_with({}),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),Set<Jakt::ids::ModuleId>::create_with_values({}),JaktInternal::OptionalNone(),false);
 JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<ByteString,ByteString>> result = Dictionary<ByteString, JaktInternal::Tuple<ByteString,ByteString>>::create_with_entries({});
 ByteStringBuilder output = ByteStringBuilder::create();
 JaktInternal::DynamicArray<Jakt::ids::ModuleId> const sorted_modules = generator.topologically_sort_modules();
@@ -427,30 +567,19 @@ break;
 }
 size_t idx = _magic_value.value();
 {
-size_t const i = sorted_modules.operator[](JaktInternal::checked_sub(idx,static_cast<size_t>(1ULL))).id;
+size_t const i = sorted_modules[JaktInternal::checked_sub(idx,static_cast<size_t>(1ULL))].id;
 if (i == static_cast<size_t>(0ULL)){
 continue;
 }
-NonnullRefPtr<Jakt::types::Module> const module = generator.program->modules.operator[](i);
+NonnullRefPtr<Jakt::types::Module> const module = generator.program->modules[i];
 generator.compiler->dbg_println(__jakt_format(StringView::from_string_literal("generate: module idx: {}, module.name {} - forward: {}"sv),i,module->name,true));
 ByteString const header_name = __jakt_format(StringView::from_string_literal("{}.h"sv),module->name);
 output.clear();
 output.append(StringView::from_string_literal("#pragma once\n"sv));
 output.append(StringView::from_string_literal("#include <lib.h>\n"sv));
-size_t const main_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<ByteString,ByteString>>>> {
-auto __jakt_enum_value = (module->id.id);
-if (__jakt_enum_value == static_cast<size_t>(1ULL)) {return JaktInternal::ExplicitValue(static_cast<size_t>(1ULL));
-}else {return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+size_t const main_id = [&]() -> size_t { auto __jakt_enum_value = module->id.id;
+if (__jakt_enum_value == static_cast<size_t>(1ULL)) {return static_cast<size_t>(1ULL);}else {return static_cast<size_t>(0ULL);} 
+}();
 Jakt::ids::ScopeId const scope_id = Jakt::ids::ScopeId(module->id,main_id);
 NonnullRefPtr<Jakt::types::Scope> const scope = generator.program->get_scope(scope_id);
 {
@@ -477,9 +606,7 @@ break;
 }
 Jakt::parser::IncludeAction action = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<ByteString,ByteString>>>>{
-auto&& __jakt_match_variant = action;
+{auto&& __jakt_match_variant = action;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Define */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Define;ByteString const& name = __jakt_match_value.name;
@@ -490,8 +617,7 @@ output.appendff(ByteString::from_utf8_without_validation("#undef {}\n"sv),name);
 output.append(StringView::from_string_literal("#endif\n"sv));
 output.appendff(ByteString::from_utf8_without_validation("#define {} {}\n"sv),name,value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_154;};/*case end*/
 case 1 /* Undefine */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Undefine;ByteString const& name = __jakt_match_value.name;
 {
@@ -499,19 +625,9 @@ output.appendff(ByteString::from_utf8_without_validation("#ifdef {}\n"sv),name);
 output.appendff(ByteString::from_utf8_without_validation("#undef {}\n"sv),name);
 output.append(StringView::from_string_literal("#endif\n"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_154;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+break;}goto __jakt_label_154; __jakt_label_154:;;
 }
 
 }
@@ -527,9 +643,7 @@ break;
 }
 Jakt::parser::IncludeAction action = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<ByteString,ByteString>>>>{
-auto&& __jakt_match_variant = action;
+{auto&& __jakt_match_variant = action;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Define */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Define;ByteString const& name = __jakt_match_value.name;
@@ -540,8 +654,7 @@ output.appendff(ByteString::from_utf8_without_validation("#undef {}\n"sv),name);
 output.append(StringView::from_string_literal("#endif\n"sv));
 output.appendff(ByteString::from_utf8_without_validation("#define {} {}\n"sv),name,value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_155;};/*case end*/
 case 1 /* Undefine */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Undefine;ByteString const& name = __jakt_match_value.name;
 {
@@ -549,19 +662,9 @@ output.appendff(ByteString::from_utf8_without_validation("#ifdef {}\n"sv),name);
 output.appendff(ByteString::from_utf8_without_validation("#undef {}\n"sv),name);
 output.append(StringView::from_string_literal("#endif\n"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_155;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+break;}goto __jakt_label_155; __jakt_label_155:;;
 }
 
 }
@@ -605,7 +708,7 @@ break;
 Jakt::ids::ModuleId id = _magic_value.value();
 {
 if ((id.id != static_cast<size_t>(0ULL)) && (id.id != module->id.id)){
-NonnullRefPtr<Jakt::types::Module> const module = generator.program->modules.operator[](id.id);
+NonnullRefPtr<Jakt::types::Module> const module = generator.program->modules[id.id];
 output.appendff(ByteString::from_utf8_without_validation("#include \"{}.h\"\n"sv),module->name);
 }
 else {
@@ -634,11 +737,11 @@ break;
 }
 size_t idx = _magic_value.value();
 {
-size_t const i = sorted_modules.operator[](JaktInternal::checked_sub(idx,static_cast<size_t>(1ULL))).id;
+size_t const i = sorted_modules[JaktInternal::checked_sub(idx,static_cast<size_t>(1ULL))].id;
 if (i == static_cast<size_t>(0ULL)){
 continue;
 }
-NonnullRefPtr<Jakt::types::Module> const module = generator.program->modules.operator[](i);
+NonnullRefPtr<Jakt::types::Module> const module = generator.program->modules[i];
 generator.compiler->dbg_println(__jakt_format(StringView::from_string_literal("generate: module idx: {}, module.name {} - forward: {}"sv),i,module->name,false));
 ByteString const header_name = __jakt_format(StringView::from_string_literal("{}.h"sv),module->name);
 ByteString const impl_name = __jakt_format(StringView::from_string_literal("{}.cpp"sv),module->name);
@@ -646,20 +749,9 @@ output.clear();
 output.append(StringView::from_string_literal("#ifdef _WIN32\n"sv));
 output.append(StringView::from_string_literal("extern \"C\" __cdecl int SetConsoleOutputCP(unsigned int code_page);\n"sv));
 output.append(StringView::from_string_literal("#endif\n"sv));
-size_t const main_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<ByteString,ByteString>>>> {
-auto __jakt_enum_value = (module->id.id);
-if (__jakt_enum_value == static_cast<size_t>(1ULL)) {return JaktInternal::ExplicitValue(static_cast<size_t>(1ULL));
-}else {return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+size_t const main_id = [&]() -> size_t { auto __jakt_enum_value = module->id.id;
+if (__jakt_enum_value == static_cast<size_t>(1ULL)) {return static_cast<size_t>(1ULL);}else {return static_cast<size_t>(0ULL);} 
+}();
 Jakt::ids::ScopeId const scope_id = Jakt::ids::ScopeId(module->id,main_id);
 NonnullRefPtr<Jakt::types::Scope> const scope = generator.program->get_scope(scope_id);
 if (!module->is_root){
@@ -672,9 +764,9 @@ TRY((gen.codegen_namespace(scope,module,output)));
 return {};
 }
 ,inside_namespace)));
-JaktInternal::Optional<JaktInternal::Set<Jakt::ids::ModuleId>> __jakt_tmp379 = modules_in_header.get(i);
-if (__jakt_tmp379.has_value()){
-JaktInternal::Set<Jakt::ids::ModuleId> const already_included = __jakt_tmp379.value();
+JaktInternal::Optional<JaktInternal::Set<Jakt::ids::ModuleId>> __jakt_tmp245 = modules_in_header.get(i);
+if (__jakt_tmp245.has_value()){
+JaktInternal::Set<Jakt::ids::ModuleId> const already_included = __jakt_tmp245.value();
 {
 JaktInternal::SetIterator<Jakt::ids::ModuleId> _magic = already_included.iterator();
 for (;;){
@@ -711,7 +803,7 @@ Jakt::ids::ModuleId id = _magic_value.value();
 if (id.id == static_cast<size_t>(0ULL)){
 continue;
 }
-NonnullRefPtr<Jakt::types::Module> const module = generator.program->modules.operator[](id.id);
+NonnullRefPtr<Jakt::types::Module> const module = generator.program->modules[id.id];
 output.appendff(ByteString::from_utf8_without_validation("#include \"{}.h\"\n"sv),module->name);
 }
 
@@ -741,24 +833,13 @@ break;
 }
 size_t idx = _magic_value.value();
 {
-size_t const i = sorted_modules.operator[](JaktInternal::checked_sub(idx,static_cast<size_t>(1ULL))).id;
-NonnullRefPtr<Jakt::types::Module> const module = generator.program->modules.operator[](i);
+size_t const i = sorted_modules[JaktInternal::checked_sub(idx,static_cast<size_t>(1ULL))].id;
+NonnullRefPtr<Jakt::types::Module> const module = generator.program->modules[i];
 ByteString const header_name = __jakt_format(StringView::from_string_literal("{}.h"sv),module->name);
 ByteString const impl_name = __jakt_format(StringView::from_string_literal("{}_specializations.cpp"sv),module->name);
-size_t const main_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<ByteString,ByteString>>>> {
-auto __jakt_enum_value = (module->id.id);
-if (__jakt_enum_value == static_cast<size_t>(1ULL)) {return JaktInternal::ExplicitValue(static_cast<size_t>(1ULL));
-}else {return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+size_t const main_id = [&]() -> size_t { auto __jakt_enum_value = module->id.id;
+if (__jakt_enum_value == static_cast<size_t>(1ULL)) {return static_cast<size_t>(1ULL);}else {return static_cast<size_t>(0ULL);} 
+}();
 Jakt::ids::ScopeId const scope_id = Jakt::ids::ScopeId(module->id,main_id);
 NonnullRefPtr<Jakt::types::Scope> const scope = generator.program->get_scope(scope_id);
 ByteStringBuilder code_output = ByteStringBuilder::create();
@@ -771,9 +852,9 @@ TRY((gen.codegen_namespace_specializations(scope,module,output)));
 return {};
 }
 ,code_output)));
-JaktInternal::Optional<JaktInternal::Set<Jakt::ids::ModuleId>> __jakt_tmp380 = modules_in_header.get(i);
-if (__jakt_tmp380.has_value()){
-JaktInternal::Set<Jakt::ids::ModuleId> const already_included = __jakt_tmp380.value();
+JaktInternal::Optional<JaktInternal::Set<Jakt::ids::ModuleId>> __jakt_tmp246 = modules_in_header.get(i);
+if (__jakt_tmp246.has_value()){
+JaktInternal::Set<Jakt::ids::ModuleId> const already_included = __jakt_tmp246.value();
 {
 JaktInternal::SetIterator<Jakt::ids::ModuleId> _magic = already_included.iterator();
 for (;;){
@@ -811,7 +892,7 @@ Jakt::ids::ModuleId id = _magic_value.value();
 if (id.id == static_cast<size_t>(0ULL)){
 continue;
 }
-NonnullRefPtr<Jakt::types::Module> const module = generator.program->modules.operator[](id.id);
+NonnullRefPtr<Jakt::types::Module> const module = generator.program->modules[id.id];
 output.appendff(ByteString::from_utf8_without_validation("#include \"{}.h\"\n"sv),module->name);
 }
 
@@ -865,7 +946,7 @@ JaktInternal::DynamicArray<Jakt::parser::ParsedName> const unprefixed_name = jak
 used_modules.add(type_id.module);
 bool const should_be_namespaced = unprefixed_name.size() > static_cast<size_t>(1ULL);
 if (should_be_namespaced){
-cpp_code.appendff(ByteString::from_utf8_without_validation("namespace {}"sv),unprefixed_name.operator[](static_cast<i64>(0LL)).name);
+cpp_code.appendff(ByteString::from_utf8_without_validation("namespace {}"sv),unprefixed_name[static_cast<i64>(0LL)].name);
 if (unprefixed_name.size() > static_cast<size_t>(2ULL)){
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(1ULL)),static_cast<size_t>(JaktInternal::checked_sub(unprefixed_name.size(),static_cast<size_t>(1ULL)))};
@@ -876,7 +957,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-cpp_code.append(__jakt_format(StringView::from_string_literal("::{}"sv),unprefixed_name.operator[](i).name));
+cpp_code.append(__jakt_format(StringView::from_string_literal("::{}"sv),unprefixed_name[i].name));
 }
 
 }
@@ -908,7 +989,7 @@ break;
 }
 Jakt::ids::ModuleId id = _magic_value.value();
 {
-NonnullRefPtr<Jakt::types::Module> const module = generator.program->modules.operator[](id.id);
+NonnullRefPtr<Jakt::types::Module> const module = generator.program->modules[id.id];
 Jakt::jakt__path::Path const module_path = binary_dir.join(__jakt_format(StringView::from_string_literal("{}.h"sv),module->name));
 Jakt::jakt__path::Path const module_path_relative = module_path.relative_to(export_dir);
 output.appendff(ByteString::from_utf8_without_validation("#include \"{}\"\n"sv),module_path_relative.to_string());
@@ -1052,35 +1133,24 @@ dependencies.push(dependency);
 
 return dependencies;
 }
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const inner_dependencies = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::ids::TypeId>, JaktInternal::DynamicArray<Jakt::ids::TypeId>>{
-auto&& __jakt_match_variant = *type_;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const inner_dependencies = [&]() -> JaktInternal::DynamicArray<Jakt::ids::TypeId> { auto&& __jakt_match_variant = *type_;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->extract_dependencies_from_enum(enum_id,dependency_graph,top_level));
-};/*case end*/
+return this->extract_dependencies_from_enum(enum_id,dependency_graph,top_level);};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(this->extract_dependencies_from_enum(id,dependency_graph,top_level));
-};/*case end*/
+return this->extract_dependencies_from_enum(id,dependency_graph,top_level);};/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->extract_dependencies_from_struct(id,dependency_graph,top_level,DynamicArray<Jakt::ids::TypeId>::create_with({})));
-};/*case end*/
+return this->extract_dependencies_from_struct(id,dependency_graph,top_level,DynamicArray<Jakt::ids::TypeId>::create_with({}));};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(this->extract_dependencies_from_struct(id,dependency_graph,top_level,args));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(DynamicArray<Jakt::ids::TypeId>::create_with({}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return this->extract_dependencies_from_struct(id,dependency_graph,top_level,args);};/*case end*/
+default:return DynamicArray<Jakt::ids::TypeId>::create_with({});}/*switch end*/
+ 
+}();
 {
 JaktInternal::ArrayIterator<Jakt::ids::TypeId> _magic = inner_dependencies.iterator();
 for (;;){
@@ -1142,9 +1212,7 @@ break;
 }
 Jakt::types::CheckedEnumVariant variant = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, JaktInternal::DynamicArray<Jakt::ids::TypeId>>{
-auto&& __jakt_match_variant = variant;
+{auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
@@ -1166,8 +1234,7 @@ dependencies.push(dependency);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_156;};/*case end*/
 case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;JaktInternal::DynamicArray<Jakt::ids::VarId> const& fields = __jakt_match_value.fields;
 {
@@ -1203,22 +1270,11 @@ dependencies.push(dependency);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_156;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_156;}/*switch end*/
+break;}goto __jakt_label_156; __jakt_label_156:;;
 }
 
 }
@@ -1252,23 +1308,11 @@ break;
 }
 Jakt::ids::TypeId inner_type = _magic_value.value();
 {
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const inner_dependencies = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::ids::TypeId>, JaktInternal::DynamicArray<Jakt::ids::TypeId>>{
-auto&& __jakt_match_variant = *this->program->get_type(inner_type);
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const inner_dependencies = [&]() -> JaktInternal::DynamicArray<Jakt::ids::TypeId> { auto&& __jakt_match_variant = *this->program->get_type(inner_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 24 /* Enum */:case 23 /* Struct */:return JaktInternal::ExplicitValue(this->extract_dependencies_from(inner_type,dependency_graph,false));
-default:return JaktInternal::ExplicitValue(DynamicArray<Jakt::ids::TypeId>::create_with({}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+case 24 /* Enum */:case 23 /* Struct */:return this->extract_dependencies_from(inner_type,dependency_graph,false);default:return DynamicArray<Jakt::ids::TypeId>::create_with({});}/*switch end*/
+ 
+}();
 {
 JaktInternal::ArrayIterator<Jakt::ids::TypeId> _magic = inner_dependencies.iterator();
 for (;;){
@@ -1367,7 +1411,7 @@ return {};
 }
 JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>> const previous_function = this->current_function;
 this->current_function = function;
-ScopeGuard __jakt_var_114([&] {
+ScopeGuard __jakt_var_110([&] {
 this->current_function = previous_function;
 });
 if ((((function->linkage.__jakt_init_index() == 1 /* External */) || (function->type.__jakt_init_index() == 3 /* ImplicitConstructor */)) || (function->type.__jakt_init_index() == 4 /* ImplicitEnumConstructor */)) || (function->type.__jakt_init_index() == 2 /* Destructor */)){
@@ -1376,34 +1420,25 @@ return {};
 if (function->generics->params.is_empty() || (!function->specialization_index.has_value())){
 return {};
 }
-if (containing_struct.has_value() && (!({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, ErrorOr<void>>{
-auto&& __jakt_match_variant = *this->program->get_type(containing_struct.value());
+if (containing_struct.has_value() && (![&]() -> bool { auto&& __jakt_match_variant = *this->program->get_type(containing_struct.value());
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->program->get_struct(struct_id).generic_parameters.is_empty());
-};/*case end*/
+return this->program->get_struct(struct_id).generic_parameters.is_empty();};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& struct_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->program->get_enum(struct_id).generic_parameters.is_empty());
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}))){
+return this->program->get_enum(struct_id).generic_parameters.is_empty();};/*case end*/
+default:return false;}/*switch end*/
+ 
+}())){
 return {};
 }
-bool const is_full_respecialization = this->is_full_respecialization(function->generics->specializations.operator[](function->specialization_index.value()));
+bool const is_full_respecialization = this->is_full_respecialization(function->generics->specializations[function->specialization_index.value()]);
 if (define_pass && is_full_respecialization){
 output.append(StringView::from_string_literal("template<"sv));
 bool first = true;
 {
-JaktInternal::ArrayIterator<Jakt::ids::TypeId> _magic = function->generics->specializations.operator[](function->specialization_index.value()).iterator();
+JaktInternal::ArrayIterator<Jakt::ids::TypeId> _magic = function->generics->specializations[function->specialization_index.value()].iterator();
 for (;;){
 JaktInternal::Optional<Jakt::ids::TypeId> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
@@ -1411,9 +1446,9 @@ break;
 }
 Jakt::ids::TypeId arg = _magic_value.value();
 {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp381 = this->program->get_type(arg);
-if (__jakt_tmp381->__jakt_init_index() == 18 /* TypeVariable */){
-ByteString const name = __jakt_tmp381->as.TypeVariable.name;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp247 = this->program->get_type(arg);
+if (__jakt_tmp247->__jakt_init_index() == 18 /* TypeVariable */){
+ByteString const name = __jakt_tmp247->as.TypeVariable.name;
 if (first){
 first = false;
 }
@@ -1429,12 +1464,12 @@ output.appendff(ByteString::from_utf8_without_validation("typename {}"sv),name);
 }
 
 output.append(StringView::from_string_literal(">\n"sv));
-TRY((this->codegen_function_in_namespace(function,containing_struct,false,true,function->generics->specializations.operator[](function->specialization_index.value()),output)));
+TRY((this->codegen_function_in_namespace(function,containing_struct,false,true,function->generics->specializations[function->specialization_index.value()],output)));
 }
 else if (is_full_respecialization){
 JaktInternal::DynamicArray<ByteString> args = DynamicArray<ByteString>::create_with({});
 {
-JaktInternal::ArrayIterator<Jakt::ids::TypeId> _magic = function->generics->specializations.operator[](function->specialization_index.value()).iterator();
+JaktInternal::ArrayIterator<Jakt::ids::TypeId> _magic = function->generics->specializations[function->specialization_index.value()].iterator();
 for (;;){
 JaktInternal::Optional<Jakt::ids::TypeId> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
@@ -1453,29 +1488,15 @@ output.append(StringView::from_string_literal("\ntemplate<> "sv));
 if (function->return_type_id.equals(Jakt::types::never_type_id())){
 output.append(StringView::from_string_literal("[[noreturn]] "sv));
 }
-output.append(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (function->can_throw);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("ErrorOr<{}>"sv),TRY((this->codegen_type(function->return_type_id)))));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->codegen_type(function->return_type_id))));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+output.append(TRY(([&]() -> ErrorOr<ByteString> { auto __jakt_enum_value = function->can_throw;
+if (__jakt_enum_value) {return __jakt_format(StringView::from_string_literal("ErrorOr<{}>"sv),TRY((this->codegen_type(function->return_type_id))));}else if (!__jakt_enum_value) {return this->codegen_type(function->return_type_id);}VERIFY_NOT_REACHED();
+ 
+}())));
 output.append(StringView::from_string_literal(" "sv));
-ByteString const qualifier = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (containing_struct.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->codegen_type_possibly_as_namespace(containing_struct.value(),true))));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const qualifier = TRY(([&]() -> ErrorOr<ByteString> { auto __jakt_enum_value = containing_struct.has_value();
+if (__jakt_enum_value) {return this->codegen_type_possibly_as_namespace(containing_struct.value(),true);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation(""sv);}VERIFY_NOT_REACHED();
+ 
+}()));
 if (!qualifier.is_empty()){
 output.append(qualifier);
 output.append(StringView::from_string_literal("::"sv));
@@ -1484,7 +1505,7 @@ output.append(function->name_for_codegen().as_name_for_definition());
 output.append(StringView::from_string_literal("<"sv));
 bool first = true;
 {
-JaktInternal::ArrayIterator<Jakt::ids::TypeId> _magic = function->generics->specializations.operator[](function->specialization_index.value()).iterator();
+JaktInternal::ArrayIterator<Jakt::ids::TypeId> _magic = function->generics->specializations[function->specialization_index.value()].iterator();
 for (;;){
 JaktInternal::Optional<Jakt::ids::TypeId> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
@@ -1546,7 +1567,7 @@ output.append(StringView::from_string_literal(" const"sv));
 output.append(StringView::from_string_literal(";\n"sv));
 }
 else {
-output.appendff(ByteString::from_utf8_without_validation("\n/* specialisation {} of function {} omitted, not fully specialized: {} */\n"sv),function->specialization_index.value(),function->name,function->generics->specializations.operator[](function->specialization_index.value()));
+output.appendff(ByteString::from_utf8_without_validation("\n/* specialisation {} of function {} omitted, not fully specialized: {} */\n"sv),function->specialization_index.value(),function->name,function->generics->specializations[function->specialization_index.value()]);
 }
 
 }
@@ -1786,49 +1807,34 @@ break;
 Jakt::ids::TypeId type_id = _magic_value.value();
 {
 NonnullRefPtr<typename Jakt::types::Type> const type_ = this->program->get_type(type_id);
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = *type_;
+{auto&& __jakt_match_variant = *type_;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
 {
 if (!enum_id.module.equals(current_module->id)){
-return JaktInternal::LoopContinue{};
+continue;
 }
 Jakt::types::CheckedEnum const enum_ = this->program->get_enum(enum_id);
 TRY((this->codegen_enum(enum_,inside_namespace)));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_157;};/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
 {
 if (!struct_id.module.equals(current_module->id)){
-return JaktInternal::LoopContinue{};
+continue;
 }
 TRY((this->codegen_struct(this->program->get_struct(struct_id),inside_namespace)));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_157;};/*case end*/
 case 26 /* Trait */:{
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_157;default:{
 Jakt::utility::panic(__jakt_format(StringView::from_string_literal("Unexpected type in dependency graph: {}"sv),type_));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_157;}/*switch end*/
+break;}goto __jakt_label_157; __jakt_label_157:;;
 seen_types.add(type_id);
 }
 
@@ -1925,7 +1931,7 @@ continue;
 }
 JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>> const previous_function = this->current_function;
 this->current_function = function;
-ScopeGuard __jakt_var_115([&] {
+ScopeGuard __jakt_var_111([&] {
 this->current_function = previous_function;
 });
 if ((((function->linkage.__jakt_init_index() == 1 /* External */) || (function->type.__jakt_init_index() == 3 /* ImplicitConstructor */)) || (function->type.__jakt_init_index() == 4 /* ImplicitEnumConstructor */)) || (function->type.__jakt_init_index() == 2 /* Destructor */)){
@@ -2019,7 +2025,7 @@ continue;
 }
 JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>> const previous_function = this->current_function;
 this->current_function = function;
-ScopeGuard __jakt_var_116([&] {
+ScopeGuard __jakt_var_112([&] {
 this->current_function = previous_function;
 });
 if ((((function->linkage.__jakt_init_index() == 1 /* External */) || (function->type.__jakt_init_index() == 3 /* ImplicitConstructor */)) || (function->type.__jakt_init_index() == 4 /* ImplicitEnumConstructor */)) || (function->type.__jakt_init_index() == 2 /* Destructor */)){
@@ -2092,7 +2098,7 @@ continue;
 }
 JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>> const previous_function = this->current_function;
 this->current_function = function;
-ScopeGuard __jakt_var_117([&] {
+ScopeGuard __jakt_var_113([&] {
 this->current_function = previous_function;
 });
 if (function->type.__jakt_init_index() == 3 /* ImplicitConstructor */){
@@ -2184,7 +2190,7 @@ Jakt::ids::FunctionId function_id = _magic_value.value();
 NonnullRefPtr<Jakt::types::CheckedFunction> const function = this->program->get_function(function_id);
 JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>> const previous_function = this->current_function;
 this->current_function = function;
-ScopeGuard __jakt_var_118([&] {
+ScopeGuard __jakt_var_114([&] {
 this->current_function = previous_function;
 });
 if ((!(function->type.__jakt_init_index() == 3 /* ImplicitConstructor */)) && ((!(function->type.__jakt_init_index() == 4 /* ImplicitEnumConstructor */)) && ((!(function->type.__jakt_init_index() == 2 /* Destructor */)) && ((!function->is_comptime) && function->generics->params.is_empty())))){
@@ -2348,7 +2354,7 @@ continue;
 }
 JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>> const previous_function_id = this->current_function;
 this->current_function = static_cast<JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>>>(function);
-ScopeGuard __jakt_var_119([&] {
+ScopeGuard __jakt_var_115([&] {
 this->current_function = previous_function_id;
 });
 if ((!(function->type.__jakt_init_index() == 3 /* ImplicitConstructor */)) && ((!(function->type.__jakt_init_index() == 2 /* Destructor */)) && ([](ByteString const& self, ByteString rhs) -> bool {{
@@ -2457,9 +2463,9 @@ else {
 output.append(StringView::from_string_literal(","sv));
 }
 
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp382 = this->program->get_type(id);
-if (__jakt_tmp382->__jakt_init_index() == 18 /* TypeVariable */){
-bool const is_value = __jakt_tmp382->as.TypeVariable.is_value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp248 = this->program->get_type(id);
+if (__jakt_tmp248->__jakt_init_index() == 18 /* TypeVariable */){
+bool const is_value = __jakt_tmp248->as.TypeVariable.is_value;
 if (is_value){
 output.append(StringView::from_string_literal("auto "sv));
 }
@@ -2528,17 +2534,10 @@ output.append(StringView::from_string_literal("virtual "sv));
 }
 if ((!(function->type.__jakt_init_index() == 2 /* Destructor */)) && (!(function->type.__jakt_init_index() == 1 /* Constructor */))){
 ByteString const naked_return_type = TRY((this->codegen_type(function->return_type_id)));
-ByteString const return_type = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (function->can_throw);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("ErrorOr<{}>"sv),naked_return_type));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(naked_return_type);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const return_type = [&]() -> ByteString { auto __jakt_enum_value = function->can_throw;
+if (__jakt_enum_value) {return __jakt_format(StringView::from_string_literal("ErrorOr<{}>"sv),naked_return_type);}else if (!__jakt_enum_value) {return naked_return_type;}VERIFY_NOT_REACHED();
+ 
+}();
 output.append(return_type);
 }
 }
@@ -2600,20 +2599,11 @@ output.append(StringView::from_string_literal("template <"sv));
 TRY((this->codegen_template_parameter_names(struct_.generic_parameters,output)));
 output.append(StringView::from_string_literal(">"sv));
 }
-output.append(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<StringView, ErrorOr<void>>{
-auto&& __jakt_match_variant = struct_.record_type;
+output.append([&]() -> StringView { auto&& __jakt_match_variant = struct_.record_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 1 /* Class */:return JaktInternal::ExplicitValue(StringView::from_string_literal("class "sv));
-case 0 /* Struct */:return JaktInternal::ExplicitValue(StringView::from_string_literal("struct "sv));
-default:return JaktInternal::ExplicitValue(StringView::from_string_literal(""sv));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+case 1 /* Class */:return StringView::from_string_literal("class "sv);case 0 /* Struct */:return StringView::from_string_literal("struct "sv);default:return StringView::from_string_literal(""sv);}/*switch end*/
+ 
+}());
 output.append(struct_.name_for_codegen().as_name_for_definition());
 output.append(StringView::from_string_literal(";"sv));
 }
@@ -2635,9 +2625,7 @@ TRY((this->codegen_template_parameter_names(struct_.generic_parameters,generic_p
 template_parameters = template_parameters_builder.to_string();
 output.appendff(ByteString::from_utf8_without_validation("template <{}>"sv),template_parameters);
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = struct_.record_type;
+{auto&& __jakt_match_variant = struct_.record_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Class */:{
 ByteString class_name_with_generics = ByteString::from_utf8_without_validation(""sv);
@@ -2744,8 +2732,7 @@ output.append(StringView::from_string_literal("  public:\n"sv));
 output.appendff(ByteString::from_utf8_without_validation("virtual ~{}() = default;\n"sv),struct_.name_for_codegen().as_name_for_definition());
 }
 }
-return JaktInternal::ExplicitValue<void>();
-case 0 /* Struct */:{
+goto __jakt_label_158;case 0 /* Struct */:{
 output.appendff(ByteString::from_utf8_without_validation("struct {}"sv),struct_.name_for_codegen().as_name_for_definition());
 if (struct_.super_struct_id.has_value()){
 output.appendff(ByteString::from_utf8_without_validation(": public {}"sv),TRY((this->codegen_struct_type(struct_.super_struct_id.value(),true))));
@@ -2753,45 +2740,27 @@ output.appendff(ByteString::from_utf8_without_validation(": public {}"sv),TRY((t
 output.append(StringView::from_string_literal(" {\n"sv));
 output.append(StringView::from_string_literal("  public:\n"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* SumEnum */:{
+goto __jakt_label_158;case 3 /* SumEnum */:{
 Jakt::utility::todo(ByteString::from_utf8_without_validation("codegen_struct SumEnum"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* ValueEnum */:{
+goto __jakt_label_158;case 2 /* ValueEnum */:{
 Jakt::utility::todo(ByteString::from_utf8_without_validation("codegen_struct ValueEnum"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_158;default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_158;}/*switch end*/
+}goto __jakt_label_158; __jakt_label_158:;;
 Function<ErrorOr<void>(Jakt::types::CheckedVisibility)> const set_access_level = [&output](Jakt::types::CheckedVisibility visibility) -> ErrorOr<void> {{
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = visibility;
+{auto&& __jakt_match_variant = visibility;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* Restricted */:case 0 /* Public */:{
 output.append(StringView::from_string_literal("public: "sv));
 }
-return JaktInternal::ExplicitValue<void>();
-case 1 /* Private */:{
+return {};case 1 /* Private */:{
 output.append(StringView::from_string_literal("private: "sv));
 }
-return JaktInternal::ExplicitValue<void>();
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}); return {};
+return {};default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 return {};
 }
@@ -2843,7 +2812,7 @@ JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>> const previo
 NonnullRefPtr<Jakt::types::CheckedFunction> const function = this->program->get_function(function_id);
 TRY((set_access_level(function->visibility)));
 this->current_function = static_cast<JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>>>(function);
-ScopeGuard __jakt_var_120([&] {
+ScopeGuard __jakt_var_116([&] {
 this->current_function = previous_function_id;
 });
 if (function->type.__jakt_init_index() == 2 /* Destructor */){
@@ -2946,10 +2915,10 @@ break;
 }
 Jakt::types::CheckedEnumVariant variant = _magic_value.value();
 {
-Jakt::types::CheckedEnumVariant __jakt_tmp383 = variant;
-if (__jakt_tmp383.__jakt_init_index() == 2 /* WithValue */){
-ByteString const name = __jakt_tmp383.as.WithValue.name;
-NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr = __jakt_tmp383.as.WithValue.expr;
+Jakt::types::CheckedEnumVariant __jakt_tmp249 = variant;
+if (__jakt_tmp249.__jakt_init_index() == 2 /* WithValue */){
+ByteString const name = __jakt_tmp249.as.WithValue.name;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr = __jakt_tmp249.as.WithValue.expr;
 output.append(name);
 output.append(StringView::from_string_literal(" = "sv));
 TRY((this->codegen_expression(expr,output,true,false)));
@@ -2993,18 +2962,9 @@ output.append(StringView::from_string_literal(">"sv));
 }
 output.append(StringView::from_string_literal(" {\n"sv));
 size_t const max_index_value = enum_.variants.size();
-ByteString const index_type = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (max_index_value);
-if (__jakt_enum_value >= static_cast<size_t>(0ULL)&&__jakt_enum_value < static_cast<size_t>(256ULL)) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u8"sv));
-}else if (__jakt_enum_value >= static_cast<size_t>(256ULL)&&__jakt_enum_value < static_cast<size_t>(65536ULL)) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u16"sv));
-}else if (__jakt_enum_value >= static_cast<size_t>(65536ULL)&&__jakt_enum_value < static_cast<size_t>(4294967296ULL)) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u32"sv));
-}else {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("size_t"sv));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const index_type = [&]() -> ByteString { auto __jakt_enum_value = max_index_value;
+if (__jakt_enum_value >= static_cast<size_t>(0ULL)&&__jakt_enum_value < static_cast<size_t>(256ULL)) {return ByteString::from_utf8_without_validation("u8"sv);}else if (__jakt_enum_value >= static_cast<size_t>(256ULL)&&__jakt_enum_value < static_cast<size_t>(65536ULL)) {return ByteString::from_utf8_without_validation("u16"sv);}else if (__jakt_enum_value >= static_cast<size_t>(65536ULL)&&__jakt_enum_value < static_cast<size_t>(4294967296ULL)) {return ByteString::from_utf8_without_validation("u32"sv);}else {return ByteString::from_utf8_without_validation("size_t"sv);} 
+}();
 JaktInternal::Tuple<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>,JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>>>> const common_fields_variant_field_list_ = TRY((this->codegen_enum_field_lists(enum_)));
 JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> const common_fields = common_fields_variant_field_list_.template get<0>();
 JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>>> const variant_field_list = common_fields_variant_field_list_.template get<1>();
@@ -3049,8 +3009,8 @@ break;
 }
 size_t variant_index = _magic_value.value();
 {
-Jakt::types::CheckedEnumVariant const variant = enum_.variants.operator[](variant_index);
-JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> const fields = variant_field_list.operator[](variant_index).template get<1>();
+Jakt::types::CheckedEnumVariant const variant = enum_.variants[variant_index];
+JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> const fields = variant_field_list[variant_index].template get<1>();
 if (!fields.is_empty()){
 output.append(StringView::from_string_literal("struct {\n"sv));
 {
@@ -3155,7 +3115,7 @@ Jakt::ids::FunctionId function_id = _magic_value.value();
 NonnullRefPtr<Jakt::types::CheckedFunction> const function = this->program->get_function(function_id);
 JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>> const previous_function_id = this->current_function;
 this->current_function = static_cast<JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>>>(function);
-ScopeGuard __jakt_var_121([&] {
+ScopeGuard __jakt_var_117([&] {
 this->current_function = previous_function_id;
 });
 if (!(function->type.__jakt_init_index() == 4 /* ImplicitEnumConstructor */)){
@@ -3199,7 +3159,7 @@ output.appendff(ByteString::from_utf8_without_validation("{} {}::{}("sv),ctor_re
 
 bool const has_common_fields = !common_fields.is_empty();
 if (has_common_fields){
-JaktInternal::Tuple<ByteString,ByteString> const first_name_first_type_ = common_fields.operator[](static_cast<i64>(0LL));
+JaktInternal::Tuple<ByteString,ByteString> const first_name_first_type_ = common_fields[static_cast<i64>(0LL)];
 ByteString const first_name = first_name_first_type_.template get<0>();
 ByteString const first_type = first_name_first_type_.template get<1>();
 
@@ -3213,7 +3173,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-JaktInternal::Tuple<ByteString,ByteString> const name_type_ = common_fields.operator[](i);
+JaktInternal::Tuple<ByteString,ByteString> const name_type_ = common_fields[i];
 ByteString const name = name_type_.template get<0>();
 ByteString const type = name_type_.template get<1>();
 
@@ -3244,7 +3204,7 @@ output.appendff(ByteString::from_utf8_without_validation(", {} {}"sv),type,name)
 
 }
 else if (!variant_fields.is_empty()){
-JaktInternal::Tuple<ByteString,ByteString> const first_name_first_type_ = variant_fields.operator[](static_cast<i64>(0LL));
+JaktInternal::Tuple<ByteString,ByteString> const first_name_first_type_ = variant_fields[static_cast<i64>(0LL)];
 ByteString const first_name = first_name_first_type_.template get<0>();
 ByteString const first_type = first_name_first_type_.template get<1>();
 
@@ -3258,7 +3218,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-JaktInternal::Tuple<ByteString,ByteString> const name_type_ = variant_fields.operator[](i);
+JaktInternal::Tuple<ByteString,ByteString> const name_type_ = variant_fields[i];
 ByteString const name = name_type_.template get<0>();
 ByteString const type = name_type_.template get<1>();
 
@@ -3286,25 +3246,21 @@ break;
 }
 size_t variant_index = _magic_value.value();
 {
-Jakt::types::CheckedEnumVariant const& variant = enum_.variants.operator[](variant_index);
+Jakt::types::CheckedEnumVariant const& variant = enum_.variants[variant_index];
 ByteString const variant_name = variant.name();
 builder.appendff(ByteString::from_utf8_without_validation("case {} /* {} */:\n"sv),variant_index,variant_name);
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, void>{
-auto&& __jakt_match_variant = variant;
+{auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Untyped */:case 2 /* WithValue */:{
 }
-return JaktInternal::ExplicitValue<void>();
-case 1 /* Typed */:{
+goto __jakt_label_159;case 1 /* Typed */:{
 builder.append(stmt_fmt(__jakt_format(StringView::from_string_literal("as.{}.value"sv),variant_name)));
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* StructLike */: {
+goto __jakt_label_159;case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;JaktInternal::DynamicArray<Jakt::ids::VarId> const& fields = __jakt_match_value.fields;
 {
 {
-JaktInternal::ArrayIterator<Jakt::ids::VarId> _magic = fields.operator[](JaktInternal::Range<size_t>{static_cast<size_t>(common_field_count),static_cast<size_t>(9223372036854775807LL)}).iterator();
+JaktInternal::ArrayIterator<Jakt::ids::VarId> _magic = fields[JaktInternal::Range<size_t>{static_cast<size_t>(common_field_count),static_cast<size_t>(9223372036854775807LL)}].iterator();
 for (;;){
 JaktInternal::Optional<Jakt::ids::VarId> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
@@ -3321,19 +3277,9 @@ builder.append(stmt_fmt(__jakt_format(StringView::from_string_literal("as.{}.{}"
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_159;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+break;}goto __jakt_label_159; __jakt_label_159:;;
 builder.append(StringView::from_string_literal("break;\n"sv));
 }
 
@@ -3356,33 +3302,19 @@ builder.append(StringView::from_string_literal("VERIFY(this->__jakt_variant_inde
 }
 
 Function<ByteString(ByteString)> const assign = [use_move](ByteString accessor) -> ByteString {{
-ByteString const rhs = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ByteString> {
-auto __jakt_enum_value = (use_move);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("move(rhs.{})"sv),accessor));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("rhs.{}"sv),accessor));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const rhs = [&]() -> ByteString { auto __jakt_enum_value = use_move;
+if (__jakt_enum_value) {return __jakt_format(StringView::from_string_literal("move(rhs.{})"sv),accessor);}else if (!__jakt_enum_value) {return __jakt_format(StringView::from_string_literal("rhs.{}"sv),accessor);}VERIFY_NOT_REACHED();
+ 
+}();
 return __jakt_format(StringView::from_string_literal("this->{} = {};\n"sv),accessor,rhs);
 }
 }
 ;
 Function<ByteString(ByteString)> const placement_new = [use_move](ByteString accessor) -> ByteString {{
-ByteString const rhs = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ByteString> {
-auto __jakt_enum_value = (use_move);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("move(rhs.{})"sv),accessor));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("rhs.{}"sv),accessor));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const rhs = [&]() -> ByteString { auto __jakt_enum_value = use_move;
+if (__jakt_enum_value) {return __jakt_format(StringView::from_string_literal("move(rhs.{})"sv),accessor);}else if (!__jakt_enum_value) {return __jakt_format(StringView::from_string_literal("rhs.{}"sv),accessor);}VERIFY_NOT_REACHED();
+ 
+}();
 return __jakt_format(StringView::from_string_literal("new (&this->{0}) (decltype(this->{0}))({1});\n"sv),accessor,rhs);
 }
 }
@@ -3448,28 +3380,14 @@ void Jakt::codegen::CodeGenerator::codegen_enum_constructors(Jakt::types::Checke
 {
 bool const is_generic = !enum_.generic_parameters.is_empty();
 ByteString const ctor_result_type = Jakt::codegen::CodeGenerator::enum_constructor_result_type(enum_,generic_parameter_list);
-ByteString const ctor_type = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,void> {
-auto __jakt_enum_value = (is_generic);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}<{}>"sv),enum_.name,generic_parameter_list));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(enum_.name);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-JaktInternal::Tuple<ByteString,ByteString> const declare_uninit_deref_uninit_ = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<ByteString,ByteString>,void> {
-auto __jakt_enum_value = (enum_.is_boxed);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Tuple{__jakt_format(StringView::from_string_literal("NonnullRefPtr<{0}> __jakt_uninit_enum = adopt_ref(*new {0});\n"sv),ctor_type), ByteString::from_utf8_without_validation("__jakt_uninit_enum->"sv)});
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Tuple{__jakt_format(StringView::from_string_literal("{} __jakt_uninit_enum;\n"sv),enum_.name), ByteString::from_utf8_without_validation("__jakt_uninit_enum."sv)});
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const ctor_type = [&]() -> ByteString { auto __jakt_enum_value = is_generic;
+if (__jakt_enum_value) {return __jakt_format(StringView::from_string_literal("{}<{}>"sv),enum_.name,generic_parameter_list);}else if (!__jakt_enum_value) {return enum_.name;}VERIFY_NOT_REACHED();
+ 
+}();
+JaktInternal::Tuple<ByteString,ByteString> const declare_uninit_deref_uninit_ = [&]() -> JaktInternal::Tuple<ByteString,ByteString> { auto __jakt_enum_value = enum_.is_boxed;
+if (__jakt_enum_value) {return Tuple{__jakt_format(StringView::from_string_literal("NonnullRefPtr<{0}> __jakt_uninit_enum = adopt_ref(*new {0});\n"sv),ctor_type), ByteString::from_utf8_without_validation("__jakt_uninit_enum->"sv)};}else if (!__jakt_enum_value) {return Tuple{__jakt_format(StringView::from_string_literal("{} __jakt_uninit_enum;\n"sv),enum_.name), ByteString::from_utf8_without_validation("__jakt_uninit_enum."sv)};}VERIFY_NOT_REACHED();
+ 
+}();
 ByteString const declare_uninit = declare_uninit_deref_uninit_.template get<0>();
 ByteString const deref_uninit = declare_uninit_deref_uninit_.template get<1>();
 
@@ -3488,7 +3406,7 @@ break;
 }
 size_t variant_index = _magic_value.value();
 {
-JaktInternal::Tuple<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>> const variant_name_variant_fields_ = variant_field_list.operator[](variant_index);
+JaktInternal::Tuple<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>> const variant_name_variant_fields_ = variant_field_list[variant_index];
 ByteString const variant_name = variant_name_variant_fields_.template get<0>();
 JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> const variant_fields = variant_name_variant_fields_.template get<1>();
 
@@ -3615,15 +3533,12 @@ break;
 }
 size_t variant_index = _magic_value.value();
 {
-Jakt::types::CheckedEnumVariant const variant = enum_.variants.operator[](variant_index);
-JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> const fields = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>, ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>,JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>>>>>>{
-auto&& __jakt_match_variant = variant;
+Jakt::types::CheckedEnumVariant const variant = enum_.variants[variant_index];
+JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> const fields = TRY(([&]() -> ErrorOr<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>> { auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Untyped */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Untyped;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>::create_with({}));
-};/*case end*/
+return DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>::create_with({});};/*case end*/
 case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;ByteString const& name = __jakt_match_value.name;
 JaktInternal::DynamicArray<Jakt::ids::VarId> const& own_fields = __jakt_match_value.fields;
@@ -3647,7 +3562,7 @@ fields.push(Tuple{variable->name_for_codegen().as_name_for_definition(), TRY((th
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>>(fields);
+return fields;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -3657,7 +3572,7 @@ Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
 JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> fields = DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>::create_with({});
 fields.push(Tuple{ByteString::from_utf8_without_validation("value"sv), TRY((this->codegen_type(type_id)))});
-return JaktInternal::ExplicitValue<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>>(fields);
+return fields;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -3665,16 +3580,8 @@ default:{
 Jakt::utility::todo(__jakt_format(StringView::from_string_literal("codegen enum variant: {}"sv),variant));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}()));
 variant_field_list.push(Tuple{variant.name(), fields});
 }
 
@@ -3687,26 +3594,15 @@ return Tuple{common_fields, variant_field_list};
 
 JaktInternal::Optional<ByteString> Jakt::codegen::CodeGenerator::destructor_name(Jakt::ids::TypeId const id) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>, JaktInternal::Optional<ByteString>>{
-auto&& __jakt_match_variant = *this->program->get_type(id);
+{auto&& __jakt_match_variant = *this->program->get_type(id);
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 13 /* JaktString */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("ByteString"sv));
-case 20 /* GenericInstance */: {
+case 13 /* JaktString */:return ByteString::from_utf8_without_validation("ByteString"sv);case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
 {
 Jakt::types::CheckedStruct const struct_ = this->program->get_struct(id);
-return JaktInternal::ExplicitValue<JaktInternal::Optional<ByteString>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,JaktInternal::Optional<ByteString>> {
-auto __jakt_enum_value = (struct_.record_type.__jakt_init_index() == 1 /* Class */);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("NonnullRefPtr"sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(struct_.name_for_codegen().as_name_for_use());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+{auto __jakt_enum_value = struct_.record_type.__jakt_init_index() == 1 /* Class */;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation("NonnullRefPtr"sv);}else if (!__jakt_enum_value) {return struct_.name_for_codegen().as_name_for_use();}VERIFY_NOT_REACHED();
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -3714,39 +3610,22 @@ case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
 {
 Jakt::types::CheckedStruct const struct_ = this->program->get_struct(id);
-return JaktInternal::ExplicitValue<JaktInternal::Optional<ByteString>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,JaktInternal::Optional<ByteString>> {
-auto __jakt_enum_value = (struct_.record_type.__jakt_init_index() == 1 /* Class */);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("NonnullRefPtr"sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(struct_.name_for_codegen().as_name_for_use());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+{auto __jakt_enum_value = struct_.record_type.__jakt_init_index() == 1 /* Class */;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation("NonnullRefPtr"sv);}else if (!__jakt_enum_value) {return struct_.name_for_codegen().as_name_for_use();}VERIFY_NOT_REACHED();
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 18 /* TypeVariable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeVariable;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(name);
-};/*case end*/
+return name;};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
 {
 Jakt::types::CheckedEnum const enum_ = this->program->get_enum(id);
-return JaktInternal::ExplicitValue<JaktInternal::Optional<ByteString>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,JaktInternal::Optional<ByteString>> {
-auto __jakt_enum_value = (enum_.is_boxed);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("NonnullRefPtr"sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(enum_.name);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+{auto __jakt_enum_value = enum_.is_boxed;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation("NonnullRefPtr"sv);}else if (!__jakt_enum_value) {return enum_.name;}VERIFY_NOT_REACHED();
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -3754,28 +3633,14 @@ case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
 {
 Jakt::types::CheckedEnum const enum_ = this->program->get_enum(id);
-return JaktInternal::ExplicitValue<JaktInternal::Optional<ByteString>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,JaktInternal::Optional<ByteString>> {
-auto __jakt_enum_value = (enum_.is_boxed);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("NonnullRefPtr"sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(enum_.name);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+{auto __jakt_enum_value = enum_.is_boxed;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation("NonnullRefPtr"sv);}else if (!__jakt_enum_value) {return enum_.name;}VERIFY_NOT_REACHED();
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return JaktInternal::OptionalNone();}/*switch end*/
+}
 }
 }
 
@@ -3809,33 +3674,29 @@ break;
 }
 size_t variant_index = _magic_value.value();
 {
-Jakt::types::CheckedEnumVariant const variant = enum_.variants.operator[](variant_index);
+Jakt::types::CheckedEnumVariant const variant = enum_.variants[variant_index];
 ByteString const variant_name = variant.name();
 output.appendff(ByteString::from_utf8_without_validation("case {} /* {} */:"sv),variant_index,variant_name);
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, void>{
-auto&& __jakt_match_variant = variant;
+{auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Untyped */:case 2 /* WithValue */:{
 }
-return JaktInternal::ExplicitValue<void>();
-case 1 /* Typed */: {
+goto __jakt_label_160;case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
 JaktInternal::Optional<ByteString> const ds_name = this->destructor_name(type_id);
-JaktInternal::Optional<ByteString> __jakt_tmp384 = ds_name;
-if (__jakt_tmp384.has_value()){
-ByteString const name = __jakt_tmp384.value();
+JaktInternal::Optional<ByteString> __jakt_tmp250 = ds_name;
+if (__jakt_tmp250.has_value()){
+ByteString const name = __jakt_tmp250.value();
 output.appendff(ByteString::from_utf8_without_validation("this->as.{}.value.~{}();\n"sv),variant_name,name);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_160;};/*case end*/
 case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;JaktInternal::DynamicArray<Jakt::ids::VarId> const& fields = __jakt_match_value.fields;
 {
 {
-JaktInternal::ArrayIterator<Jakt::ids::VarId> _magic = fields.operator[](JaktInternal::Range<size_t>{static_cast<size_t>(common_field_count),static_cast<size_t>(9223372036854775807LL)}).iterator();
+JaktInternal::ArrayIterator<Jakt::ids::VarId> _magic = fields[JaktInternal::Range<size_t>{static_cast<size_t>(common_field_count),static_cast<size_t>(9223372036854775807LL)}].iterator();
 for (;;){
 JaktInternal::Optional<Jakt::ids::VarId> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
@@ -3845,9 +3706,9 @@ Jakt::ids::VarId field = _magic_value.value();
 {
 NonnullRefPtr<Jakt::types::CheckedVariable> const variable = this->program->get_variable(field);
 JaktInternal::Optional<ByteString> const ds = this->destructor_name(variable->type_id);
-JaktInternal::Optional<ByteString> __jakt_tmp385 = ds;
-if (__jakt_tmp385.has_value()){
-ByteString const name = __jakt_tmp385.value();
+JaktInternal::Optional<ByteString> __jakt_tmp251 = ds;
+if (__jakt_tmp251.has_value()){
+ByteString const name = __jakt_tmp251.value();
 output.appendff(ByteString::from_utf8_without_validation("this->as.{}.{}.~{}();\n"sv),variant_name,variable->name_for_codegen().as_name_for_use(),name);
 }
 }
@@ -3856,19 +3717,9 @@ output.appendff(ByteString::from_utf8_without_validation("this->as.{}.{}.~{}();\
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_160;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+break;}goto __jakt_label_160; __jakt_label_160:;;
 output.append(StringView::from_string_literal("break;\n"sv));
 }
 
@@ -3894,9 +3745,9 @@ NonnullRefPtr<Jakt::types::CheckedField> common_field = _magic_value.value();
 {
 NonnullRefPtr<Jakt::types::CheckedVariable> const variable = this->program->get_variable(common_field->variable_id);
 JaktInternal::Optional<ByteString> const ds = this->destructor_name(variable->type_id);
-JaktInternal::Optional<ByteString> __jakt_tmp386 = ds;
-if (__jakt_tmp386.has_value()){
-ByteString const name = __jakt_tmp386.value();
+JaktInternal::Optional<ByteString> __jakt_tmp252 = ds;
+if (__jakt_tmp252.has_value()){
+ByteString const name = __jakt_tmp252.value();
 output.appendff(ByteString::from_utf8_without_validation("this->common.init_common.{}.~{}();\n"sv),variable->name_for_codegen().as_name_for_use(),name);
 }
 }
@@ -3949,42 +3800,17 @@ if (i != JaktInternal::checked_sub(struct_.fields.size(),static_cast<size_t>(1UL
 output.append(StringView::from_string_literal(", "sv));
 }
 output.append(StringView::from_string_literal("\", "sv));
-output.append(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<StringView, ErrorOr<void>>{
-auto&& __jakt_match_variant = *this->program->get_type(field_var->type_id);
+output.append([&]() -> StringView { auto&& __jakt_match_variant = *this->program->get_type(field_var->type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<StringView, ErrorOr<void>>{
-auto&& __jakt_match_variant = this->program->get_struct(struct_id).record_type;
+{auto&& __jakt_match_variant = this->program->get_struct(struct_id).record_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 1 /* Class */:return JaktInternal::ExplicitValue(StringView::from_string_literal("*"sv));
-default:return JaktInternal::ExplicitValue(StringView::from_string_literal(""sv));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(StringView::from_string_literal(""sv));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-}));
+case 1 /* Class */:return StringView::from_string_literal("*"sv);default:return StringView::from_string_literal(""sv);}/*switch end*/
+}};/*case end*/
+default:return StringView::from_string_literal(""sv);}/*switch end*/
+ 
+}());
 output.append(field_var->name_for_codegen().as_name_for_use());
 output.append(StringView::from_string_literal(");\n"sv));
 i++;
@@ -4026,12 +3852,10 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::types::CheckedEnumVariant const variant = enum_.variants.operator[](i);
+Jakt::types::CheckedEnumVariant const variant = enum_.variants[i];
 ByteString const name = variant.name();
 output.appendff(ByteString::from_utf8_without_validation("case {} /* {} */: {{\n"sv),i,name);
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = variant;
+{auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;JaktInternal::DynamicArray<Jakt::ids::VarId> const& fields = __jakt_match_value.fields;
@@ -4079,8 +3903,7 @@ i++;
 output.append(StringView::from_string_literal("}\n"sv));
 output.append(StringView::from_string_literal("builder.append(\")\"sv);\n"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_161;};/*case end*/
 case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
@@ -4094,23 +3917,12 @@ output.append(StringView::from_string_literal("builder.appendff(\"({})\", that.v
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_161;};/*case end*/
 default:{
 output.appendff(ByteString::from_utf8_without_validation("return ByteString(\"{}::{}\"sv);\n"sv),enum_.name,name);
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_161;}/*switch end*/
+break;}goto __jakt_label_161; __jakt_label_161:;;
 output.append(StringView::from_string_literal("break;}\n"sv));
 }
 
@@ -4187,45 +3999,35 @@ return {};
 ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_expression(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expression,ByteStringBuilder& output,bool const forward_error_with_try,bool const syntactically_self_contained) {
 {
 this->generic_inferences = expression->common.init_common.generic_inferences.value_or_lazy_evaluated_optional([&] { return this->generic_inferences; });
-ScopeGuard __jakt_var_122([&] {
+ScopeGuard __jakt_var_118([&] {
 this->generic_inferences = JaktInternal::OptionalNone();
 });
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = *expression;
+{auto&& __jakt_match_variant = *expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 34 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 Jakt::utility::panic(__jakt_format(StringView::from_string_literal("Unexpected reflect expression at {}"sv),span));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 9 /* Range */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Range;JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& from = __jakt_match_value.from;
 JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& to = __jakt_match_value.to;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
 NonnullRefPtr<typename Jakt::types::Type> const type = this->program->get_type(type_id);
-Jakt::ids::TypeId const index_type = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId, ErrorOr<void>>{
-auto&& __jakt_match_variant = *type;
+Jakt::ids::TypeId const index_type = [&]() -> Jakt::ids::TypeId { auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(args.operator[](static_cast<i64>(0LL)));
-};/*case end*/
+return args[static_cast<i64>(0LL)];};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Internal error: range expression doesn't have Range type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 output.append(TRY((this->codegen_type(type_id))));
 output.append(StringView::from_string_literal("{"sv));
 output.append(StringView::from_string_literal("static_cast<"sv));
@@ -4250,13 +4052,11 @@ output.append(StringView::from_string_literal("9223372036854775807LL"sv));
 
 output.append(StringView::from_string_literal(")}"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 25 /* OptionalNone */:{
 output.append(StringView::from_string_literal("JaktInternal::OptionalNone()"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-case 26 /* OptionalSome */: {
+goto __jakt_label_162;case 26 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
@@ -4266,8 +4066,7 @@ output.append(StringView::from_string_literal(">("sv));
 TRY((this->codegen_expression(expr,output,true,false)));
 output.append(StringView::from_string_literal(")"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 27 /* ForcedUnwrap */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForcedUnwrap;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
@@ -4275,8 +4074,7 @@ Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 TRY((this->codegen_expression(expr,output,true,true)));
 output.append(StringView::from_string_literal(".value()"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 2 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;Jakt::types::CheckedStringLiteral const& val = __jakt_match_value.val;
 {
@@ -4292,17 +4090,10 @@ JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::ids::FunctionId>> const 
 if ((!ids.has_value()) || ids.value().is_empty()){
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Internal error: couldn't find a 'from_string_literal' function despite passing typecheck"sv));
 }
-ByteString const name = this->program->get_function(ids.value().operator[](static_cast<i64>(0LL)))->name_for_codegen().as_name_for_use();
-ByteString const error_handler = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (val.may_throw);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(this->current_error_handler(forward_error_with_try));
-}else {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const name = this->program->get_function(ids.value()[static_cast<i64>(0LL)])->name_for_codegen().as_name_for_use();
+ByteString const error_handler = [&]() -> ByteString { auto __jakt_enum_value = val.may_throw;
+if (__jakt_enum_value) {return this->current_error_handler(forward_error_with_try);}else {return ByteString::from_utf8_without_validation(""sv);} 
+}();
 output.append(error_handler);
 if (!error_handler.is_empty()){
 output.append_code_point(static_cast<u32>(U'('));
@@ -4314,8 +4105,7 @@ output.append_code_point(static_cast<u32>(U')'));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 3 /* ByteConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ByteConstant;ByteString const& val = __jakt_match_value.val;
 {
@@ -4323,8 +4113,7 @@ output.append(StringView::from_string_literal("static_cast<u8>(u8'"sv));
 output.append(val);
 output.append(StringView::from_string_literal("')"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 5 /* CCharacterConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CCharacterConstant;ByteString const& val = __jakt_match_value.val;
 {
@@ -4332,8 +4121,7 @@ output.append(StringView::from_string_literal("'"sv));
 output.append(val);
 output.append(StringView::from_string_literal("'"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 4 /* CharacterConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CharacterConstant;ByteString const& val = __jakt_match_value.val;
 {
@@ -4341,16 +4129,15 @@ output.append(StringView::from_string_literal("static_cast<u32>(U'"sv));
 output.append(val);
 output.append(StringView::from_string_literal("')"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 24 /* Var */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Var;NonnullRefPtr<Jakt::types::CheckedVariable> const& var = __jakt_match_value.var;
 {
 ByteString const name = var->name_for_codegen().as_name_for_use();
 if (name == ByteString::from_utf8_without_validation("this"sv)){
-JaktInternal::Optional<ByteString> __jakt_tmp387 = this->this_replacement;
-if (__jakt_tmp387.has_value()){
-ByteString const replacement = __jakt_tmp387.value();
+JaktInternal::Optional<ByteString> __jakt_tmp253 = this->this_replacement;
+if (__jakt_tmp253.has_value()){
+ByteString const replacement = __jakt_tmp253.value();
 output.append(replacement);
 }
 else {
@@ -4369,16 +4156,15 @@ output.append(name);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 13 /* IndexedExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedExpression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const& index = __jakt_match_value.index;
 JaktInternal::Optional<Jakt::types::OperatorTraitImplementation> const& trait_implementation = __jakt_match_value.trait_implementation;
 {
-JaktInternal::Optional<Jakt::types::OperatorTraitImplementation> __jakt_tmp388 = trait_implementation;
-if (__jakt_tmp388.has_value()){
-Jakt::types::OperatorTraitImplementation const implementation = __jakt_tmp388.value();
+JaktInternal::Optional<Jakt::types::OperatorTraitImplementation> __jakt_tmp254 = trait_implementation;
+if (__jakt_tmp254.has_value()){
+Jakt::types::OperatorTraitImplementation const implementation = __jakt_tmp254.value();
 TRY((this->codegen_method_call(expr,implementation.call_expression,false,output,forward_error_with_try,syntactically_self_contained)));
 }
 else {
@@ -4386,16 +4172,15 @@ Jakt::utility::panic(ByteString::from_utf8_without_validation("Internal error: a
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 14 /* IndexedDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedDictionary;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const& index = __jakt_match_value.index;
 JaktInternal::Optional<Jakt::types::OperatorTraitImplementation> const& trait_implementation = __jakt_match_value.trait_implementation;
 {
-JaktInternal::Optional<Jakt::types::OperatorTraitImplementation> __jakt_tmp389 = trait_implementation;
-if (__jakt_tmp389.has_value()){
-Jakt::types::OperatorTraitImplementation const implementation = __jakt_tmp389.value();
+JaktInternal::Optional<Jakt::types::OperatorTraitImplementation> __jakt_tmp255 = trait_implementation;
+if (__jakt_tmp255.has_value()){
+Jakt::types::OperatorTraitImplementation const implementation = __jakt_tmp255.value();
 TRY((this->codegen_method_call(expr,implementation.call_expression,false,output,forward_error_with_try,syntactically_self_contained)));
 }
 else {
@@ -4403,8 +4188,7 @@ Jakt::utility::panic(ByteString::from_utf8_without_validation("Internal error: d
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 15 /* IndexedTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedTuple;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 size_t const& index = __jakt_match_value.index;
@@ -4427,36 +4211,25 @@ output.appendff(ByteString::from_utf8_without_validation("template get<{}>()"sv)
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 16 /* IndexedStruct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedStruct;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 ByteString const& name = __jakt_match_value.name;
 JaktInternal::Optional<Jakt::ids::VarId> const& index = __jakt_match_value.index;
 bool const& is_optional = __jakt_match_value.is_optional;
 {
-ByteString const var_name = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (index.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(this->program->get_variable(index.value())->name_for_codegen().as_name_for_use());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(name);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const var_name = [&]() -> ByteString { auto __jakt_enum_value = index.has_value();
+if (__jakt_enum_value) {return this->program->get_variable(index.value())->name_for_codegen().as_name_for_use();}else if (!__jakt_enum_value) {return name;}VERIFY_NOT_REACHED();
+ 
+}();
 NonnullRefPtr<typename Jakt::types::Type> const expression_type = this->program->get_type(expr->type());
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = *expression_type;
+{auto&& __jakt_match_variant = *expression_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 25 /* RawPtr */:{
 TRY((this->codegen_expression(expr,output,true,true)));
 output.append(StringView::from_string_literal("->"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-case 23 /* Struct */: {
+goto __jakt_label_163;case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
 {
 bool const expr_is_thisptr = this->expr_codegens_to_this_pointer(expr);
@@ -4476,8 +4249,7 @@ output.append(StringView::from_string_literal("."sv));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_163;};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
 {
@@ -4498,8 +4270,7 @@ output.append(StringView::from_string_literal("."sv));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_163;};/*case end*/
 default:{
 if ((!is_optional) && this->expr_codegens_to_this_pointer(expr)){
 output.append(StringView::from_string_literal("this->"sv));
@@ -4510,24 +4281,16 @@ output.append(StringView::from_string_literal("."sv));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_163;}/*switch end*/
+}goto __jakt_label_163; __jakt_label_163:;;
 if (is_optional){
 output.append(StringView::from_string_literal("map([](auto& _value) { return _value"sv));
 ByteString access_operator = ByteString::from_utf8_without_validation("."sv);
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp390 = expression_type;
-if (__jakt_tmp390->__jakt_init_index() == 20 /* GenericInstance */){
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp390->as.GenericInstance.args;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp256 = expression_type;
+if (__jakt_tmp256->__jakt_init_index() == 20 /* GenericInstance */){
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp256->as.GenericInstance.args;
 if (args.size() > static_cast<size_t>(0ULL)){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = *this->program->get_type(args.operator[](static_cast<i64>(0LL)));
+{auto&& __jakt_match_variant = *this->program->get_type(args[static_cast<i64>(0LL)]);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
@@ -4536,8 +4299,7 @@ if (this->program->get_struct(id).record_type.__jakt_init_index() == 1 /* Class 
 access_operator = ByteString::from_utf8_without_validation("->"sv);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_164;};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
 {
@@ -4545,18 +4307,11 @@ if (this->program->get_struct(id).record_type.__jakt_init_index() == 1 /* Class 
 access_operator = ByteString::from_utf8_without_validation("->"sv);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_164;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_164;}/*switch end*/
+}goto __jakt_label_164; __jakt_label_164:;;
 }
 }
 output.append(access_operator);
@@ -4568,23 +4323,19 @@ output.append(var_name);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 17 /* IndexedCommonEnumMember */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedCommonEnumMember;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 ByteString const& index = __jakt_match_value.index;
 bool const& is_optional = __jakt_match_value.is_optional;
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = *this->program->get_type(expr->type());
+{auto&& __jakt_match_variant = *this->program->get_type(expr->type());
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 25 /* RawPtr */:{
 TRY((this->codegen_expression(expr,output,true,true)));
 output.append(StringView::from_string_literal("->"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-case 24 /* Enum */: {
+goto __jakt_label_165;case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
 {
 bool const expr_is_thisptr = this->expr_codegens_to_this_pointer(expr);
@@ -4594,9 +4345,9 @@ output.append(StringView::from_string_literal("this->common.init_common."sv));
 else {
 TRY((this->codegen_expression(expr,output,true,true)));
 Jakt::types::CheckedEnum const structure = this->program->get_enum(id);
-Jakt::parser::RecordType __jakt_tmp392 = structure.record_type;
-if (__jakt_tmp392.__jakt_init_index() == 3 /* SumEnum */){
-bool const is_boxed = __jakt_tmp392.as.SumEnum.is_boxed;
+Jakt::parser::RecordType __jakt_tmp257 = structure.record_type;
+if (__jakt_tmp257.__jakt_init_index() == 3 /* SumEnum */){
+bool const is_boxed = __jakt_tmp257.as.SumEnum.is_boxed;
 if (is_boxed && (!this->expr_codegens_to_this_pointer(expr))){
 output.append(StringView::from_string_literal("->common.init_common."sv));
 }
@@ -4612,8 +4363,7 @@ output.append(StringView::from_string_literal(".common.init_common."sv));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_165;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
 {
@@ -4624,9 +4374,9 @@ output.append(StringView::from_string_literal("this->common.init_common."sv));
 else {
 TRY((this->codegen_expression(expr,output,true,true)));
 Jakt::types::CheckedEnum const structure = this->program->get_enum(id);
-Jakt::parser::RecordType __jakt_tmp392 = structure.record_type;
-if (__jakt_tmp392.__jakt_init_index() == 3 /* SumEnum */){
-bool const is_boxed = __jakt_tmp392.as.SumEnum.is_boxed;
+Jakt::parser::RecordType __jakt_tmp257 = structure.record_type;
+if (__jakt_tmp257.__jakt_init_index() == 3 /* SumEnum */){
+bool const is_boxed = __jakt_tmp257.as.SumEnum.is_boxed;
 if (is_boxed && (!this->expr_codegens_to_this_pointer(expr))){
 output.append(StringView::from_string_literal("->common.init_common."sv));
 }
@@ -4642,8 +4392,7 @@ output.append(StringView::from_string_literal(".common.init_common."sv));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_165;};/*case end*/
 default:{
 if ((!is_optional) && this->expr_codegens_to_this_pointer(expr)){
 output.append(StringView::from_string_literal("this->"sv));
@@ -4654,14 +4403,8 @@ output.append(StringView::from_string_literal("."sv));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_165;}/*switch end*/
+}goto __jakt_label_165; __jakt_label_165:;;
 if (is_optional){
 output.append(StringView::from_string_literal("map([](auto& _value) { return _value."sv));
 output.append(index);
@@ -4672,26 +4415,22 @@ output.append(index);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 18 /* ComptimeIndex */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Internal error: ComptimeIndex should have been replaced by now"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-case 28 /* Block */: {
+goto __jakt_label_162;case 28 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
 {
 TRY((this->codegen_block(block,output)));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 21 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::types::CheckedCall const& call = __jakt_match_value.call;
 {
 TRY((this->codegen_call(call,output,forward_error_with_try)));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 22 /* MethodCall */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MethodCall;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 Jakt::types::CheckedCall const& call = __jakt_match_value.call;
@@ -4699,55 +4438,26 @@ bool const& is_optional = __jakt_match_value.is_optional;
 {
 TRY((this->codegen_method_call(expr,call,is_optional,output,forward_error_with_try,syntactically_self_contained)));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 0 /* Boolean */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boolean;bool const& val = __jakt_match_value.val;
 {
-output.append(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<StringView,ErrorOr<void>> {
-auto __jakt_enum_value = (val);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(StringView::from_string_literal("true"sv));
-}else {return JaktInternal::ExplicitValue(StringView::from_string_literal("false"sv));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+output.append([&]() -> StringView { auto __jakt_enum_value = val;
+if (__jakt_enum_value) {return StringView::from_string_literal("true"sv);}else {return StringView::from_string_literal("false"sv);} 
+}());
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 6 /* UnaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 Jakt::types::CheckedUnaryOperator const& op = __jakt_match_value.op;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = op;
+{auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* PreIncrement */:return ({TRY((this->codegen_prefix_unary(expr,StringView::from_string_literal("++"sv),output,syntactically_self_contained)));}), JaktInternal::ExplicitValue<void>();
-case 2 /* PreDecrement */:return ({TRY((this->codegen_prefix_unary(expr,StringView::from_string_literal("--"sv),output,syntactically_self_contained)));}), JaktInternal::ExplicitValue<void>();
-case 4 /* Negate */:return ({TRY((this->codegen_prefix_unary(expr,StringView::from_string_literal("-"sv),output,syntactically_self_contained)));}), JaktInternal::ExplicitValue<void>();
-case 9 /* LogicalNot */:return ({TRY((this->codegen_prefix_unary(expr,StringView::from_string_literal("!"sv),output,syntactically_self_contained)));}), JaktInternal::ExplicitValue<void>();
-case 10 /* BitwiseNot */:return ({TRY((this->codegen_prefix_unary(expr,StringView::from_string_literal("~"sv),output,syntactically_self_contained)));}), JaktInternal::ExplicitValue<void>();
-case 1 /* PostIncrement */:return ({TRY((this->codegen_postfix_unary(expr,StringView::from_string_literal("++"sv),output,syntactically_self_contained)));}), JaktInternal::ExplicitValue<void>();
-case 3 /* PostDecrement */:return ({TRY((this->codegen_postfix_unary(expr,StringView::from_string_literal("--"sv),output,syntactically_self_contained)));}), JaktInternal::ExplicitValue<void>();
-case 5 /* Dereference */:return ({({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = *this->program->get_type(expr->type());
+case 0 /* PreIncrement */:TRY((this->codegen_prefix_unary(expr,StringView::from_string_literal("++"sv),output,syntactically_self_contained)));goto __jakt_label_166;case 2 /* PreDecrement */:TRY((this->codegen_prefix_unary(expr,StringView::from_string_literal("--"sv),output,syntactically_self_contained)));goto __jakt_label_166;case 4 /* Negate */:TRY((this->codegen_prefix_unary(expr,StringView::from_string_literal("-"sv),output,syntactically_self_contained)));goto __jakt_label_166;case 9 /* LogicalNot */:TRY((this->codegen_prefix_unary(expr,StringView::from_string_literal("!"sv),output,syntactically_self_contained)));goto __jakt_label_166;case 10 /* BitwiseNot */:TRY((this->codegen_prefix_unary(expr,StringView::from_string_literal("~"sv),output,syntactically_self_contained)));goto __jakt_label_166;case 1 /* PostIncrement */:TRY((this->codegen_postfix_unary(expr,StringView::from_string_literal("++"sv),output,syntactically_self_contained)));goto __jakt_label_166;case 3 /* PostDecrement */:TRY((this->codegen_postfix_unary(expr,StringView::from_string_literal("--"sv),output,syntactically_self_contained)));goto __jakt_label_166;case 5 /* Dereference */:{auto&& __jakt_match_variant = *this->program->get_type(expr->type());
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 25 /* RawPtr */:return ({TRY((this->codegen_prefix_unary(expr,StringView::from_string_literal("*"sv),output,syntactically_self_contained)));}), JaktInternal::ExplicitValue<void>();
-default:return ({TRY((this->codegen_expression(expr,output,true,syntactically_self_contained)));}), JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});}), JaktInternal::ExplicitValue<void>();
-case 7 /* Reference */:case 8 /* MutableReference */:return ({TRY((this->codegen_expression(expr,output,true,syntactically_self_contained)));}), JaktInternal::ExplicitValue<void>();
-case 6 /* RawAddress */:{
+case 25 /* RawPtr */:TRY((this->codegen_prefix_unary(expr,StringView::from_string_literal("*"sv),output,syntactically_self_contained)));goto __jakt_label_167;default:TRY((this->codegen_expression(expr,output,true,syntactically_self_contained)));goto __jakt_label_167;}/*switch end*/
+}goto __jakt_label_167; __jakt_label_167:;;goto __jakt_label_166;case 7 /* Reference */:case 8 /* MutableReference */:TRY((this->codegen_expression(expr,output,true,syntactically_self_contained)));goto __jakt_label_166;case 6 /* RawAddress */:{
 bool const is_boxed = this->program->get_type(expr->type())->is_boxed(this->program);
 output.appendff(ByteString::from_utf8_without_validation("const_cast<{}>(&"sv),TRY((this->codegen_type_possibly_as_namespace(type_id,is_boxed))));
 if (is_boxed){
@@ -4756,83 +4466,62 @@ output.append_code_point(static_cast<u32>(U'*'));
 TRY((this->codegen_expression(expr,output,true,true)));
 output.append_code_point(static_cast<u32>(U')'));
 }
-return JaktInternal::ExplicitValue<void>();
-case 16 /* Sizeof */: {
+goto __jakt_label_166;case 16 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return ({output.appendff(ByteString::from_utf8_without_validation("sizeof({})"sv),TRY((this->codegen_type(type_id))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+output.appendff(ByteString::from_utf8_without_validation("sizeof({})"sv),TRY((this->codegen_type(type_id))));goto __jakt_label_166;};/*case end*/
 case 12 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
 {
-ByteString const is_type = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<void>>{
-auto&& __jakt_match_variant = *this->program->get_type(type_id);
+ByteString const is_type = TRY(([&]() -> ErrorOr<ByteString> { auto&& __jakt_match_variant = *this->program->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
 {
 Jakt::types::CheckedStruct const struct_ = this->program->get_struct(id);
-return JaktInternal::ExplicitValue<ByteString>(TRY((this->codegen_namespace_qualifier(struct_.scope_id,this->program->get_module(id.module)->is_prelude(),true,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()))) + struct_.name_for_codegen().as_name_for_use());
+return TRY((this->codegen_namespace_qualifier(struct_.scope_id,this->program->get_module(id.module)->is_prelude(),true,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()))) + struct_.name_for_codegen().as_name_for_use();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(TRY((this->codegen_type(type_id))));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return this->codegen_type(type_id);}/*switch end*/
+ 
+}()));
 output.appendff(ByteString::from_utf8_without_validation("JaktInternal::lenient_is<{}>("sv),is_type);
 TRY((this->codegen_expression(expr,output,true,false)));
 output.append_code_point(static_cast<u32>(U')'));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_166;};/*case end*/
 case 15 /* IsNone */:{
 output.append_code_point(static_cast<u32>(U'!'));
 TRY((this->codegen_expression(expr,output,true,true)));
 output.append(StringView::from_string_literal(".has_value()"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-case 14 /* IsSome */:{
+goto __jakt_label_166;case 14 /* IsSome */:{
 TRY((this->codegen_expression(expr,output,true,true)));
 output.append(StringView::from_string_literal(".has_value()"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-case 11 /* TypeCast */: {
+goto __jakt_label_166;case 11 /* TypeCast */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeCast;Jakt::types::CheckedTypeCast const& cast = __jakt_match_value.value;
 {
 Jakt::ids::TypeId final_type_id = cast.type_id();
 NonnullRefPtr<typename Jakt::types::Type> const type = this->program->get_type(final_type_id);
-ByteString const cast_type = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<void>>{
-auto&& __jakt_match_variant = cast;
+ByteString const cast_type = [&]() -> ByteString { auto&& __jakt_match_variant = cast;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Fallible */:{
-Jakt::ids::TypeId const type_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId, ErrorOr<void>>{
-auto&& __jakt_match_variant = *type;
+Jakt::ids::TypeId const type_id = [&]() -> Jakt::ids::TypeId { auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(args.operator[](static_cast<i64>(0LL)));
-};/*case end*/
+return args[static_cast<i64>(0LL)];};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Fallible type cast must have Optional result."sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 ByteString cast_type = ByteString::from_utf8_without_validation("dynamic_cast"sv);
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp393 = this->program->get_type(type_id);
-if (__jakt_tmp393->__jakt_init_index() == 23 /* Struct */){
-Jakt::ids::StructId const struct_id = __jakt_tmp393->as.Struct.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp258 = this->program->get_type(type_id);
+if (__jakt_tmp258->__jakt_init_index() == 23 /* Struct */){
+Jakt::ids::StructId const struct_id = __jakt_tmp258->as.Struct.value;
 if (this->program->get_struct(struct_id).record_type.__jakt_init_index() == 1 /* Class */){
 final_type_id = type_id;
 cast_type = ByteString::from_utf8_without_validation("fallible_class_cast"sv);
@@ -4854,13 +4543,13 @@ else if (this->program->is_floating(type_id)){
 final_type_id = type_id;
 cast_type = ByteString::from_utf8_without_validation("fallible_float_cast"sv);
 }
-return JaktInternal::ExplicitValue<ByteString>(cast_type);
+return cast_type;
 }
 VERIFY_NOT_REACHED();
 case 1 /* Infallible */:{
 ByteString cast_type = ByteString::from_utf8_without_validation("verify_cast"sv);
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp394 = type;
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp396 = type;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp259 = type;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp261 = type;
 if (expr->type().equals(Jakt::types::unknown_type_id())){
 cast_type = ByteString::from_utf8_without_validation("assert_type"sv);
 }
@@ -4873,38 +4562,32 @@ cast_type = ByteString::from_utf8_without_validation("infallible_float_cast"sv);
 else if (this->program->is_integer(type_id)){
 cast_type = ByteString::from_utf8_without_validation("infallible_integer_cast"sv);
 }
-else if (__jakt_tmp394->__jakt_init_index() == 24 /* Enum */){
-Jakt::ids::EnumId const enum_id = __jakt_tmp394->as.Enum.value;
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp395 = type;
+else if (__jakt_tmp259->__jakt_init_index() == 24 /* Enum */){
+Jakt::ids::EnumId const enum_id = __jakt_tmp259->as.Enum.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp260 = type;
 if (this->program->is_integer(this->program->get_enum(enum_id).underlying_type_id)){
 cast_type = ByteString::from_utf8_without_validation("infallible_enum_cast"sv);
 }
-else if (__jakt_tmp395->__jakt_init_index() == 25 /* RawPtr */){
-Jakt::ids::TypeId const inner = __jakt_tmp395->as.RawPtr.value;
+else if (__jakt_tmp260->__jakt_init_index() == 25 /* RawPtr */){
+Jakt::ids::TypeId const inner = __jakt_tmp260->as.RawPtr.value;
 cast_type = ByteString::from_utf8_without_validation("reinterpret_cast"sv);
 }
 }
-else if (__jakt_tmp396->__jakt_init_index() == 25 /* RawPtr */){
-Jakt::ids::TypeId const inner = __jakt_tmp396->as.RawPtr.value;
+else if (__jakt_tmp261->__jakt_init_index() == 25 /* RawPtr */){
+Jakt::ids::TypeId const inner = __jakt_tmp261->as.RawPtr.value;
 cast_type = ByteString::from_utf8_without_validation("reinterpret_cast"sv);
 }
-return JaktInternal::ExplicitValue<ByteString>(cast_type);
+return cast_type;
 }
 VERIFY_NOT_REACHED();
-case 2 /* Identity */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("static_cast"sv));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 2 /* Identity */:return ByteString::from_utf8_without_validation("static_cast"sv);default: VERIFY_NOT_REACHED();}/*switch end*/
+ 
+}();
 output.appendff(ByteString::from_utf8_without_validation("{}<{}>("sv),cast_type,TRY((this->codegen_type(final_type_id))));
 TRY((this->codegen_expression(expr,output,true,false)));
 output.append_code_point(static_cast<u32>(U')'));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_166;};/*case end*/
 case 13 /* IsEnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IsEnumVariant;Jakt::types::CheckedEnumVariant const& enum_variant = __jakt_match_value.enum_variant;
 Jakt::ids::TypeId const& enum_type_id = __jakt_match_value.type_id;
@@ -4912,38 +4595,28 @@ Jakt::ids::TypeId const& enum_type_id = __jakt_match_value.type_id;
 if (syntactically_self_contained){
 output.append_code_point(static_cast<u32>(U'('));
 }
-ScopeGuard __jakt_var_123([&] {
+ScopeGuard __jakt_var_119([&] {
 if (syntactically_self_contained){
 output.append_code_point(static_cast<u32>(U')'));
 }
 });
 ByteString const name = enum_variant.name();
-Jakt::ids::EnumId const enum_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::EnumId, ErrorOr<void>>{
-auto&& __jakt_match_variant = *this->program->get_type(enum_type_id);
+Jakt::ids::EnumId const enum_id = [&]() -> Jakt::ids::EnumId { auto&& __jakt_match_variant = *this->program->get_type(enum_type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(enum_id);
-};/*case end*/
+return enum_id;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(__jakt_format(StringView::from_string_literal("Unexpected type in IsEnumVariant: {}"sv),this->program->get_type(enum_type_id)));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 Jakt::types::CheckedEnum const enum_ = this->program->get_enum(enum_id);
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = enum_.record_type;
+{auto&& __jakt_match_variant = enum_.record_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* SumEnum */:{
 bool const is_boxed = enum_.is_boxed;
@@ -4982,36 +4655,21 @@ variant_index++;
 
 output.appendff(ByteString::from_utf8_without_validation("__jakt_init_index() == {} /* {} */"sv),variant_index,name);
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* ValueEnum */:{
+goto __jakt_label_168;case 2 /* ValueEnum */:{
 TRY((this->codegen_expression(expr,output,true,true)));
 output.appendff(ByteString::from_utf8_without_validation("== {}{}::{}"sv),TRY((this->codegen_namespace_qualifier(enum_.scope_id,this->program->get_module(enum_id.module)->is_prelude(),true,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()))),enum_.name,name);
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_168;default:{
 Jakt::utility::panic(__jakt_format(StringView::from_string_literal("Unexpected enum record type in IsEnumVariant: {}"sv),enum_.record_type));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_168;}/*switch end*/
+}goto __jakt_label_168; __jakt_label_168:;;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_166;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}goto __jakt_label_166; __jakt_label_166:;;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 7 /* BinaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.BinaryOp;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& lhs = __jakt_match_value.lhs;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const& rhs = __jakt_match_value.rhs;
@@ -5020,97 +4678,61 @@ Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
 TRY((this->codegen_binary_expression(expression,type_id,lhs,rhs,op,output,forward_error_with_try,syntactically_self_contained)));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 1 /* NumericConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NumericConstant;Jakt::types::CheckedNumericConstant const& val = __jakt_match_value.val;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
-ByteString const suffix = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<void>>{
-auto&& __jakt_match_variant = val;
+ByteString const suffix = [&]() -> ByteString { auto&& __jakt_match_variant = val;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 3 /* I64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("LL"sv));
-case 7 /* U64 */:case 8 /* USize */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("ULL"sv));
-default:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-ByteString const type_name = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<void>>{
-auto&& __jakt_match_variant = val;
+case 3 /* I64 */:return ByteString::from_utf8_without_validation("LL"sv);case 7 /* U64 */:case 8 /* USize */:return ByteString::from_utf8_without_validation("ULL"sv);default:return ByteString::from_utf8_without_validation(""sv);}/*switch end*/
+ 
+}();
+ByteString const type_name = TRY(([&]() -> ErrorOr<ByteString> { auto&& __jakt_match_variant = val;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 8 /* USize */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("size_t"sv));
-default:return JaktInternal::ExplicitValue(TRY((this->codegen_type(type_id))));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-output.append(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<void>>{
-auto&& __jakt_match_variant = val;
+case 8 /* USize */:return ByteString::from_utf8_without_validation("size_t"sv);default:return this->codegen_type(type_id);}/*switch end*/
+ 
+}()));
+output.append([&]() -> ByteString { auto&& __jakt_match_variant = val;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix);};/*case end*/
 case 10 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix);};/*case end*/
 case 0 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix);};/*case end*/
 case 1 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix);};/*case end*/
 case 2 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix);};/*case end*/
 case 3 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix);};/*case end*/
 case 4 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix);};/*case end*/
 case 5 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix);};/*case end*/
 case 6 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix);};/*case end*/
 case 7 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix);};/*case end*/
 case 8 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;u64 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("static_cast<{}>({}{})"sv),type_name,val,suffix);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+ 
+}());
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 23 /* NamespacedVar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedVar;JaktInternal::DynamicArray<Jakt::types::CheckedNamespace> const& namespaces = __jakt_match_value.namespaces;
 NonnullRefPtr<Jakt::types::CheckedVariable> const& var = __jakt_match_value.var;
@@ -5141,18 +4763,16 @@ output.append(StringView::from_string_literal("::"sv));
 }
 output.append(var->name_for_codegen().as_name_for_use());
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 19 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const& match_cases = __jakt_match_value.match_cases;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 bool const& all_variants_constant = __jakt_match_value.all_variants_constant;
 {
-TRY((this->codegen_match(expr,match_cases,type_id,all_variants_constant,output)));
+TRY((this->codegen_match(expr,match_cases,type_id,all_variants_constant,forward_error_with_try,output)));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 20 /* EnumVariantArg */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariantArg;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 Jakt::types::CheckedEnumVariantBinding const& arg = __jakt_match_value.arg;
@@ -5160,16 +4780,9 @@ Jakt::types::CheckedEnumVariant const& enum_variant = __jakt_match_value.enum_va
 {
 ByteString const variant_name = enum_variant.name();
 Jakt::types::CheckedEnum const enum_ = this->program->get_enum(enum_variant.enum_id());
-ByteString const cpp_deref_operator = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (enum_.is_boxed);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("->"sv));
-}else {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("."sv));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const cpp_deref_operator = [&]() -> ByteString { auto __jakt_enum_value = enum_.is_boxed;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation("->"sv);}else {return ByteString::from_utf8_without_validation("."sv);} 
+}();
 ByteString section = __jakt_format(StringView::from_string_literal("as.{}"sv),variant_name);
 bool is_common_field = false;
 ByteString field_name = arg.name.value_or_lazy_evaluated([&] { return arg.binding; });
@@ -5202,8 +4815,7 @@ output.append(section);
 output.append(StringView::from_string_literal("."sv));
 output.append(field_name);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 10 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& vals = __jakt_match_value.vals;
 JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& repeat = __jakt_match_value.repeat;
@@ -5218,7 +4830,7 @@ output.append(TRY((this->codegen_type(inner_type_id))));
 output.append(StringView::from_string_literal(">::filled("sv));
 TRY((this->codegen_expression(repeat_val,output,true,false)));
 output.append(StringView::from_string_literal(", "sv));
-TRY((this->codegen_expression(vals.operator[](static_cast<i64>(0LL)),output,true,false)));
+TRY((this->codegen_expression(vals[static_cast<i64>(0LL)],output,true,false)));
 output.append(StringView::from_string_literal(")"sv));
 }
 else {
@@ -5252,8 +4864,7 @@ output.append(StringView::from_string_literal("})"sv));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 12 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>> const& vals = __jakt_match_value.vals;
 Jakt::utility::Span const& span = __jakt_match_value.span;
@@ -5295,8 +4906,7 @@ output.append(StringView::from_string_literal("}"sv));
 
 output.append(StringView::from_string_literal("})"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 11 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& vals = __jakt_match_value.vals;
 Jakt::utility::Span const& span = __jakt_match_value.span;
@@ -5329,8 +4939,7 @@ TRY((this->codegen_expression(value,output,true,false)));
 
 output.append(StringView::from_string_literal("})"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 8 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& vals = __jakt_match_value.vals;
 Jakt::utility::Span const& span = __jakt_match_value.span;
@@ -5362,13 +4971,11 @@ TRY((this->codegen_expression(val,output,true,false)));
 
 output.append(StringView::from_string_literal("}"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 30 /* DependentFunction */:{
 this->compiler->panic(ByteString::from_utf8_without_validation("Dependent functions should have been resolved by now"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-case 29 /* Function */: {
+goto __jakt_label_162;case 29 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<Jakt::types::CheckedCapture> const& captures = __jakt_match_value.captures;
 JaktInternal::DynamicArray<Jakt::types::CheckedParameter> const& params = __jakt_match_value.params;
 bool const& can_throw = __jakt_match_value.can_throw;
@@ -5386,24 +4993,11 @@ break;
 }
 Jakt::types::CheckedCapture capture = _magic_value.value();
 {
-generated_captures.push(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<void>>{
-auto&& __jakt_match_variant = capture;
+generated_captures.push([&]() -> ByteString { auto&& __jakt_match_variant = capture;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* ByValue */:return JaktInternal::ExplicitValue(capture.common.init_common.name);
-case 4 /* AllByReference */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("&"sv));
-default:return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("&{}"sv),capture.common.init_common.name));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-}));
+case 0 /* ByValue */:return capture.common.init_common.name;case 4 /* AllByReference */:return ByteString::from_utf8_without_validation("&"sv);default:return __jakt_format(StringView::from_string_literal("&{}"sv),capture.common.init_common.name);}/*switch end*/
+ 
+}());
 }
 
 }
@@ -5425,20 +5019,13 @@ generated_params.push(__jakt_format(StringView::from_string_literal("{} {}"sv),T
 }
 }
 
-ByteString const return_type = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (can_throw);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("ErrorOr<{}>"sv),TRY((this->codegen_type(return_type_id)))));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->codegen_type(return_type_id))));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const return_type = TRY(([&]() -> ErrorOr<ByteString> { auto __jakt_enum_value = can_throw;
+if (__jakt_enum_value) {return __jakt_format(StringView::from_string_literal("ErrorOr<{}>"sv),TRY((this->codegen_type(return_type_id))));}else if (!__jakt_enum_value) {return this->codegen_type(return_type_id);}VERIFY_NOT_REACHED();
+ 
+}()));
 Jakt::codegen::ControlFlowState const last_control_flow = this->control_flow_state;
 this->control_flow_state = last_control_flow.enter_function();
-ScopeGuard __jakt_var_124([&] {
+ScopeGuard __jakt_var_120([&] {
 this->control_flow_state = last_control_flow;
 });
 output.appendff(ByteString::from_utf8_without_validation("[{}]({}) -> {} "sv),Jakt::utility::join(generated_captures,ByteString::from_utf8_without_validation(", "sv)),Jakt::utility::join(generated_params,ByteString::from_utf8_without_validation(", "sv)),return_type);
@@ -5446,7 +5033,7 @@ if (pseudo_function_id.has_value()){
 NonnullRefPtr<Jakt::types::CheckedFunction> const function = this->program->get_function(pseudo_function_id.value());
 JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>> const previous_function = this->current_function;
 this->current_function = function;
-ScopeGuard __jakt_var_125([&] {
+ScopeGuard __jakt_var_121([&] {
 this->current_function = previous_function;
 });
 TRY((this->codegen_lambda_block(can_throw,block,return_type_id,output)));
@@ -5456,8 +5043,7 @@ TRY((this->codegen_lambda_block(can_throw,block,return_type_id,output)));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 33 /* TryBlock */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TryBlock;NonnullRefPtr<typename Jakt::types::CheckedStatement> const& stmt = __jakt_match_value.stmt;
 ByteString const& error_name = __jakt_match_value.error_name;
@@ -5465,19 +5051,11 @@ Jakt::types::CheckedBlock const& catch_block = __jakt_match_value.catch_block;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 ByteString const try_var = this->fresh_var();
-bool const can_affect_loop = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, ErrorOr<void>>{
-auto&& __jakt_match_variant = stmt->control_flow();
+bool const can_affect_loop = [&]() -> bool { auto&& __jakt_match_variant = stmt->control_flow();
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(false);
-default:return JaktInternal::ExplicitValue(true);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 3 /* MayReturn */:return false;default:return true;}/*switch end*/
+ 
+}();
 ByteStringBuilder builder = ByteStringBuilder::create();
 Jakt::codegen::ControlFlowState const last_control_flow = this->control_flow_state;
 if (can_affect_loop){
@@ -5528,8 +5106,7 @@ TRY((this->codegen_block(catch_block,output)));
 this->control_flow_state = last_control_flow;
 output.append(StringView::from_string_literal("}"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 32 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 JaktInternal::Optional<Jakt::types::CheckedBlock> const& catch_block = __jakt_match_value.catch_block;
@@ -5545,7 +5122,7 @@ Jakt::codegen::ControlFlowState const last_control_flow = this->control_flow_sta
 this->control_flow_state.directly_inside_match = false;
 this->control_flow_state.indirectly_inside_match = false;
 this->control_flow_state.passes_through_try = true;
-ScopeGuard __jakt_var_126([&] {
+ScopeGuard __jakt_var_122([&] {
 {
 this->control_flow_state = last_control_flow;
 }
@@ -5585,7 +5162,7 @@ if (catch_block.value().yielded_type.has_value()){
 ByteString const label = this->fresh_label();
 JaktInternal::Optional<Jakt::codegen::YieldMethod> const old_yield_method = this->yield_method;
 this->yield_method = Jakt::codegen::YieldMethod::AssignAndGoto(fresh_var,label);
-ScopeGuard __jakt_var_127([&] {
+ScopeGuard __jakt_var_123([&] {
 this->yield_method = old_yield_method;
 });
 TRY((this->codegen_block(catch_block.value(),output)));
@@ -5622,8 +5199,7 @@ output.append(StringView::from_string_literal(".release_value()"sv));
 output.append(StringView::from_string_literal("; })"sv));
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 31 /* Must */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Must;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
@@ -5632,7 +5208,7 @@ Jakt::codegen::ControlFlowState const last_control_flow = this->control_flow_sta
 this->control_flow_state.directly_inside_match = false;
 this->control_flow_state.indirectly_inside_match = false;
 this->control_flow_state.passes_through_try = true;
-ScopeGuard __jakt_var_128([&] {
+ScopeGuard __jakt_var_124([&] {
 {
 this->control_flow_state = last_control_flow;
 }
@@ -5642,31 +5218,24 @@ output.append(StringView::from_string_literal("MUST(("sv));
 TRY((this->codegen_expression(expr,output,false,false)));
 output.append(StringView::from_string_literal("))"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 case 35 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 Jakt::utility::todo(__jakt_format(StringView::from_string_literal("codegen_expression of bad AST node in {} at {}..{}"sv),this->compiler->get_file_path(span.file_id),span.start,span.end));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_162;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}goto __jakt_label_162; __jakt_label_162:;;
 }
 return {};
 }
 
 bool Jakt::codegen::CodeGenerator::expr_codegens_to_this_pointer(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr) const {
 {
-NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp397 = expr;
-if (__jakt_tmp397->__jakt_init_index() == 24 /* Var */){
-NonnullRefPtr<Jakt::types::CheckedVariable> const var = __jakt_tmp397->as.Var.var;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp262 = expr;
+if (__jakt_tmp262->__jakt_init_index() == 24 /* Var */){
+NonnullRefPtr<Jakt::types::CheckedVariable> const var = __jakt_tmp262->as.Var.var;
 return (var->name == ByteString::from_utf8_without_validation("this"sv)) && !this->this_replacement.has_value();
 }
 else {
@@ -5704,8 +5273,14 @@ output.append_code_point(static_cast<u32>(U')'));
 return {};
 }
 
-ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_match(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr,JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const match_cases,Jakt::ids::TypeId const type_id,bool const all_variants_constant,ByteStringBuilder& output) {
+ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_match(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr,JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const match_cases,Jakt::ids::TypeId const type_id,bool const all_variants_constant,bool const forward_error_with_try,ByteStringBuilder& output) {
 {
+if (!Jakt::codegen::has_cpp_value(type_id)){
+TRY((this->codegen_void_match(expr,match_cases,type_id,output))); return {};
+}
+if (!Jakt::codegen::has_control_flow<Jakt::types::CheckedMatchCase>(match_cases,true)){
+TRY((this->codegen_value_match(expr,match_cases,type_id,forward_error_with_try,output))); return {};
+}
 ByteStringBuilder builder = ByteStringBuilder::create();
 Jakt::codegen::ControlFlowState const last_control_flow = this->control_flow_state;
 this->control_flow_state = this->control_flow_state.enter_match();
@@ -5713,77 +5288,122 @@ ByteString const cpp_match_result_type = TRY((this->codegen_type(type_id)));
 NonnullRefPtr<typename Jakt::types::Type> const expr_type = this->program->get_type(expr->type());
 JaktInternal::Optional<Jakt::codegen::YieldMethod> const old_yield_method = this->yield_method;
 this->yield_method = Jakt::codegen::YieldMethod::ReturnExplicitValue(__jakt_format(StringView::from_string_literal("JaktInternal::ExplicitValue<{}>"sv),cpp_match_result_type));
-ScopeGuard __jakt_var_129([&] {
+ScopeGuard __jakt_var_125([&] {
 this->yield_method = old_yield_method;
 });
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp398 = expr_type;
-if (__jakt_tmp398->__jakt_init_index() == 24 /* Enum */){
-Jakt::ids::EnumId const enum_id = __jakt_tmp398->as.Enum.value;
-TRY((this->codegen_enum_match(this->program->get_enum(enum_id),expr,match_cases,type_id,cpp_match_result_type,all_variants_constant,builder)));
-}
-else {
-TRY((this->codegen_generic_match(expr,match_cases,type_id,cpp_match_result_type,all_variants_constant,builder)));
-}
-
+builder.append(StringView::from_string_literal("([&]() -> JaktInternal::ExplicitValueOrControlFlow<"sv));
+builder.append(cpp_match_result_type);
+builder.append(StringView::from_string_literal(", "sv));
+builder.append(TRY((this->codegen_function_return_type(this->current_function.value()))));
+builder.append(StringView::from_string_literal(">{\n"sv));
+TRY((this->codegen_inner_match(expr,match_cases,type_id,builder)));
+builder.append(StringView::from_string_literal("}()\n)"sv));
 this->control_flow_state = last_control_flow;
 output.append(TRY((this->control_flow_state.apply_control_flow_macro(builder.to_string(),this->current_function.value()->return_type_id,this->current_function.value()->can_throw))));
 }
 return {};
 }
 
-ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_generic_match(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr,JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const cases,Jakt::ids::TypeId const return_type_id,ByteString const cpp_match_result_type,bool const all_variants_constant,ByteStringBuilder& output) {
+ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_value_match(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr,JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const match_cases,Jakt::ids::TypeId const type_id,bool const forward_error_with_try,ByteStringBuilder& output) {
 {
-bool is_generic_enum = false;
+bool const old_yields_erroror = this->yields_erroror;
+this->yields_erroror = false;
+ByteStringBuilder inner = ByteStringBuilder::create();
 {
-JaktInternal::ArrayIterator<Jakt::types::CheckedMatchCase> _magic = cases.iterator();
-for (;;){
-JaktInternal::Optional<Jakt::types::CheckedMatchCase> const _magic_value = _magic.next();
-if (!_magic_value.has_value()){
-break;
-}
-Jakt::types::CheckedMatchCase case_ = _magic_value.value();
-{
-{
-JaktInternal::ArrayIterator<Jakt::types::CheckedMatchPattern> _magic = case_.patterns.iterator();
-for (;;){
-JaktInternal::Optional<Jakt::types::CheckedMatchPattern> const _magic_value = _magic.next();
-if (!_magic_value.has_value()){
-break;
-}
-Jakt::types::CheckedMatchPattern pattern = _magic_value.value();
-{
-if (pattern.__jakt_init_index() == 0 /* EnumVariant */){
-is_generic_enum = true;
-break;
-}
+JaktInternal::Optional<Jakt::codegen::YieldMethod> const old_yield_method = this->yield_method;
+Jakt::codegen::ControlFlowState const old_cf = this->control_flow_state;
+ScopeGuard __jakt_var_126([&] {
+this->yield_method = old_yield_method;
+});
+ScopeGuard __jakt_var_127([&] {
+this->control_flow_state = old_cf;
+});
+this->control_flow_state = this->control_flow_state.enter_match();
+this->control_flow_state.allowed_exits = Jakt::codegen::AllowedControlExits::JustReturn();
+this->yield_method = Jakt::codegen::YieldMethod::Return();
+TRY((this->codegen_inner_match(expr,match_cases,type_id,inner)));
 }
 
-}
-}
-
-if (is_generic_enum){
-break;
-}
-}
-
-}
-}
-
-bool const match_values_all_constant = all_variants_constant && (!is_generic_enum);
-Jakt::ids::TypeId const byte_string_type_id = this->program->find_or_add_type_id(Jakt::types::Type::Struct(Jakt::parser::CheckedQualifiers(false),TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("String"sv))))),this->program->prelude_module_id(),false);
-output.appendff(ByteString::from_utf8_without_validation("([&]() -> JaktInternal::ExplicitValueOrControlFlow<{},{}> {{\n"sv),cpp_match_result_type,TRY((this->codegen_function_return_type(this->current_function.value()))));
-if (is_generic_enum){
-output.append(StringView::from_string_literal("auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer("sv));
+ByteString const handler = [&]() -> ByteString { auto __jakt_enum_value = this->yields_erroror;
+if (__jakt_enum_value) {return this->current_error_handler(forward_error_with_try);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation(""sv);}VERIFY_NOT_REACHED();
+ 
+}();
+this->yields_erroror |= old_yields_erroror;
+if (!handler.is_empty()){
+output.appendff(ByteString::from_utf8_without_validation("{}(([&]() -> ErrorOr<{}> {{ {} \n}}()))"sv),handler,TRY((this->codegen_type(type_id))),inner.to_string());
 }
 else {
-output.append(StringView::from_string_literal("auto __jakt_enum_value = ("sv));
+output.appendff(ByteString::from_utf8_without_validation("[&]() -> {} {{ {} \n}}()"sv),TRY((this->codegen_type(type_id))),inner.to_string());
 }
 
+}
+return {};
+}
+
+ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_inner_match(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr,JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const match_cases,Jakt::ids::TypeId const type_id,ByteStringBuilder& output) {
+{
+{auto&& __jakt_match_variant = *this->program->get_type(expr->type());
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 24 /* Enum */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
+{
+TRY((this->codegen_enum_match(this->program->get_enum(enum_id),expr,match_cases,type_id,output)));
+}
+return {};};/*case end*/
+case 21 /* GenericEnumInstance */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& enum_id = __jakt_match_value.id;
+{
+TRY((this->codegen_enum_match(this->program->get_enum(enum_id),expr,match_cases,type_id,output)));
+}
+return {};};/*case end*/
+default:{
+TRY((this->codegen_generic_match(expr,match_cases,type_id,output)));
+}
+return {};}/*switch end*/
+}
+}
+return {};
+}
+
+ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_void_match(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr,JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const match_cases,Jakt::ids::TypeId const type_id,ByteStringBuilder& output) {
+{
+JaktInternal::Optional<Jakt::codegen::YieldMethod> const old_yield_method = this->yield_method;
+ByteString const label = this->fresh_label();
+ScopeGuard __jakt_var_128([&] {
+this->yield_method = old_yield_method;
+});
+this->yield_method = Jakt::codegen::YieldMethod::AssignAndGoto(ByteString::from_utf8_without_validation("__VOID_MATCH_HAS_NO_VALUE"sv),label);
+output.append_code_point(static_cast<u32>(U'{'));
+TRY((this->codegen_inner_match(expr,match_cases,type_id,output)));
+output.append_code_point(static_cast<u32>(U'}'));
+output.appendff(ByteString::from_utf8_without_validation("goto {0}; {0}:;"sv),label);
+}
+return {};
+}
+
+ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_returned_match(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr,JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const match_cases,Jakt::ids::TypeId const type_id,ByteStringBuilder& output) {
+{
+JaktInternal::Optional<Jakt::codegen::YieldMethod> const old_yield_method = this->yield_method;
+ScopeGuard __jakt_var_129([&] {
+this->yield_method = old_yield_method;
+});
+this->yield_method = Jakt::codegen::YieldMethod::Return();
+output.append_code_point(static_cast<u32>(U'{'));
+TRY((this->codegen_inner_match(expr,match_cases,type_id,output)));
+output.append_code_point(static_cast<u32>(U'}'));
+}
+return {};
+}
+
+ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_generic_match(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr,JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const cases,Jakt::ids::TypeId const return_type_id,ByteStringBuilder& output) {
+{
+Jakt::ids::TypeId const byte_string_type_id = this->program->find_or_add_type_id(Jakt::types::Type::Struct(Jakt::parser::CheckedQualifiers(false),TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("String"sv))))),this->program->prelude_module_id(),false);
+output.append(StringView::from_string_literal("auto __jakt_enum_value = "sv));
 TRY((this->codegen_expression(expr,output,true,false)));
-output.append(StringView::from_string_literal(");\n"sv));
+output.append(StringView::from_string_literal(";\n"sv));
 bool first = true;
 JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> cases_with_bindings = DynamicArray<Jakt::types::CheckedMatchCase>::create_with({});
-JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>>,Jakt::types::CheckedMatchBody>> deferred_catch_all = JaktInternal::OptionalNone();
+JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>,JaktInternal::Dictionary<ByteString,Jakt::ids::VarId>,Jakt::types::CheckedMatchBody>> deferred_catch_all = JaktInternal::OptionalNone();
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(cases.size())};
 for (;;){
@@ -5793,13 +5413,13 @@ break;
 }
 size_t case_index = _magic_value.value();
 {
-Jakt::types::CheckedMatchCase const match_case = cases.operator[](case_index);
+Jakt::types::CheckedMatchCase const match_case = cases[case_index];
 if (match_case.patterns.size() == static_cast<size_t>(1ULL)){
-Jakt::types::CheckedMatchPattern __jakt_tmp399 = match_case.patterns.operator[](static_cast<i64>(0LL));
-if (__jakt_tmp399.__jakt_init_index() == 3 /* CatchAll */){
-bool const has_arguments = __jakt_tmp399.as.CatchAll.has_arguments;
+Jakt::types::CheckedMatchPattern __jakt_tmp263 = match_case.patterns[static_cast<i64>(0LL)];
+if (__jakt_tmp263.__jakt_init_index() == 3 /* CatchAll */){
+bool const has_arguments = __jakt_tmp263.as.CatchAll.has_arguments;
 if (!has_arguments){
-deferred_catch_all = Tuple{match_case.patterns.operator[](static_cast<i64>(0LL)).common.init_common.defaults, match_case.body};
+deferred_catch_all = Tuple{match_case.patterns[static_cast<i64>(0LL)].common.init_common.defaults, match_case.bindings, match_case.body};
 continue;
 }
 else {
@@ -5869,7 +5489,7 @@ break;
 }
 Jakt::types::CheckedMatchPattern pattern = _magic_value.value();
 {
-JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const defaults = pattern.common.init_common.defaults;
+JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const defaults = pattern.common.init_common.defaults;
 ScopeGuard __jakt_var_131([&] {
 first = false;
 });
@@ -5882,46 +5502,31 @@ output.append(StringView::from_string_literal(") {"sv));
 ScopeGuard __jakt_var_132([&] {
 output.append_code_point(static_cast<u32>(U'}'));
 });
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = pattern;
+{auto&& __jakt_match_variant = pattern;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* EnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;ByteString const& name = __jakt_match_value.name;
 JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> const& args = __jakt_match_value.args;
 Jakt::ids::TypeId const& subject_type_id = __jakt_match_value.subject_type_id;
 size_t const& variant_index = __jakt_match_value.index;
-Jakt::ids::ScopeId const& scope_id = __jakt_match_value.scope_id;
 {
-Jakt::types::CheckedEnum const enum_ = this->program->get_enum(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::EnumId, ErrorOr<void>>{
-auto&& __jakt_match_variant = *this->program->get_type(subject_type_id);
+Jakt::types::CheckedEnum const enum_ = this->program->get_enum([&]() -> Jakt::ids::EnumId { auto&& __jakt_match_variant = *this->program->get_type(subject_type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(enum_id);
-};/*case end*/
+return enum_id;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(__jakt_format(StringView::from_string_literal("Unexpected type in IsEnumVariant: {}"sv),this->program->get_type(subject_type_id)));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
+ 
+}());
 if (!args.is_empty()){
 output.append(StringView::from_string_literal("auto& __jakt_match_value = __jakt_enum_value.as."sv));
-output.append(enum_.variants.operator[](variant_index).name());
+output.append(enum_.variants[variant_index].name());
 output.append(StringView::from_string_literal(";\n"sv));
 {
 JaktInternal::ArrayIterator<Jakt::parser::EnumVariantPatternArgument> _magic = args.iterator();
@@ -5935,9 +5540,9 @@ Jakt::parser::EnumVariantPatternArgument arg = _magic_value.value();
 output.append(StringView::from_string_literal("auto& "sv));
 output.append(arg.binding);
 bool is_common_member = false;
-JaktInternal::Optional<ByteString> __jakt_tmp400 = arg.name;
-if (__jakt_tmp400.has_value()){
-ByteString const name = __jakt_tmp400.value();
+JaktInternal::Optional<ByteString> __jakt_tmp264 = arg.name;
+if (__jakt_tmp264.has_value()){
+ByteString const name = __jakt_tmp264.value();
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<Jakt::types::CheckedField>> _magic = enum_.fields.iterator();
 for (;;){
@@ -5975,54 +5580,27 @@ output.append(StringView::from_string_literal(";\n"sv));
 
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_169;};/*case end*/
 case 3 /* CatchAll */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("unreachable"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-case 1 /* Expression */:{
+goto __jakt_label_169;case 1 /* Expression */:{
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* ClassInstance */: {
+goto __jakt_label_169;case 2 /* ClassInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ClassInstance;Jakt::ids::TypeId const& type = __jakt_match_value.type;
 JaktInternal::Optional<Jakt::types::ClassInstanceRebind> const& rebind_name = __jakt_match_value.rebind_name;
-Jakt::utility::Span const& marker_span = __jakt_match_value.marker_span;
+Jakt::utility::Span const& marker_span = __jakt_match_variant.common.init_common.marker_span;
 {
-JaktInternal::Optional<Jakt::types::ClassInstanceRebind> __jakt_tmp401 = rebind_name;
-if (__jakt_tmp401.has_value()){
-Jakt::types::ClassInstanceRebind const rebind = __jakt_tmp401.value();
+JaktInternal::Optional<Jakt::types::ClassInstanceRebind> __jakt_tmp265 = rebind_name;
+if (__jakt_tmp265.has_value()){
+Jakt::types::ClassInstanceRebind const rebind = __jakt_tmp265.value();
 output.appendff(ByteString::from_utf8_without_validation("auto {} = NonnullRefPtr {{ *static_cast<RawPtr<{}>>(__jakt_enum_value.ptr()) }};\n"sv),rebind.name,TRY((this->codegen_type_possibly_as_namespace(type,true))));
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_169;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
-{
-JaktInternal::ArrayIterator<NonnullRefPtr<typename Jakt::types::CheckedStatement>> _magic = defaults.iterator();
-for (;;){
-JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const _magic_value = _magic.next();
-if (!_magic_value.has_value()){
-break;
-}
-NonnullRefPtr<typename Jakt::types::CheckedStatement> default_ = _magic_value.value();
-{
-TRY((this->codegen_statement(default_,output)));
-}
-
-}
-}
-
+break;}goto __jakt_label_169; __jakt_label_169:;;
+TRY((this->declare_pattern_defaults(defaults,case_.bindings,output)));
 TRY((this->codegen_match_body(body,return_type_id,output)));
 }
 
@@ -6034,51 +5612,32 @@ TRY((this->codegen_match_body(body,return_type_id,output)));
 }
 }
 
-JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>>,Jakt::types::CheckedMatchBody>> __jakt_tmp402 = deferred_catch_all;
-if (__jakt_tmp402.has_value()){
-JaktInternal::Tuple<JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>>,Jakt::types::CheckedMatchBody> const catch_all_case = __jakt_tmp402.value();
-JaktInternal::Tuple<JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>>,Jakt::types::CheckedMatchBody> const defaults_body_ = catch_all_case;
-JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const defaults = defaults_body_.template get<0>();
-Jakt::types::CheckedMatchBody const body = defaults_body_.template get<1>();
+JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>,JaktInternal::Dictionary<ByteString,Jakt::ids::VarId>,Jakt::types::CheckedMatchBody>> __jakt_tmp266 = deferred_catch_all;
+if (__jakt_tmp266.has_value()){
+JaktInternal::Tuple<JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>,JaktInternal::Dictionary<ByteString,Jakt::ids::VarId>,Jakt::types::CheckedMatchBody> const catch_all_case = __jakt_tmp266.value();
+JaktInternal::Tuple<JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>,JaktInternal::Dictionary<ByteString,Jakt::ids::VarId>,Jakt::types::CheckedMatchBody> const defaults_variables_body_ = catch_all_case;
+JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const defaults = defaults_variables_body_.template get<0>();
+JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> const variables = defaults_variables_body_.template get<1>();
+Jakt::types::CheckedMatchBody const body = defaults_variables_body_.template get<2>();
 
 if (!first){
 output.append(StringView::from_string_literal("else "sv));
 }
 output.append_code_point(static_cast<u32>(U'{'));
-{
-JaktInternal::ArrayIterator<NonnullRefPtr<typename Jakt::types::CheckedStatement>> _magic = defaults.iterator();
-for (;;){
-JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const _magic_value = _magic.next();
-if (!_magic_value.has_value()){
-break;
-}
-NonnullRefPtr<typename Jakt::types::CheckedStatement> default_ = _magic_value.value();
-{
-TRY((this->codegen_statement(default_,output)));
-}
-
-}
-}
-
+TRY((this->declare_pattern_defaults(defaults,variables,output)));
 TRY((this->codegen_match_body(body,return_type_id,output)));
 output.append_code_point(static_cast<u32>(U'}'));
 }
-if (return_type_id.equals(Jakt::types::void_type_id()) || return_type_id.equals(Jakt::types::unknown_type_id())){
-output.append(StringView::from_string_literal("return JaktInternal::ExplicitValue<void>();\n"sv));
-}
-else if (!deferred_catch_all.has_value()){
+if ((Jakt::codegen::has_cpp_value(return_type_id) || (!(this->yield_method.value().__jakt_init_index() == 0 /* ReturnExplicitValue */))) && !deferred_catch_all.has_value()){
 output.append(StringView::from_string_literal("VERIFY_NOT_REACHED();\n"sv));
 }
-output.append(StringView::from_string_literal("}())"sv));
 }
 return {};
 }
 
 ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_generic_pattern_condition(Jakt::types::CheckedMatchPattern const& pattern,bool const is_parenthesized,ByteStringBuilder& output) {
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = pattern;
+{auto&& __jakt_match_variant = pattern;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* EnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;ByteString const& name = __jakt_match_value.name;
@@ -6086,13 +5645,10 @@ size_t const& variant_index = __jakt_match_value.index;
 {
 output.appendff(ByteString::from_utf8_without_validation("__jakt_enum_value.__jakt_init_index() == {} /* {} */"sv),variant_index,name);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_170;};/*case end*/
 case 1 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expression;
-return ({({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = *expr;
+{auto&& __jakt_match_variant = *expr;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* Range */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Range;JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& from = __jakt_match_value.from;
@@ -6102,18 +5658,18 @@ bool const has_and = from.has_value() && to.has_value();
 if (has_and && (!is_parenthesized)){
 output.append_code_point(static_cast<u32>(U'('));
 }
-JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> __jakt_tmp403 = from;
-if (__jakt_tmp403.has_value()){
-NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr = __jakt_tmp403.value();
+JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> __jakt_tmp267 = from;
+if (__jakt_tmp267.has_value()){
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr = __jakt_tmp267.value();
 output.append(StringView::from_string_literal("__jakt_enum_value >= "sv));
 TRY((this->codegen_expression(expr,output,true,true)));
 }
 if (has_and){
 output.append(StringView::from_string_literal("&&"sv));
 }
-JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> __jakt_tmp404 = to;
-if (__jakt_tmp404.has_value()){
-NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr = __jakt_tmp404.value();
+JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> __jakt_tmp268 = to;
+if (__jakt_tmp268.has_value()){
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr = __jakt_tmp268.value();
 output.append(StringView::from_string_literal("__jakt_enum_value < "sv));
 TRY((this->codegen_expression(expr,output,true,true)));
 }
@@ -6121,8 +5677,7 @@ if (has_and && (!is_parenthesized)){
 output.append_code_point(static_cast<u32>(U')'));
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_171;};/*case end*/
 case 0 /* Boolean */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boolean;bool const& val = __jakt_match_value.val;
 {
@@ -6131,8 +5686,7 @@ output.append_code_point(static_cast<u32>(U'!'));
 }
 output.append(StringView::from_string_literal("__jakt_enum_value"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_171;};/*case end*/
 default:{
 if (!is_parenthesized){
 output.append_code_point(static_cast<u32>(U'('));
@@ -6143,38 +5697,24 @@ if (!is_parenthesized){
 output.append_code_point(static_cast<u32>(U')'));
 }
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_171;}/*switch end*/
+}goto __jakt_label_171; __jakt_label_171:;;goto __jakt_label_170;};/*case end*/
 case 2 /* ClassInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ClassInstance;Jakt::ids::TypeId const& type_id = __jakt_match_value.type;
 {
 output.appendff(ByteString::from_utf8_without_validation("JaktInternal::lenient_is<{}>(__jakt_enum_value.ptr())"sv),TRY((this->codegen_type_possibly_as_namespace(type_id,true))));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_170;};/*case end*/
 case 3 /* CatchAll */:{
 this->compiler->panic(ByteString::from_utf8_without_validation("catch all has no condition, should be emitted separately"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_170;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_170; __jakt_label_170:;;
 }
 return {};
 }
 
-ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_enum_match(Jakt::types::CheckedEnum const enum_,NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr,JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const match_cases,Jakt::ids::TypeId const type_id,ByteString const cpp_match_result_type,bool const all_variants_constant,ByteStringBuilder& output) {
+ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_enum_match(Jakt::types::CheckedEnum const enum_,NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr,JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const match_cases,Jakt::ids::TypeId const type_id,ByteStringBuilder& output) {
 {
 ByteStringBuilder subject_builder = ByteStringBuilder::create();
 TRY((this->codegen_expression(expr,subject_builder,true,false)));
@@ -6185,11 +5725,6 @@ return !(self == rhs);
 }
 (subject,ByteString::from_utf8_without_validation("*this"sv));
 if (enum_.underlying_type_id.equals(Jakt::types::void_type_id())){
-output.append(StringView::from_string_literal("([&]() -> JaktInternal::ExplicitValueOrControlFlow<"sv));
-output.append(cpp_match_result_type);
-output.append(StringView::from_string_literal(", "sv));
-output.append(TRY((this->codegen_function_return_type(this->current_function.value()))));
-output.append(StringView::from_string_literal(">{\n"sv));
 output.append(StringView::from_string_literal("auto&& __jakt_match_variant = "sv));
 if (needs_deref){
 output.append(StringView::from_string_literal("*"sv));
@@ -6222,61 +5757,47 @@ if (!Jakt::codegen::pattern_has_bindings(pattern)){
 patterns_without_bindings.push(pattern);
 continue;
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = pattern;
+{auto&& __jakt_match_variant = pattern;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* EnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;ByteString const& name = __jakt_match_value.name;
 JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> const& args = __jakt_match_value.args;
 Jakt::ids::TypeId const& subject_type_id = __jakt_match_value.subject_type_id;
 size_t const& index = __jakt_match_value.index;
-Jakt::ids::ScopeId const& scope_id = __jakt_match_value.scope_id;
 {
 NonnullRefPtr<typename Jakt::types::Type> const enum_type = this->program->get_type(subject_type_id);
-Jakt::ids::EnumId const enum_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::EnumId, ErrorOr<void>>{
-auto&& __jakt_match_variant = *enum_type;
+Jakt::ids::EnumId const enum_id = [&]() -> Jakt::ids::EnumId { auto&& __jakt_match_variant = *enum_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
+case 21 /* GenericEnumInstance */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected enum type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+ 
+}();
 Jakt::types::CheckedEnum const match_case_enum = this->program->get_enum(enum_id);
-Jakt::types::CheckedEnumVariant const variant = match_case_enum.variants.operator[](index);
+Jakt::types::CheckedEnumVariant const variant = match_case_enum.variants[index];
 output.appendff(ByteString::from_utf8_without_validation("case {} /* {} */: {{\n"sv),index,variant.name());
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = variant;
+{auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Untyped */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Untyped;ByteString const& name = __jakt_match_value.name;
 {
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_173;};/*case end*/
 case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;ByteString const& name = __jakt_match_value.name;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
 if (!args.is_empty()){
 output.appendff(ByteString::from_utf8_without_validation("auto&& __jakt_match_value = __jakt_match_variant.as.{};"sv),name);
-Jakt::parser::EnumVariantPatternArgument const arg = args.operator[](static_cast<i64>(0LL));
-NonnullRefPtr<Jakt::types::CheckedVariable> const var = TRY((this->program->find_var_in_scope(scope_id,arg.binding,false,JaktInternal::OptionalNone()))).value();
+Jakt::parser::EnumVariantPatternArgument const arg = args[static_cast<i64>(0LL)];
+NonnullRefPtr<Jakt::types::CheckedVariable> const var = this->program->get_variable(match_case.bindings[arg.binding]);
 output.append(TRY((this->codegen_type(var->type_id))));
 if (!var->is_mutable){
 output.append(StringView::from_string_literal(" const"sv));
@@ -6286,8 +5807,7 @@ output.append(arg.binding);
 output.append(StringView::from_string_literal(" = __jakt_match_value.value;\n"sv));
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_173;};/*case end*/
 case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;ByteString const& name = __jakt_match_value.name;
 JaktInternal::DynamicArray<Jakt::ids::VarId> const& fields = __jakt_match_value.fields;
@@ -6303,7 +5823,7 @@ break;
 }
 Jakt::parser::EnumVariantPatternArgument arg = _magic_value.value();
 {
-NonnullRefPtr<Jakt::types::CheckedVariable> const var = TRY((this->program->find_var_in_scope(scope_id,arg.binding,false,JaktInternal::OptionalNone()))).value();
+NonnullRefPtr<Jakt::types::CheckedVariable> const var = this->program->get_variable(match_case.bindings[arg.binding]);
 output.append(TRY((this->codegen_type(var->type_id))));
 if (!var->is_mutable){
 output.append(StringView::from_string_literal(" const"sv));
@@ -6348,80 +5868,29 @@ output.append(StringView::from_string_literal(";\n"sv));
 
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_173;};/*case end*/
 default:{
 Jakt::utility::todo(__jakt_format(StringView::from_string_literal("codegen_enum_match match variant else: {}"sv),variant));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
-{
-JaktInternal::ArrayIterator<NonnullRefPtr<typename Jakt::types::CheckedStatement>> _magic = pattern.common.init_common.defaults.iterator();
-for (;;){
-JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const _magic_value = _magic.next();
-if (!_magic_value.has_value()){
-break;
-}
-NonnullRefPtr<typename Jakt::types::CheckedStatement> default_ = _magic_value.value();
-{
-TRY((this->codegen_statement(default_,output)));
-}
-
-}
-}
-
+goto __jakt_label_173;}/*switch end*/
+break;}goto __jakt_label_173; __jakt_label_173:;;
+TRY((this->declare_pattern_defaults(pattern.common.init_common.defaults,match_case.bindings,output)));
 TRY((this->codegen_match_body(body,type_id,output)));
 output.append(StringView::from_string_literal("};/*case end*/\n"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_172;};/*case end*/
 case 3 /* CatchAll */:{
 has_default = true;
 output.append(StringView::from_string_literal("default: {\n"sv));
-{
-JaktInternal::ArrayIterator<NonnullRefPtr<typename Jakt::types::CheckedStatement>> _magic = pattern.common.init_common.defaults.iterator();
-for (;;){
-JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const _magic_value = _magic.next();
-if (!_magic_value.has_value()){
-break;
-}
-NonnullRefPtr<typename Jakt::types::CheckedStatement> default_ = _magic_value.value();
-{
-TRY((this->codegen_statement(default_,output)));
-}
-
-}
-}
-
+TRY((this->declare_pattern_defaults(pattern.common.init_common.defaults,match_case.bindings,output)));
 TRY((this->codegen_match_body(body,type_id,output)));
 output.append(StringView::from_string_literal("};/*case end*/\n"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_172;default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Matching enum subject with non-enum value"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_172;}/*switch end*/
+break;}goto __jakt_label_172; __jakt_label_172:;;
 }
 
 }
@@ -6437,9 +5906,7 @@ break;
 }
 Jakt::types::CheckedMatchPattern pattern = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = pattern;
+{auto&& __jakt_match_variant = pattern;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* EnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;ByteString const& name = __jakt_match_value.name;
@@ -6447,28 +5914,16 @@ size_t const& index = __jakt_match_value.index;
 {
 output.appendff(ByteString::from_utf8_without_validation("case {} /* {} */:"sv),index,name);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_174;};/*case end*/
 case 3 /* CatchAll */:{
 has_default = true;
 output.append(StringView::from_string_literal("default:"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_174;default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Matching enum subject with non-enum value"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_174;}/*switch end*/
+break;}goto __jakt_label_174; __jakt_label_174:;;
 }
 
 }
@@ -6488,14 +5943,8 @@ Jakt::utility::panic(ByteString::from_utf8_without_validation("Inexhaustive matc
 output.append(StringView::from_string_literal("default: VERIFY_NOT_REACHED();"sv));
 }
 output.append(StringView::from_string_literal("}/*switch end*/\n"sv));
-output.append(StringView::from_string_literal("}()\n)"sv));
 }
 else {
-output.append(StringView::from_string_literal("([&]() -> JaktInternal::ExplicitValueOrControlFlow<"sv));
-output.append(cpp_match_result_type);
-output.append(StringView::from_string_literal(", "sv));
-output.append(TRY((this->codegen_function_return_type(this->current_function.value()))));
-output.append(StringView::from_string_literal(">{\n"sv));
 output.append(StringView::from_string_literal("switch ("sv));
 TRY((this->codegen_expression(expr,output,true,false)));
 output.append(StringView::from_string_literal(") {\n"sv));
@@ -6517,36 +5966,22 @@ break;
 }
 Jakt::types::CheckedMatchPattern pattern = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = pattern;
+{auto&& __jakt_match_variant = pattern;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* EnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;ByteString const& name = __jakt_match_value.name;
 {
 output.appendff(ByteString::from_utf8_without_validation("case {}::{}:"sv),enum_.name,name);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_175;};/*case end*/
 case 3 /* CatchAll */:{
 output.append(StringView::from_string_literal("default:"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_175;default:{
 Jakt::utility::todo(__jakt_format(StringView::from_string_literal("underlying type enum match, match_case: {}"sv),match_case));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_175;}/*switch end*/
+break;}goto __jakt_label_175; __jakt_label_175:;;
 }
 
 }
@@ -6559,7 +5994,40 @@ TRY((this->codegen_match_body(match_case.body,type_id,output)));
 }
 
 output.append(StringView::from_string_literal("}/*switch end*/\n"sv));
-output.append(StringView::from_string_literal("}()\n)"sv));
+}
+
+if (Jakt::codegen::are_loop_exits_allowed(this->control_flow_state.allowed_exits)){
+{auto&& __jakt_match_variant = this->yield_method.value();
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 2 /* Return */:case 1 /* AssignAndGoto */:output.append(this->break_statement());goto __jakt_label_176;case 0 /* ReturnExplicitValue */:{
+}
+goto __jakt_label_176;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_176; __jakt_label_176:;;
+}
+}
+return {};
+}
+
+ErrorOr<void> Jakt::codegen::CodeGenerator::declare_pattern_defaults(JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& defaults,JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> const& variables,ByteStringBuilder& output) {
+{
+{
+JaktInternal::DictionaryIterator<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> _magic = defaults.iterator();
+for (;;){
+JaktInternal::Optional<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>> const _magic_value = _magic.next();
+if (!_magic_value.has_value()){
+break;
+}
+JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> name__init__ = _magic_value.value();
+{
+JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const jakt__name__init__ = name__init__;
+ByteString const name = jakt__name__init__.template get<0>();
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const init = jakt__name__init__.template get<1>();
+
+Jakt::ids::VarId const var_id = variables[name];
+TRY((this->codegen_var_decl(var_id,init,output)));
+}
+
+}
 }
 
 }
@@ -6568,33 +6036,41 @@ return {};
 
 ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_match_body(Jakt::types::CheckedMatchBody const body,Jakt::ids::TypeId const return_type_id,ByteStringBuilder& output) {
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = body;
+{auto&& __jakt_match_variant = body;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& block = __jakt_match_value.value;
 {
 TRY((this->codegen_block(block,output)));
-if (return_type_id.equals(Jakt::types::void_type_id()) || return_type_id.equals(Jakt::types::unknown_type_id())){
-output.append(StringView::from_string_literal("return JaktInternal::ExplicitValue<void>();\n"sv));
+if (!Jakt::codegen::has_cpp_value(return_type_id)){
+{auto&& __jakt_match_variant = this->yield_method.value();
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 2 /* Return */:TRY((this->codegen_return(JaktInternal::OptionalNone(),output)));goto __jakt_label_178;case 0 /* ReturnExplicitValue */:{
+Jakt::utility::panic(ByteString::from_utf8_without_validation("Void match should not be using ExplicitValue"sv));
+}
+goto __jakt_label_178;case 1 /* AssignAndGoto */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.AssignAndGoto;ByteString const& label = __jakt_match_value.label;
+output.appendff(ByteString::from_utf8_without_validation("goto {};"sv),label);goto __jakt_label_178;};/*case end*/
+default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_178; __jakt_label_178:;;
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_177;};/*case end*/
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.value;
 {
-NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp405 = expr;
-if (__jakt_tmp405->__jakt_init_index() == 28 /* Block */){
-Jakt::types::CheckedBlock const block = __jakt_tmp405->as.Block.block;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp269 = expr;
+if (__jakt_tmp269->__jakt_init_index() == 28 /* Block */){
+Jakt::types::CheckedBlock const block = __jakt_tmp269->as.Block.block;
 TRY((this->codegen_block(block,output)));
 output.append(StringView::from_string_literal("VERIFY_NOT_REACHED();\n"sv));
 }
-else if ((expr->type().equals(Jakt::types::void_type_id()) || expr->type().equals(Jakt::types::never_type_id())) || (expr->type().equals(Jakt::types::unknown_type_id()) && (!(expr->__jakt_init_index() == 25 /* OptionalNone */)))){
-output.append(StringView::from_string_literal("return ({"sv));
-TRY((this->codegen_expression(expr,output,true,false)));
-output.append(StringView::from_string_literal(";}), JaktInternal::ExplicitValue<void>();\n"sv));
+else {
+{auto&& __jakt_match_variant = this->yield_method.value();
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 2 /* Return */:TRY((this->codegen_value_return(expr,output)));goto __jakt_label_179;case 0 /* ReturnExplicitValue */:{
+if ((expr->type().equals(Jakt::types::void_type_id()) || expr->type().equals(Jakt::types::never_type_id())) || (expr->type().equals(Jakt::types::unknown_type_id()) && (!(expr->__jakt_init_index() == 25 /* OptionalNone */)))){
+Jakt::utility::panic(ByteString::from_utf8_without_validation("Void match should not be using ExplicitValue"sv));
 }
 else {
 output.append(StringView::from_string_literal("return JaktInternal::ExplicitValue("sv));
@@ -6603,15 +6079,27 @@ output.append(StringView::from_string_literal(");\n"sv));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_179;case 1 /* AssignAndGoto */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.AssignAndGoto;ByteString const& label = __jakt_match_value.label;
+{
+if (!Jakt::codegen::has_cpp_value(expr->type())){
+TRY((this->codegen_expression(expr,output,true,false)));
+output.appendff(ByteString::from_utf8_without_validation(";goto {};"sv),label);
+}
+else {
+Jakt::utility::panic(ByteString::from_utf8_without_validation("Only matches yielding void can use AssignAndGoto"sv));
+}
+
+}
+goto __jakt_label_179;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}goto __jakt_label_179; __jakt_label_179:;;
+}
+
+}
+goto __jakt_label_177;};/*case end*/
+default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_177; __jakt_label_177:;;
 }
 return {};
 }
@@ -6631,9 +6119,9 @@ return type_name;
 
 ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_binary_expression(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expression,Jakt::ids::TypeId const type_id,NonnullRefPtr<typename Jakt::types::CheckedExpression> const lhs,NonnullRefPtr<typename Jakt::types::CheckedExpression> const rhs,Jakt::types::CheckedBinaryOperator const op,ByteStringBuilder& output,bool const forward_error_with_try,bool const syntactically_self_contained) {
 {
-JaktInternal::Optional<Jakt::types::OperatorTraitImplementation> __jakt_tmp406 = op.trait_implementation;
-if (__jakt_tmp406.has_value()){
-Jakt::types::OperatorTraitImplementation const implementation = __jakt_tmp406.value();
+JaktInternal::Optional<Jakt::types::OperatorTraitImplementation> __jakt_tmp270 = op.trait_implementation;
+if (__jakt_tmp270.has_value()){
+Jakt::types::OperatorTraitImplementation const implementation = __jakt_tmp270.value();
 TRY((this->codegen_method_call(lhs,implementation.call_expression,false,output,forward_error_with_try,syntactically_self_contained)));
 return {};
 }
@@ -6646,9 +6134,9 @@ output.append(this->current_error_handler(true));
 output.append(StringView::from_string_literal("(("sv));
 }
 TRY((this->codegen_expression(lhs,output,true,true)));
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp407 = rhs_type;
-if (__jakt_tmp407->__jakt_init_index() == 20 /* GenericInstance */){
-Jakt::ids::StructId const id = __jakt_tmp407->as.GenericInstance.id;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp271 = rhs_type;
+if (__jakt_tmp271->__jakt_init_index() == 20 /* GenericInstance */){
+Jakt::ids::StructId const id = __jakt_tmp271->as.GenericInstance.id;
 if (this->program->get_struct(id).name_for_codegen().as_name_for_definition() == ByteString::from_utf8_without_validation("Optional"sv)){
 if (rhs_can_throw){
 output.append(StringView::from_string_literal(".try_value_or_lazy_evaluated_optional"sv));
@@ -6715,10 +6203,10 @@ output.append(StringView::from_string_literal(")"sv));
 return {};
 }
 if (op.op.__jakt_init_index() == 21 /* Assign */){
-NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp408 = lhs;
-if (__jakt_tmp408->__jakt_init_index() == 14 /* IndexedDictionary */){
-NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr = __jakt_tmp408->as.IndexedDictionary.expr;
-NonnullRefPtr<typename Jakt::types::CheckedExpression> const index = __jakt_tmp408->as.IndexedDictionary.index;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp272 = lhs;
+if (__jakt_tmp272->__jakt_init_index() == 14 /* IndexedDictionary */){
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr = __jakt_tmp272->as.IndexedDictionary.expr;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const index = __jakt_tmp272->as.IndexedDictionary.index;
 TRY((this->codegen_expression(expr,output,true,true)));
 output.append(StringView::from_string_literal(".set("sv));
 TRY((this->codegen_expression(index,output,true,false)));
@@ -6729,9 +6217,7 @@ return {};
 }
 }
 if (this->program->is_integer(type_id)){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = op.op;
+{auto&& __jakt_match_variant = op.op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */:case 1 /* Subtract */:case 2 /* Multiply */:case 3 /* Divide */:case 4 /* Modulo */:{
 if (this->compiler->optimize){
@@ -6749,8 +6235,7 @@ TRY((this->codegen_checked_binary_op(lhs,rhs,op.op,type_id,output)));
 
 return {};
 }
-return JaktInternal::ExplicitValue<void>();
-case 27 /* AddAssign */:case 28 /* SubtractAssign */:case 29 /* MultiplyAssign */:case 31 /* DivideAssign */:case 30 /* ModuloAssign */:{
+goto __jakt_label_180;case 27 /* AddAssign */:case 28 /* SubtractAssign */:case 29 /* MultiplyAssign */:case 31 /* DivideAssign */:case 30 /* ModuloAssign */:{
 if (this->compiler->optimize){
 if (syntactically_self_contained){
 output.append_code_point(static_cast<u32>(U'('));
@@ -6765,66 +6250,23 @@ TRY((this->codegen_checked_binary_op_assignment(lhs,rhs,op.op,type_id,output)));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_180;default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_180;}/*switch end*/
+}goto __jakt_label_180; __jakt_label_180:;;
 }
 if (syntactically_self_contained){
 output.append_code_point(static_cast<u32>(U'('));
 }
 TRY((this->codegen_expression(lhs,output,true,true)));
-output.append(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<StringView, ErrorOr<void>>{
-auto&& __jakt_match_variant = op.op;
+output.append([&]() -> StringView { auto&& __jakt_match_variant = op.op;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Add */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" + "sv));
-case 1 /* Subtract */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" - "sv));
-case 2 /* Multiply */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" * "sv));
-case 4 /* Modulo */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" % "sv));
-case 3 /* Divide */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" / "sv));
-case 21 /* Assign */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" = "sv));
-case 27 /* AddAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" += "sv));
-case 28 /* SubtractAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" -= "sv));
-case 29 /* MultiplyAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" *= "sv));
-case 30 /* ModuloAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" %= "sv));
-case 31 /* DivideAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" /= "sv));
-case 22 /* BitwiseAndAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" &= "sv));
-case 23 /* BitwiseOrAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" |= "sv));
-case 24 /* BitwiseXorAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" ^= "sv));
-case 25 /* BitwiseLeftShiftAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" <<= "sv));
-case 26 /* BitwiseRightShiftAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" >>= "sv));
-case 9 /* Equal */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" == "sv));
-case 10 /* NotEqual */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" != "sv));
-case 5 /* LessThan */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" < "sv));
-case 6 /* LessThanOrEqual */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" <= "sv));
-case 7 /* GreaterThan */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" > "sv));
-case 8 /* GreaterThanOrEqual */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" >= "sv));
-case 18 /* LogicalAnd */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" && "sv));
-case 19 /* LogicalOr */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" || "sv));
-case 11 /* BitwiseAnd */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" & "sv));
-case 13 /* BitwiseOr */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" | "sv));
-case 12 /* BitwiseXor */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" ^ "sv));
-case 16 /* ArithmeticLeftShift */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" << "sv));
-case 14 /* BitwiseLeftShift */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" << "sv));
-case 15 /* BitwiseRightShift */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" >> "sv));
-default:{
+case 0 /* Add */:return StringView::from_string_literal(" + "sv);case 1 /* Subtract */:return StringView::from_string_literal(" - "sv);case 2 /* Multiply */:return StringView::from_string_literal(" * "sv);case 4 /* Modulo */:return StringView::from_string_literal(" % "sv);case 3 /* Divide */:return StringView::from_string_literal(" / "sv);case 21 /* Assign */:return StringView::from_string_literal(" = "sv);case 27 /* AddAssign */:return StringView::from_string_literal(" += "sv);case 28 /* SubtractAssign */:return StringView::from_string_literal(" -= "sv);case 29 /* MultiplyAssign */:return StringView::from_string_literal(" *= "sv);case 30 /* ModuloAssign */:return StringView::from_string_literal(" %= "sv);case 31 /* DivideAssign */:return StringView::from_string_literal(" /= "sv);case 22 /* BitwiseAndAssign */:return StringView::from_string_literal(" &= "sv);case 23 /* BitwiseOrAssign */:return StringView::from_string_literal(" |= "sv);case 24 /* BitwiseXorAssign */:return StringView::from_string_literal(" ^= "sv);case 25 /* BitwiseLeftShiftAssign */:return StringView::from_string_literal(" <<= "sv);case 26 /* BitwiseRightShiftAssign */:return StringView::from_string_literal(" >>= "sv);case 9 /* Equal */:return StringView::from_string_literal(" == "sv);case 10 /* NotEqual */:return StringView::from_string_literal(" != "sv);case 5 /* LessThan */:return StringView::from_string_literal(" < "sv);case 6 /* LessThanOrEqual */:return StringView::from_string_literal(" <= "sv);case 7 /* GreaterThan */:return StringView::from_string_literal(" > "sv);case 8 /* GreaterThanOrEqual */:return StringView::from_string_literal(" >= "sv);case 18 /* LogicalAnd */:return StringView::from_string_literal(" && "sv);case 19 /* LogicalOr */:return StringView::from_string_literal(" || "sv);case 11 /* BitwiseAnd */:return StringView::from_string_literal(" & "sv);case 13 /* BitwiseOr */:return StringView::from_string_literal(" | "sv);case 12 /* BitwiseXor */:return StringView::from_string_literal(" ^ "sv);case 16 /* ArithmeticLeftShift */:return StringView::from_string_literal(" << "sv);case 14 /* BitwiseLeftShift */:return StringView::from_string_literal(" << "sv);case 15 /* BitwiseRightShift */:return StringView::from_string_literal(" >> "sv);default:{
 Jakt::utility::todo(__jakt_format(StringView::from_string_literal("codegen_binary_expression {}"sv),op));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+ 
+}());
 TRY((this->codegen_expression(rhs,output,true,true)));
 if (syntactically_self_contained){
 output.append_code_point(static_cast<u32>(U')'));
@@ -6839,25 +6281,14 @@ output.append(StringView::from_string_literal("static_cast<"sv));
 output.append(TRY((this->codegen_type(type_id))));
 output.append(StringView::from_string_literal(">("sv));
 TRY((this->codegen_expression(lhs,output,true,false)));
-output.append(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<StringView, ErrorOr<void>>{
-auto&& __jakt_match_variant = op;
+output.append([&]() -> StringView { auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Add */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" + "sv));
-case 1 /* Subtract */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" - "sv));
-case 2 /* Multiply */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" * "sv));
-case 3 /* Divide */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" / "sv));
-case 4 /* Modulo */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" % "sv));
-default:{
+case 0 /* Add */:return StringView::from_string_literal(" + "sv);case 1 /* Subtract */:return StringView::from_string_literal(" - "sv);case 2 /* Multiply */:return StringView::from_string_literal(" * "sv);case 3 /* Divide */:return StringView::from_string_literal(" / "sv);case 4 /* Modulo */:return StringView::from_string_literal(" % "sv);default:{
 Jakt::utility::panic(__jakt_format(StringView::from_string_literal("Checked binary operation codegen is not supported for BinaryOperator::{}"sv),op));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+ 
+}());
 TRY((this->codegen_expression(rhs,output,true,false)));
 output.append(StringView::from_string_literal(")"sv));
 }
@@ -6867,25 +6298,14 @@ return {};
 ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_checked_binary_op(NonnullRefPtr<typename Jakt::types::CheckedExpression> const lhs,NonnullRefPtr<typename Jakt::types::CheckedExpression> const rhs,Jakt::parser::BinaryOperator const op,Jakt::ids::TypeId const type_id,ByteStringBuilder& output) {
 {
 output.append(StringView::from_string_literal("JaktInternal::"sv));
-output.append(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<StringView, ErrorOr<void>>{
-auto&& __jakt_match_variant = op;
+output.append([&]() -> StringView { auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Add */:return JaktInternal::ExplicitValue(StringView::from_string_literal("checked_add"sv));
-case 1 /* Subtract */:return JaktInternal::ExplicitValue(StringView::from_string_literal("checked_sub"sv));
-case 2 /* Multiply */:return JaktInternal::ExplicitValue(StringView::from_string_literal("checked_mul"sv));
-case 3 /* Divide */:return JaktInternal::ExplicitValue(StringView::from_string_literal("checked_div"sv));
-case 4 /* Modulo */:return JaktInternal::ExplicitValue(StringView::from_string_literal("checked_mod"sv));
-default:{
+case 0 /* Add */:return StringView::from_string_literal("checked_add"sv);case 1 /* Subtract */:return StringView::from_string_literal("checked_sub"sv);case 2 /* Multiply */:return StringView::from_string_literal("checked_mul"sv);case 3 /* Divide */:return StringView::from_string_literal("checked_div"sv);case 4 /* Modulo */:return StringView::from_string_literal("checked_mod"sv);default:{
 Jakt::utility::panic(__jakt_format(StringView::from_string_literal("Checked binary operation codegen is not supported for BinaryOperator::{}"sv),op));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+ 
+}());
 output.append(StringView::from_string_literal("<"sv));
 output.append(TRY((this->codegen_type(type_id))));
 output.append(StringView::from_string_literal(">("sv));
@@ -6906,25 +6326,14 @@ output.append(StringView::from_string_literal(";"sv));
 output.append(StringView::from_string_literal("_jakt_ref = static_cast<"sv));
 output.append(TRY((this->codegen_type(type_id))));
 output.append(StringView::from_string_literal(">(_jakt_ref "sv));
-output.append(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<StringView, ErrorOr<void>>{
-auto&& __jakt_match_variant = op;
+output.append([&]() -> StringView { auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 27 /* AddAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" + "sv));
-case 28 /* SubtractAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" - "sv));
-case 29 /* MultiplyAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" * "sv));
-case 31 /* DivideAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" / "sv));
-case 30 /* ModuloAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal(" % "sv));
-default:{
+case 27 /* AddAssign */:return StringView::from_string_literal(" + "sv);case 28 /* SubtractAssign */:return StringView::from_string_literal(" - "sv);case 29 /* MultiplyAssign */:return StringView::from_string_literal(" * "sv);case 31 /* DivideAssign */:return StringView::from_string_literal(" / "sv);case 30 /* ModuloAssign */:return StringView::from_string_literal(" % "sv);default:{
 Jakt::utility::panic(__jakt_format(StringView::from_string_literal("Checked binary operation assignment codegen is not supported for BinaryOperator::{}"sv),op));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+ 
+}());
 TRY((this->codegen_expression(rhs,output,true,false)));
 output.append(StringView::from_string_literal(");"sv));
 output.append(StringView::from_string_literal("}"sv));
@@ -6939,25 +6348,14 @@ output.append(StringView::from_string_literal("auto& _jakt_ref = "sv));
 TRY((this->codegen_expression(lhs,output,true,false)));
 output.append(StringView::from_string_literal(";"sv));
 output.append(StringView::from_string_literal("_jakt_ref = JaktInternal::"sv));
-output.append(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<StringView, ErrorOr<void>>{
-auto&& __jakt_match_variant = op;
+output.append([&]() -> StringView { auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 27 /* AddAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal("checked_add"sv));
-case 28 /* SubtractAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal("checked_sub"sv));
-case 29 /* MultiplyAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal("checked_mul"sv));
-case 31 /* DivideAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal("checked_div"sv));
-case 30 /* ModuloAssign */:return JaktInternal::ExplicitValue(StringView::from_string_literal("checked_mod"sv));
-default:{
+case 27 /* AddAssign */:return StringView::from_string_literal("checked_add"sv);case 28 /* SubtractAssign */:return StringView::from_string_literal("checked_sub"sv);case 29 /* MultiplyAssign */:return StringView::from_string_literal("checked_mul"sv);case 31 /* DivideAssign */:return StringView::from_string_literal("checked_div"sv);case 30 /* ModuloAssign */:return StringView::from_string_literal("checked_mod"sv);default:{
 Jakt::utility::panic(__jakt_format(StringView::from_string_literal("Checked binary operation assignment codegen is not supported for BinaryOperator::{}"sv),op));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+ 
+}());
 output.append(StringView::from_string_literal("<"sv));
 output.append(TRY((this->codegen_type(type_id))));
 output.append(StringView::from_string_literal(">(_jakt_ref, "sv));
@@ -6970,17 +6368,10 @@ return {};
 
 ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_method_call(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr,Jakt::types::CheckedCall const call,bool const is_optional,ByteStringBuilder& output,bool const forward_error_with_try,bool const syntactically_self_contained) {
 {
-ByteString const error_handler = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (call.callee_throws);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(this->current_error_handler(forward_error_with_try));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const error_handler = [&]() -> ByteString { auto __jakt_enum_value = call.callee_throws;
+if (__jakt_enum_value) {return this->current_error_handler(forward_error_with_try);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation(""sv);}VERIFY_NOT_REACHED();
+ 
+}();
 if (!error_handler.is_empty()){
 output.appendff(ByteString::from_utf8_without_validation("{}(("sv),error_handler);
 }
@@ -7003,21 +6394,14 @@ return {};
 if (call.function_id.has_value() && (call.force_inline.__jakt_init_index() == 2 /* ForceInline */)){
 NonnullRefPtr<Jakt::types::CheckedFunction> const function = this->program->get_function(call.function_id.value());
 bool const is_mutable = expr->is_mutable(this->program) && function->params.first().value().variable->is_mutable;
-NonnullRefPtr<typename Jakt::types::Type> const reference_type = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::Type>,ErrorOr<void>> {
-auto __jakt_enum_value = (is_mutable);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::Type::MutableReference(Jakt::parser::CheckedQualifiers(false),expr->type()));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::Type::Reference(Jakt::parser::CheckedQualifiers(false),expr->type()));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+NonnullRefPtr<typename Jakt::types::Type> const reference_type = [&]() -> NonnullRefPtr<typename Jakt::types::Type> { auto __jakt_enum_value = is_mutable;
+if (__jakt_enum_value) {return Jakt::types::Type::MutableReference(Jakt::parser::CheckedQualifiers(false),expr->type());}else if (!__jakt_enum_value) {return Jakt::types::Type::Reference(Jakt::parser::CheckedQualifiers(false),expr->type());}VERIFY_NOT_REACHED();
+ 
+}();
 NonnullRefPtr<Jakt::types::CheckedVariable> const var = Jakt::types::CheckedVariable::__jakt_create(ByteString::from_utf8_without_validation("self"sv),this->program->find_or_add_type_id(reference_type,expr->type().module,false),is_mutable,expr->span(),JaktInternal::OptionalNone(),Jakt::types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
 JaktInternal::DynamicArray<Jakt::types::CheckedParameter> params = DynamicArray<Jakt::types::CheckedParameter>::create_with({Jakt::types::CheckedParameter(false,var,JaktInternal::OptionalNone())});
 {
-JaktInternal::ArrayIterator<Jakt::types::CheckedParameter> _magic = function->params.operator[](JaktInternal::Range<i64>{static_cast<i64>(static_cast<i64>(1LL)),static_cast<i64>(9223372036854775807LL)}).iterator();
+JaktInternal::ArrayIterator<Jakt::types::CheckedParameter> _magic = function->params[JaktInternal::Range<i64>{static_cast<i64>(static_cast<i64>(1LL)),static_cast<i64>(9223372036854775807LL)}].iterator();
 for (;;){
 JaktInternal::Optional<Jakt::types::CheckedParameter> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
@@ -7067,84 +6451,34 @@ return {};
 }
 NonnullRefPtr<typename Jakt::types::Type> const expression_type = this->program->get_type(expr->type());
 Jakt::parser::ExternalName const name = call.name_for_codegen();
+bool const use_cpp_index_operator = (name.as_name_for_use() == ByteString::from_utf8_without_validation("operator[]"sv)) && (call.args.size() == static_cast<size_t>(1ULL));
+if (!use_cpp_index_operator){
 bool const object_is_this = this->expr_codegens_to_this_pointer(expr);
-ByteString const field_accessor = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<void>>{
-auto&& __jakt_match_variant = name;
+ByteString const field_accessor = [&]() -> ByteString { auto&& __jakt_match_variant = name;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* Operator */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<void>>{
-auto&& __jakt_match_variant = *expression_type;
+case 2 /* Operator */:return ByteString::from_utf8_without_validation(""sv);default:{auto&& __jakt_match_variant = *expression_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 25 /* RawPtr */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("->"sv));
-case 23 /* Struct */: {
+case 25 /* RawPtr */:return ByteString::from_utf8_without_validation("->"sv);case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = ((this->program->get_struct(id).record_type.__jakt_init_index() == 1 /* Class */) && (!object_is_this));
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("->"sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("."sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+{auto __jakt_enum_value = (this->program->get_struct(id).record_type.__jakt_init_index() == 1 /* Class */) && (!object_is_this);
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation("->"sv);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation("."sv);}VERIFY_NOT_REACHED();
+}};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = ((this->program->get_struct(id).record_type.__jakt_init_index() == 1 /* Class */) && (!object_is_this));
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("->"sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("."sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+{auto __jakt_enum_value = (this->program->get_struct(id).record_type.__jakt_init_index() == 1 /* Class */) && (!object_is_this);
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation("->"sv);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation("."sv);}VERIFY_NOT_REACHED();
+}};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (this->program->get_enum(id).is_boxed && (!object_is_this));
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("->"sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("."sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (expression_type->is_builtin() && (!(expression_type->__jakt_init_index() == 13 /* JaktString */)));
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("."sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = this->program->get_enum(id).is_boxed && (!object_is_this);
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation("->"sv);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation("."sv);}VERIFY_NOT_REACHED();
+}};/*case end*/
+default:{auto __jakt_enum_value = expression_type->is_builtin() && (!(expression_type->__jakt_init_index() == 13 /* JaktString */));
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation(""sv);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation("."sv);}VERIFY_NOT_REACHED();
+}}/*switch end*/
+}}/*switch end*/
+ 
+}();
 Function<ErrorOr<void>()> const generate_method_name = [this, &call, &name, &output]() -> ErrorOr<void> {{
 if (name.is_prefix()){
 output.append(name.as_name_for_use());
@@ -7189,19 +6523,11 @@ output.append_code_point(static_cast<u32>(U')'));
 }
 });
 if (is_called_as_method){
-if (object_is_this && ((!(name.__jakt_init_index() == 2 /* Operator */)) && ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, ErrorOr<void>>{
-auto&& __jakt_match_variant = *expression_type;
+if (object_is_this && ((!(name.__jakt_init_index() == 2 /* Operator */)) && [&]() -> bool { auto&& __jakt_match_variant = *expression_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 23 /* Struct */:case 20 /* GenericInstance */:case 24 /* Enum */:case 21 /* GenericEnumInstance */:return JaktInternal::ExplicitValue(true);
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}))){
+case 23 /* Struct */:case 20 /* GenericInstance */:case 24 /* Enum */:case 21 /* GenericEnumInstance */:return true;default:return false;}/*switch end*/
+ 
+}())){
 output.append(StringView::from_string_literal("this->"sv));
 }
 else {
@@ -7221,13 +6547,11 @@ TRY((generate_object(output,true)));
 if (is_optional){
 output.append(StringView::from_string_literal("map([&](auto& _value) { return _value"sv));
 ByteString access_operator = ByteString::from_utf8_without_validation("."sv);
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp409 = expression_type;
-if (__jakt_tmp409->__jakt_init_index() == 20 /* GenericInstance */){
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp409->as.GenericInstance.args;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp273 = expression_type;
+if (__jakt_tmp273->__jakt_init_index() == 20 /* GenericInstance */){
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp273->as.GenericInstance.args;
 if (args.size() > static_cast<size_t>(0ULL)){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = *this->program->get_type(args.operator[](static_cast<i64>(0LL)));
+{auto&& __jakt_match_variant = *this->program->get_type(args[static_cast<i64>(0LL)]);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
@@ -7236,8 +6560,7 @@ if (this->program->get_struct(id).record_type.__jakt_init_index() == 1 /* Class 
 access_operator = ByteString::from_utf8_without_validation("->"sv);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_181;};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
 {
@@ -7245,18 +6568,11 @@ if (this->program->get_struct(id).record_type.__jakt_init_index() == 1 /* Class 
 access_operator = ByteString::from_utf8_without_validation("->"sv);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_181;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_181;}/*switch end*/
+}goto __jakt_label_181; __jakt_label_181:;;
 }
 }
 output.append(access_operator);
@@ -7301,22 +6617,24 @@ if (is_optional){
 output.append(StringView::from_string_literal("; })"sv));
 }
 }
+else {
+TRY((this->codegen_expression(expr,output,true,true)));
+output.append_code_point(static_cast<u32>(U'['));
+TRY((this->codegen_expression(call.args[static_cast<i64>(0LL)].template get<1>(),output,true,false)));
+output.append_code_point(static_cast<u32>(U']'));
+return {};
+}
+
+}
 return {};
 }
 
 ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_call(Jakt::types::CheckedCall const call,ByteStringBuilder& output,bool const forward_error_with_try) {
 {
-ByteString const error_handler = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (call.callee_throws);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(this->current_error_handler(forward_error_with_try));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const error_handler = [&]() -> ByteString { auto __jakt_enum_value = call.callee_throws;
+if (__jakt_enum_value) {return this->current_error_handler(forward_error_with_try);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation(""sv);}VERIFY_NOT_REACHED();
+ 
+}();
 if (!error_handler.is_empty()){
 output.appendff(ByteString::from_utf8_without_validation("{}(("sv),error_handler);
 }
@@ -7334,24 +6652,11 @@ if (call.function_id.has_value() && this->program->get_function(call.function_id
 output.appendff(ByteString::from_utf8_without_validation("fail_comptime_call<{}, \"Comptime function {} called outside Jakt compiler\">()"sv),TRY((this->codegen_type(call.return_type))),call.name);
 return {};
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<void>> {
-auto __jakt_enum_value = (call.name);
+{auto __jakt_enum_value = call.name;
 if ((__jakt_enum_value == ByteString::from_utf8_without_validation("print"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("println"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("eprintln"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("eprint"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("format"sv))) {{
-ByteString const helper = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (call.name);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("print"sv)) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("out"sv));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("println"sv)) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("outln"sv));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("eprint"sv)) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("warn"sv));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("eprintln"sv)) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("warnln"sv));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("format"sv)) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("__jakt_format"sv));
-}else {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const helper = [&]() -> ByteString { auto __jakt_enum_value = call.name;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("print"sv)) {return ByteString::from_utf8_without_validation("out"sv);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("println"sv)) {return ByteString::from_utf8_without_validation("outln"sv);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("eprint"sv)) {return ByteString::from_utf8_without_validation("warn"sv);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("eprintln"sv)) {return ByteString::from_utf8_without_validation("warnln"sv);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("format"sv)) {return ByteString::from_utf8_without_validation("__jakt_format"sv);}else {return ByteString::from_utf8_without_validation(""sv);} 
+}();
 output.append(helper);
 output.append(StringView::from_string_literal("("sv));
 {
@@ -7363,7 +6668,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const __expr_ = call.args.operator[](i);
+JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const __expr_ = call.args[i];
 ByteString const _ = __expr_.template get<0>();
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr = __expr_.template get<1>();
 
@@ -7378,8 +6683,7 @@ output.append(StringView::from_string_literal(","sv));
 
 output.append(StringView::from_string_literal(")"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_182;}else {{
 bool close_enum_type_wrapper = false;
 if (call.function_id.has_value()){
 Jakt::ids::FunctionId const function_id = call.function_id.value();
@@ -7393,9 +6697,7 @@ Jakt::parser::ExternalName const name = call.name_for_codegen();
 if ((!name.is_prefix()) && name.is_scopable()){
 output.append(TRY((this->codegen_namespace_path(call))));
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = *type;
+{auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
@@ -7411,8 +6713,7 @@ output.append(call.name_for_codegen().as_name_for_use());
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_183;};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -7477,24 +6778,15 @@ output.append(StringView::from_string_literal(">"sv));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_183;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Should be unreachable"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_183;}/*switch end*/
+}goto __jakt_label_183; __jakt_label_183:;;
 }
 else if (function->type.__jakt_init_index() == 4 /* ImplicitEnumConstructor */){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = *this->program->get_type(function->return_type_id);
+{auto&& __jakt_match_variant = *this->program->get_type(function->return_type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
@@ -7505,26 +6797,18 @@ output.append(TRY((this->codegen_type_possibly_as_namespace(call.return_type,tru
 output.append(StringView::from_string_literal("::"sv));
 output.append(call.name_for_codegen().as_name_for_use());
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_184;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
 {
 Jakt::utility::todo(ByteString::from_utf8_without_validation("codegen generic enum instance"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_184;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("constructor expected enum type"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_184;}/*switch end*/
+}goto __jakt_label_184; __jakt_label_184:;;
 }
 else {
 Jakt::parser::ExternalName const name = call.name_for_codegen();
@@ -7583,13 +6867,7 @@ arguments.push(builder.to_string());
 
 output.appendff(ByteString::from_utf8_without_validation("({})"sv),Jakt::utility::join(arguments,ByteString::from_utf8_without_validation(","sv)));
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_182;}}goto __jakt_label_182; __jakt_label_182:;;
 }
 return {};
 }
@@ -7602,48 +6880,36 @@ if (func->owner_scope.has_value()){
 bool is_prelude = false;
 NonnullRefPtr<Jakt::types::Scope> const scope = this->program->get_scope(func->owner_scope.value());
 if (scope->relevant_type_id.has_value()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = *this->program->get_type(scope->relevant_type_id.value());
+{auto&& __jakt_match_variant = *this->program->get_type(scope->relevant_type_id.value());
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
 {
 is_prelude = this->program->get_module(id.module)->is_prelude();
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_185;};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
 {
 is_prelude = this->program->get_module(id.module)->is_prelude();
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_185;};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
 {
 is_prelude = this->program->get_module(id.module)->is_prelude();
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_185;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
 {
 is_prelude = this->program->get_module(id.module)->is_prelude();
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_185;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_185;}/*switch end*/
+}goto __jakt_label_185; __jakt_label_185:;;
 }
 return this->codegen_namespace_qualifier(func->owner_scope.value(),is_prelude,false,call.name_for_codegen().as_name_for_use(),func->owner_scope_generics);
 }
@@ -7745,61 +7011,47 @@ output.append(StringView::from_string_literal("}\n"sv));
 return {};
 }
 
+StringView Jakt::codegen::CodeGenerator::break_statement() const {
+{
+{auto __jakt_enum_value = this->control_flow_state.directly_inside_match;
+if (__jakt_enum_value) {return StringView::from_string_literal("return JaktInternal::LoopBreak{};"sv);}else if (!__jakt_enum_value) {return StringView::from_string_literal("break;"sv);}VERIFY_NOT_REACHED();
+}
+}
+}
+
 ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_statement(NonnullRefPtr<typename Jakt::types::CheckedStatement> const statement,ByteStringBuilder& output) {
 {
 bool add_newline = true;
 if (this->debug_info.statement_span_comments && (statement->span().has_value() && add_newline)){
 output.appendff(ByteString::from_utf8_without_validation("\n#line {}\n"sv),TRY((this->debug_info.span_to_source_location(statement->span().value()))));
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = *statement;
+{auto&& __jakt_match_variant = *statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 {
+this->yields_erroror = true;
 output.append(StringView::from_string_literal("return "sv));
 TRY((this->codegen_expression(expr,output,true,false)));
 output.append(StringView::from_string_literal(";"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_186;};/*case end*/
 case 10 /* Continue */:{
-output.append(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<StringView,ErrorOr<void>> {
-auto __jakt_enum_value = (this->control_flow_state.directly_inside_match);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(StringView::from_string_literal("return JaktInternal::LoopContinue{};"sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(StringView::from_string_literal("continue;"sv));
-}VERIFY_NOT_REACHED();
+output.append([&]() -> StringView { auto __jakt_enum_value = this->control_flow_state.directly_inside_match;
+if (__jakt_enum_value) {return StringView::from_string_literal("return JaktInternal::LoopContinue{};"sv);}else if (!__jakt_enum_value) {return StringView::from_string_literal("continue;"sv);}VERIFY_NOT_REACHED();
+ 
 }());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
 }
-return JaktInternal::ExplicitValue<void>();
-case 9 /* Break */:{
-output.append(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<StringView,ErrorOr<void>> {
-auto __jakt_enum_value = (this->control_flow_state.directly_inside_match);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(StringView::from_string_literal("return JaktInternal::LoopBreak{};"sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(StringView::from_string_literal("break;"sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+goto __jakt_label_186;case 9 /* Break */:{
+output.append(this->break_statement());
 }
-return JaktInternal::ExplicitValue<void>();
-case 0 /* Expression */: {
+goto __jakt_label_186;case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 {
 TRY((this->codegen_expression(expr,output,true,false)));
 output.append(StringView::from_string_literal(";"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_186;};/*case end*/
 case 1 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;NonnullRefPtr<typename Jakt::types::CheckedStatement> const& statement = __jakt_match_value.statement;
 {
@@ -7816,64 +7068,10 @@ output.append(StringView::from_string_literal("});"sv));
 this->control_flow_state = last_control_flow;
 this->inside_defer = old_inside_defer;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_186;};/*case end*/
 case 8 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& val = __jakt_match_value.val;
-return ({({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<void>> {
-auto __jakt_enum_value = (val.has_value());
-if (__jakt_enum_value) {return ({({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<void>> {
-auto __jakt_enum_value = (this->current_function.value()->can_throw);
-if (__jakt_enum_value) {{
-NonnullRefPtr<typename Jakt::types::Type> const type = this->program->get_type(val.value()->type());
-ByteString result = ByteString::from_utf8_without_validation(""sv);
-if ((type->__jakt_init_index() == 0 /* Void */) || (type->__jakt_init_index() == 17 /* Never */)){
-TRY((this->codegen_expression(val.value(),output,true,false)));
-output.append(StringView::from_string_literal("; return {}"sv));
-}
-else {
-output.append(StringView::from_string_literal("return "sv));
-TRY((this->codegen_expression(val.value(),output,false,false)));
-}
-
-output.append(StringView::from_string_literal(";"sv));
-}
-return JaktInternal::ExplicitValue<void>();
-}else if (!__jakt_enum_value) {{
-output.append(StringView::from_string_literal("return "sv));
-TRY((this->codegen_expression(val.value(),output,true,false)));
-output.append(StringView::from_string_literal(";"sv));
-}
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});}), JaktInternal::ExplicitValue<void>();
-}else if (!__jakt_enum_value) {{
-output.append(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<StringView,ErrorOr<void>> {
-auto __jakt_enum_value = (this->current_function.value()->can_throw || this->control_flow_state.indirectly_inside_match);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(StringView::from_string_literal("return {};"sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(StringView::from_string_literal("return;"sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((this->codegen_return(val,output)));goto __jakt_label_186;};/*case end*/
 case 6 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
 {
@@ -7887,8 +7085,7 @@ this->control_flow_state = last_control_flow.enter_loop();
 TRY((this->codegen_block(block,output)));
 this->control_flow_state = last_control_flow;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_186;};/*case end*/
 case 7 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& condition = __jakt_match_value.condition;
 Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
@@ -7908,20 +7105,17 @@ this->control_flow_state = last_control_flow;
 
 add_newline = false;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_186;};/*case end*/
 case 5 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
 {
 TRY((this->codegen_block(block,output)));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_186;};/*case end*/
 case 14 /* Garbage */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Garbage statement in codegen"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* DestructuringAssignment */: {
+goto __jakt_label_186;case 2 /* DestructuringAssignment */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DestructuringAssignment;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const& vars = __jakt_match_value.vars;
 NonnullRefPtr<typename Jakt::types::CheckedStatement> const& var_decl = __jakt_match_value.var_decl;
 {
@@ -7942,26 +7136,11 @@ TRY((this->codegen_statement(v,output)));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_186;};/*case end*/
 case 3 /* VarDecl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.VarDecl;Jakt::ids::VarId const& var_id = __jakt_match_value.var_id;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const& init = __jakt_match_value.init;
-{
-NonnullRefPtr<Jakt::types::CheckedVariable> const var = this->program->get_variable(var_id);
-NonnullRefPtr<typename Jakt::types::Type> const var_type = this->program->get_type(var->type_id);
-output.append(TRY((this->codegen_type(var->type_id))));
-output.append(StringView::from_string_literal(" "sv));
-if ((!var->is_mutable) && (!((var_type->__jakt_init_index() == 27 /* Reference */) || (var_type->__jakt_init_index() == 28 /* MutableReference */)))){
-output.append(StringView::from_string_literal("const "sv));
-}
-output.append(var->name_for_codegen().as_name_for_use());
-output.append(StringView::from_string_literal(" = "sv));
-TRY((this->codegen_expression(init,output,true,false)));
-output.append(StringView::from_string_literal(";"sv));
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((this->codegen_var_decl(var_id,init,output)));goto __jakt_label_186;};/*case end*/
 case 13 /* InlineCpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.InlineCpp;JaktInternal::DynamicArray<ByteString> const& lines = __jakt_match_value.lines;
 {
@@ -7984,8 +7163,7 @@ output.append(escaped_line);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_186;};/*case end*/
 case 4 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& condition = __jakt_match_value.condition;
 Jakt::types::CheckedBlock const& then_block = __jakt_match_value.then_block;
@@ -8004,18 +7182,18 @@ TRY((this->codegen_statement(else_statement.value(),output)));
 }
 add_newline = false;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_186;};/*case end*/
 case 12 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& expr = __jakt_match_value.expr;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 bool const is_void = expr.has_value() && expr.value()->type().equals(Jakt::types::void_type_id());
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = this->yield_method.value();
+{auto&& __jakt_match_variant = this->yield_method.value();
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* ReturnExplicitValue */: {
+case 2 /* Return */:{
+TRY((this->codegen_return(expr,output)));
+}
+goto __jakt_label_187;case 0 /* ReturnExplicitValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ReturnExplicitValue;ByteString const& ctor = __jakt_match_value.ctor;
 {
 if (is_void){
@@ -8025,51 +7203,114 @@ output.append(StringView::from_string_literal("return "sv));
 output.append(ctor);
 output.append_code_point(static_cast<u32>(U'('));
 if (!is_void){
-JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> __jakt_tmp410 = expr;
-if (__jakt_tmp410.has_value()){
-NonnullRefPtr<typename Jakt::types::CheckedExpression> const value = __jakt_tmp410.value();
+JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> __jakt_tmp274 = expr;
+if (__jakt_tmp274.has_value()){
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const value = __jakt_tmp274.value();
 TRY((this->codegen_expression(value,output,true,false)));
 }
 }
 output.append(StringView::from_string_literal(");"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_187;};/*case end*/
 case 1 /* AssignAndGoto */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AssignAndGoto;ByteString const& name = __jakt_match_value.name;
 ByteString const& label = __jakt_match_value.label;
 {
-if ((!is_void) && expr.has_value()){
-output.append(name);
-output.append(StringView::from_string_literal(" = "sv));
-TRY((this->codegen_expression(expr.value(),output,true,false)));
-output.append(StringView::from_string_literal("; "sv));
+JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> __jakt_tmp275 = expr;
+if (__jakt_tmp275.has_value()){
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const val = __jakt_tmp275.value();
+if (is_void){
+TRY((this->codegen_expression(val,output,true,false)));
+output.append_code_point(static_cast<u32>(U';'));
+}
+else {
+output.appendff(ByteString::from_utf8_without_validation("{}.emplace("sv),name);
+TRY((this->codegen_expression(val,output,true,false)));
+output.append(StringView::from_string_literal(");"sv));
+}
+
 }
 output.append(StringView::from_string_literal("goto "sv));
 output.append(label);
 output.append(StringView::from_string_literal(";\n"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_187;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}goto __jakt_label_187; __jakt_label_187:;;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_186;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}goto __jakt_label_186; __jakt_label_186:;;
 if (add_newline){
 output.append(StringView::from_string_literal("\n"sv));
+}
+}
+return {};
+}
+
+ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_var_decl(Jakt::ids::VarId const var_id,NonnullRefPtr<typename Jakt::types::CheckedExpression> const init,ByteStringBuilder& output) {
+{
+NonnullRefPtr<Jakt::types::CheckedVariable> const var = this->program->get_variable(var_id);
+NonnullRefPtr<typename Jakt::types::Type> const var_type = this->program->get_type(var->type_id);
+output.append(TRY((this->codegen_type(var->type_id))));
+output.append(StringView::from_string_literal(" "sv));
+if ((!var->is_mutable) && (!((var_type->__jakt_init_index() == 27 /* Reference */) || (var_type->__jakt_init_index() == 28 /* MutableReference */)))){
+output.append(StringView::from_string_literal("const "sv));
+}
+output.append(var->name_for_codegen().as_name_for_use());
+output.append(StringView::from_string_literal(" = "sv));
+TRY((this->codegen_expression(init,output,true,false)));
+output.append(StringView::from_string_literal(";"sv));
+}
+return {};
+}
+
+ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_return(JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const val,ByteStringBuilder& output) {
+{
+{auto __jakt_enum_value = val.has_value();
+if (__jakt_enum_value) {TRY((this->codegen_value_return(val.value(),output))); return {};}else if (!__jakt_enum_value) {{
+output.append([&]() -> StringView { auto __jakt_enum_value = this->current_function.value()->can_throw || this->control_flow_state.indirectly_inside_match;
+if (__jakt_enum_value) {return StringView::from_string_literal("return {};"sv);}else if (!__jakt_enum_value) {return StringView::from_string_literal("return;"sv);}VERIFY_NOT_REACHED();
+ 
+}());
+}
+return {};}VERIFY_NOT_REACHED();
+}
+}
+return {};
+}
+
+ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_value_return(NonnullRefPtr<typename Jakt::types::CheckedExpression> const val,ByteStringBuilder& output) {
+{
+{auto&& __jakt_match_variant = *val;
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 19 /* Match */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Match;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
+JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const& match_cases = __jakt_match_value.match_cases;
+Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
+TRY((this->codegen_returned_match(expr,match_cases,type_id,output))); return {};};/*case end*/
+default:{auto __jakt_enum_value = this->current_function.value()->can_throw;
+if (__jakt_enum_value) {{
+NonnullRefPtr<typename Jakt::types::Type> const type = this->program->get_type(val->type());
+ByteString result = ByteString::from_utf8_without_validation(""sv);
+if ((type->__jakt_init_index() == 0 /* Void */) || (type->__jakt_init_index() == 17 /* Never */)){
+TRY((this->codegen_expression(val,output,true,false)));
+output.append(StringView::from_string_literal("; return {}"sv));
+}
+else {
+output.append(StringView::from_string_literal("return "sv));
+TRY((this->codegen_expression(val,output,false,false)));
+}
+
+output.append(StringView::from_string_literal(";"sv));
+}
+return {};}else if (!__jakt_enum_value) {{
+output.append(StringView::from_string_literal("return "sv));
+TRY((this->codegen_expression(val,output,true,false)));
+output.append(StringView::from_string_literal(";"sv));
+}
+return {};}VERIFY_NOT_REACHED();
+}}/*switch end*/
 }
 }
 return {};
@@ -8092,37 +7333,18 @@ self = (self + rhs);
 }
 (qualifiers,ByteString::from_utf8_without_validation(" const"sv));
 }
-JaktInternal::Optional<JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>> __jakt_tmp411 = this->generic_inferences;
-if (__jakt_tmp411.has_value()){
-JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> const mappings = __jakt_tmp411.value();
-JaktInternal::Optional<Jakt::ids::TypeId> __jakt_tmp412 = mappings.get(type_id);
-if (__jakt_tmp412.has_value()){
-Jakt::ids::TypeId const id = __jakt_tmp412.value();
+JaktInternal::Optional<JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>> __jakt_tmp276 = this->generic_inferences;
+if (__jakt_tmp276.has_value()){
+JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> const mappings = __jakt_tmp276.value();
+JaktInternal::Optional<Jakt::ids::TypeId> __jakt_tmp277 = mappings.get(type_id);
+if (__jakt_tmp277.has_value()){
+Jakt::ids::TypeId const id = __jakt_tmp277.value();
 return TRY((this->codegen_type_possibly_as_namespace(id,as_namespace))) + qualifiers;
 }
 }
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = *this->program->get_type(type_id);
+return TRY(([&]() -> ErrorOr<ByteString> { auto&& __jakt_match_variant = *this->program->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Void */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("void"sv));
-case 1 /* Bool */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("bool"sv));
-case 2 /* U8 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u8"sv));
-case 3 /* U16 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u16"sv));
-case 4 /* U32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u32"sv));
-case 5 /* U64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u64"sv));
-case 6 /* I8 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i8"sv));
-case 7 /* I16 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i16"sv));
-case 8 /* I32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i32"sv));
-case 9 /* I64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i64"sv));
-case 10 /* F32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("f32"sv));
-case 11 /* F64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("f64"sv));
-case 12 /* Usize */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("size_t"sv));
-case 13 /* JaktString */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("ByteString"sv));
-case 14 /* CChar */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("char"sv));
-case 15 /* CInt */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("int"sv));
-case 17 /* Never */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("void"sv));
-case 31 /* Const */: {
+case 0 /* Void */:return ByteString::from_utf8_without_validation("void"sv);case 1 /* Bool */:return ByteString::from_utf8_without_validation("bool"sv);case 2 /* U8 */:return ByteString::from_utf8_without_validation("u8"sv);case 3 /* U16 */:return ByteString::from_utf8_without_validation("u16"sv);case 4 /* U32 */:return ByteString::from_utf8_without_validation("u32"sv);case 5 /* U64 */:return ByteString::from_utf8_without_validation("u64"sv);case 6 /* I8 */:return ByteString::from_utf8_without_validation("i8"sv);case 7 /* I16 */:return ByteString::from_utf8_without_validation("i16"sv);case 8 /* I32 */:return ByteString::from_utf8_without_validation("i32"sv);case 9 /* I64 */:return ByteString::from_utf8_without_validation("i64"sv);case 10 /* F32 */:return ByteString::from_utf8_without_validation("f32"sv);case 11 /* F64 */:return ByteString::from_utf8_without_validation("f64"sv);case 12 /* Usize */:return ByteString::from_utf8_without_validation("size_t"sv);case 13 /* JaktString */:return ByteString::from_utf8_without_validation("ByteString"sv);case 14 /* CChar */:return ByteString::from_utf8_without_validation("char"sv);case 15 /* CInt */:return ByteString::from_utf8_without_validation("int"sv);case 17 /* Never */:return ByteString::from_utf8_without_validation("void"sv);case 31 /* Const */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Const;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 NonnullRefPtr<Jakt::interpreter::Interpreter> interpreter = Jakt::interpreter::Interpreter::create(this->compiler,this->program,Jakt::types::TypecheckFunctions::__jakt_create([](Jakt::parser::ParsedBlock parsed_block, Jakt::ids::ScopeId parent_scope_id, Jakt::types::SafetyMode safety_mode, JaktInternal::Optional<Jakt::ids::TypeId> yield_type_hint, JaktInternal::Optional<Jakt::ids::FunctionId> containing_function_id) -> ErrorOr<Jakt::types::CheckedBlock> {{
@@ -8137,83 +7359,53 @@ Jakt::utility::panic(ByteString::from_utf8_without_validation("Cannot typecheck 
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr = TRY((Jakt::interpreter::value_to_checked_expression(value,interpreter)));
 ByteStringBuilder builder = ByteStringBuilder::create();
 TRY((this->codegen_expression(expr,builder,true,false)));
-return JaktInternal::ExplicitValue<ByteString>(builder.to_string());
+return builder.to_string();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 25 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (this->program->get_type(type_id)->is_boxed(this->program));
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->codegen_type_possibly_as_namespace(type_id,true))) + ByteString::from_utf8_without_validation("*"sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->codegen_type(type_id))) + ByteString::from_utf8_without_validation("*"sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+{auto __jakt_enum_value = this->program->get_type(type_id)->is_boxed(this->program);
+if (__jakt_enum_value) {return TRY((this->codegen_type_possibly_as_namespace(type_id,true))) + ByteString::from_utf8_without_validation("*"sv);}else if (!__jakt_enum_value) {return TRY((this->codegen_type(type_id))) + ByteString::from_utf8_without_validation("*"sv);}VERIFY_NOT_REACHED();
+}};/*case end*/
 case 27 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (this->program->get_type(type_id)->common.init_common.qualifiers.is_immutable);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->codegen_type(type_id))) + ByteString::from_utf8_without_validation("&"sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->codegen_type(type_id))) + ByteString::from_utf8_without_validation(" const&"sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+{auto __jakt_enum_value = this->program->get_type(type_id)->common.init_common.qualifiers.is_immutable;
+if (__jakt_enum_value) {return TRY((this->codegen_type(type_id))) + ByteString::from_utf8_without_validation("&"sv);}else if (!__jakt_enum_value) {return TRY((this->codegen_type(type_id))) + ByteString::from_utf8_without_validation(" const&"sv);}VERIFY_NOT_REACHED();
+}};/*case end*/
 case 28 /* MutableReference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MutableReference;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((this->codegen_type(type_id))) + ByteString::from_utf8_without_validation("&"sv));
-};/*case end*/
+return TRY((this->codegen_type(type_id))) + ByteString::from_utf8_without_validation("&"sv);};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(TRY((this->codegen_generic_type_instance(id,args,as_namespace))));
-};/*case end*/
+return this->codegen_generic_type_instance(id,args,as_namespace);};/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
 {
 JaktInternal::Optional<Jakt::ids::TypeId> const implements_type = this->program->get_struct(id).implements_type;
-return JaktInternal::ExplicitValue<ByteString>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (implements_type.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->codegen_type_possibly_as_namespace(implements_type.value(),as_namespace))));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->codegen_struct_type(id,as_namespace))));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+{auto __jakt_enum_value = implements_type.has_value();
+if (__jakt_enum_value) {return this->codegen_type_possibly_as_namespace(implements_type.value(),as_namespace);}else if (!__jakt_enum_value) {return this->codegen_struct_type(id,as_namespace);}VERIFY_NOT_REACHED();
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((this->codegen_enum_type(id,as_namespace))));
-};/*case end*/
+return this->codegen_enum_type(id,as_namespace);};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
 {
 ByteStringBuilder builder = ByteStringBuilder::create();
 TRY((this->codegen_generic_enum_instance(id,args,as_namespace,builder)));
-return JaktInternal::ExplicitValue<ByteString>(builder.to_string());
+return builder.to_string();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 18 /* TypeVariable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeVariable;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(name);
-};/*case end*/
+return name;};/*case end*/
 case 29 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& params = __jakt_match_value.params;
 bool const& can_throw = __jakt_match_value.can_throw;
@@ -8253,7 +7445,7 @@ builder.append(TRY((this->codegen_type(param))));
 }
 
 builder.append(StringView::from_string_literal(")>"sv));
-return JaktInternal::ExplicitValue<ByteString>(builder.to_string());
+return builder.to_string();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -8264,12 +7456,8 @@ default:{
 Jakt::utility::panic(__jakt_format(StringView::from_string_literal("Invalid type in codegen_type({})"sv),TRY((this->program->type_name(type_id,true)))));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}) + qualifiers;
+ 
+}())) + qualifiers;
 }
 }
 
@@ -8454,17 +7642,10 @@ return {};
 ErrorOr<ByteString> Jakt::codegen::CodeGenerator::codegen_namespace_qualifier(Jakt::ids::ScopeId const scope_id,bool const is_prelude,bool const skip_current,JaktInternal::Optional<ByteString> const possible_constructor_name,JaktInternal::Optional<JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>> const generic_mappings) {
 {
 ByteString output = ByteString::from_utf8_without_validation(""sv);
-JaktInternal::Optional<Jakt::ids::ScopeId> current_scope_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ids::ScopeId>,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (skip_current);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(this->program->get_scope(scope_id)->parent);
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(scope_id);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+JaktInternal::Optional<Jakt::ids::ScopeId> current_scope_id = [&]() -> JaktInternal::Optional<Jakt::ids::ScopeId> { auto __jakt_enum_value = skip_current;
+if (__jakt_enum_value) {return this->program->get_scope(scope_id)->parent;}else if (!__jakt_enum_value) {return scope_id;}VERIFY_NOT_REACHED();
+ 
+}();
 bool is_extern_import = false;
 bool first = true;
 while (current_scope_id.has_value()){
@@ -8485,20 +7666,17 @@ if (name.has_value()){
 if (is_constructor_call){
 continue;
 }
-ByteString const args = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (scope->relevant_type_id.has_value());
-if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}else if (__jakt_enum_value) {{
+ByteString const args = TRY(([&]() -> ErrorOr<ByteString> { auto __jakt_enum_value = scope->relevant_type_id.has_value();
+if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation(""sv);}else if (__jakt_enum_value) {{
 this->used_modules.add(scope->relevant_type_id.value().module);
 JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>> const parameters = this->program->get_type(scope->relevant_type_id.value())->generic_parameters(this->program);
 ByteStringBuilder builder = ByteStringBuilder::create();
-JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>> __jakt_tmp414 = parameters;
-if (__jakt_tmp414.has_value()){
-JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> const params = __jakt_tmp414.value();
-JaktInternal::Optional<JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>> __jakt_tmp413 = generic_mappings;
-if (__jakt_tmp413.has_value()){
-JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> const mappings = __jakt_tmp413.value();
+JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>> __jakt_tmp279 = parameters;
+if (__jakt_tmp279.has_value()){
+JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> const params = __jakt_tmp279.value();
+JaktInternal::Optional<JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>> __jakt_tmp278 = generic_mappings;
+if (__jakt_tmp278.has_value()){
+JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> const mappings = __jakt_tmp278.value();
 if (!params.is_empty()){
 builder.append(StringView::from_string_literal("<"sv));
 bool first = true;
@@ -8532,19 +7710,12 @@ builder.append(StringView::from_string_literal(">"sv));
 }
 }
 }
-return JaktInternal::ExplicitValue<ByteString>(builder.to_string());
+return builder.to_string();
 }
 VERIFY_NOT_REACHED();
 }VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}()));
 output = __jakt_format(StringView::from_string_literal("{}{}::{}"sv),name.value(),args,output);
 }
 }
@@ -8560,9 +7731,9 @@ return __jakt_format(StringView::from_string_literal("Jakt::{}"sv),output);
 
 Jakt::ids::TypeId Jakt::codegen::CodeGenerator::map_type(Jakt::ids::TypeId const type_id) const {
 {
-JaktInternal::Optional<JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>> __jakt_tmp415 = this->generic_inferences;
-if (__jakt_tmp415.has_value()){
-JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> const mapping = __jakt_tmp415.value();
+JaktInternal::Optional<JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>> __jakt_tmp280 = this->generic_inferences;
+if (__jakt_tmp280.has_value()){
+JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> const mapping = __jakt_tmp280.value();
 return mapping.get(type_id).value_or_lazy_evaluated([&] { return type_id; });
 }
 return type_id;
@@ -8661,9 +7832,9 @@ ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_constructor_predecl(NonnullR
 {
 Jakt::ids::TypeId const type_id = function->return_type_id;
 NonnullRefPtr<typename Jakt::types::Type> const type_ = this->program->get_type(type_id);
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp416 = type_;
-if (__jakt_tmp416->__jakt_init_index() == 23 /* Struct */){
-Jakt::ids::StructId const struct_id = __jakt_tmp416->as.Struct.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp281 = type_;
+if (__jakt_tmp281->__jakt_init_index() == 23 /* Struct */){
+Jakt::ids::StructId const struct_id = __jakt_tmp281->as.Struct.value;
 Jakt::types::CheckedStruct const structure = this->program->get_struct(struct_id);
 if (structure.record_type.__jakt_init_index() == 1 /* Class */){
 output.append(StringView::from_string_literal("protected:\n"sv));
@@ -8816,9 +7987,9 @@ ErrorOr<void> Jakt::codegen::CodeGenerator::codegen_constructor(NonnullRefPtr<Ja
 {
 Jakt::ids::TypeId const type_id = function->return_type_id;
 NonnullRefPtr<typename Jakt::types::Type> const type_ = this->program->get_type(type_id);
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp417 = type_;
-if (__jakt_tmp417->__jakt_init_index() == 23 /* Struct */){
-Jakt::ids::StructId const struct_id = __jakt_tmp417->as.Struct.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp282 = type_;
+if (__jakt_tmp282->__jakt_init_index() == 23 /* Struct */){
+Jakt::ids::StructId const struct_id = __jakt_tmp282->as.Struct.value;
 Jakt::types::CheckedStruct const structure = this->program->get_struct(struct_id);
 ByteString const qualified_name = TRY((this->codegen_type_possibly_as_namespace(type_id,true)));
 if ((!is_inline) && (!structure.generic_parameters.is_empty())){
@@ -8880,7 +8051,7 @@ self = (self + rhs);
 (parent_initializer,ByteString::from_utf8_without_validation("("sv));
 JaktInternal::DynamicArray<ByteString> strings = DynamicArray<ByteString>::create_with({});
 {
-JaktInternal::ArrayIterator<Jakt::types::CheckedParameter> _magic = function->params.operator[](JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(parent_constructor_parameter_count)}).iterator();
+JaktInternal::ArrayIterator<Jakt::types::CheckedParameter> _magic = function->params[JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(parent_constructor_parameter_count)}].iterator();
 for (;;){
 JaktInternal::Optional<Jakt::types::CheckedParameter> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
@@ -8915,7 +8086,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::types::CheckedParameter const param = function->params.operator[](i);
+Jakt::types::CheckedParameter const param = function->params[i];
 initializers.push(((param.variable->name_for_codegen().as_name_for_use() + ByteString::from_utf8_without_validation("(move(a_"sv)) + param.variable->name_for_codegen().as_name_for_use()) + ByteString::from_utf8_without_validation("))"sv));
 }
 
@@ -8978,17 +8149,10 @@ self = (self + rhs);
 if (is_inline){
 output.append(StringView::from_string_literal("static "sv));
 }
-ByteString const qualified_namespace = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (is_inline);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(qualified_name + ByteString::from_utf8_without_validation("::"sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const qualified_namespace = [&]() -> ByteString { auto __jakt_enum_value = is_inline;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation(""sv);}else if (!__jakt_enum_value) {return qualified_name + ByteString::from_utf8_without_validation("::"sv);}VERIFY_NOT_REACHED();
+ 
+}();
 output.appendff(ByteString::from_utf8_without_validation("NonnullRefPtr<{}> {}{}"sv),class_name_with_generics,qualified_namespace,structure.create_function_name.value_or_lazy_evaluated([&] { return ByteString::from_utf8_without_validation("__jakt_create"sv); }));
 output.append(StringView::from_string_literal("("sv));
 first = true;
@@ -9143,17 +8307,10 @@ if (as_method && function->is_static()){
 output.append(StringView::from_string_literal("static "sv));
 }
 if ((!(function->type.__jakt_init_index() == 2 /* Destructor */)) && (!(function->type.__jakt_init_index() == 1 /* Constructor */))){
-output.append(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (function->can_throw);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("ErrorOr<{}>"sv),TRY((this->codegen_type(function->return_type_id)))));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->codegen_type(function->return_type_id))));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+output.append(TRY(([&]() -> ErrorOr<ByteString> { auto __jakt_enum_value = function->can_throw;
+if (__jakt_enum_value) {return __jakt_format(StringView::from_string_literal("ErrorOr<{}>"sv),TRY((this->codegen_type(function->return_type_id))));}else if (!__jakt_enum_value) {return this->codegen_type(function->return_type_id);}VERIFY_NOT_REACHED();
+ 
+}())));
 }
 }
 
@@ -9162,25 +8319,18 @@ if (is_main){
 output.append(StringView::from_string_literal("main"sv));
 }
 else {
-ByteString const qualifier = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (containing_struct.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->codegen_type_possibly_as_namespace(containing_struct.value(),true))));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const qualifier = TRY(([&]() -> ErrorOr<ByteString> { auto __jakt_enum_value = containing_struct.has_value();
+if (__jakt_enum_value) {return this->codegen_type_possibly_as_namespace(containing_struct.value(),true);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation(""sv);}VERIFY_NOT_REACHED();
+ 
+}()));
 if (!qualifier.is_empty()){
 output.append(qualifier);
 output.append(StringView::from_string_literal("::"sv));
 }
 if (function->type.__jakt_init_index() == 2 /* Destructor */){
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp418 = this->program->get_type(containing_struct.value());
-if (__jakt_tmp418->__jakt_init_index() == 23 /* Struct */){
-Jakt::ids::StructId const struct_id = __jakt_tmp418->as.Struct.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp283 = this->program->get_type(containing_struct.value());
+if (__jakt_tmp283->__jakt_init_index() == 23 /* Struct */){
+Jakt::ids::StructId const struct_id = __jakt_tmp283->as.Struct.value;
 output.append(ByteString::from_utf8_without_validation("~"sv) + this->program->get_struct(struct_id).name_for_codegen().as_name_for_definition());
 }
 else {
@@ -9265,24 +8415,17 @@ output.append(StringView::from_string_literal(" const"sv));
 if (function->is_raw_constructor){
 output.append(StringView::from_string_literal(" : "sv));
 bool first = true;
-Jakt::types::CheckedStruct const struct_ = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::CheckedStruct, ErrorOr<void>>{
-auto&& __jakt_match_variant = *this->program->get_type(containing_struct.value());
+Jakt::types::CheckedStruct const struct_ = [&]() -> Jakt::types::CheckedStruct { auto&& __jakt_match_variant = *this->program->get_type(containing_struct.value());
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->program->get_struct(id));
-};/*case end*/
+return this->program->get_struct(id);};/*case end*/
 default:{
 this->compiler->panic(ByteString::from_utf8_without_validation("Expected a struct"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 if (struct_.super_struct_id.has_value()){
 Jakt::types::CheckedStruct const super_struct = this->program->get_struct(struct_.super_struct_id.value());
 output.append(super_struct.name_for_codegen().as_name_for_use());
@@ -9350,7 +8493,7 @@ output.append(StringView::from_string_literal("}\n"sv));
 return {};
 }
 
-Jakt::codegen::CodeGenerator::CodeGenerator(NonnullRefPtr<Jakt::compiler::Compiler> a_compiler, NonnullRefPtr<Jakt::types::CheckedProgram> a_program, Jakt::codegen::ControlFlowState a_control_flow_state, JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> a_entered_yieldable_blocks, ByteStringBuilder a_deferred_output, JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>> a_current_function, bool a_inside_defer, Jakt::codegen::CodegenDebugInfo a_debug_info, JaktInternal::DynamicArray<ByteString> a_namespace_stack, size_t a_fresh_var_counter, size_t a_fresh_label_counter, JaktInternal::Optional<ByteString> a_this_replacement, JaktInternal::Optional<JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>> a_generic_inferences, JaktInternal::Set<Jakt::ids::ModuleId> a_used_modules, JaktInternal::Optional<Jakt::codegen::YieldMethod> a_yield_method): compiler(move(a_compiler)), program(move(a_program)), control_flow_state(move(a_control_flow_state)), entered_yieldable_blocks(move(a_entered_yieldable_blocks)), deferred_output(move(a_deferred_output)), current_function(move(a_current_function)), inside_defer(move(a_inside_defer)), debug_info(move(a_debug_info)), namespace_stack(move(a_namespace_stack)), fresh_var_counter(move(a_fresh_var_counter)), fresh_label_counter(move(a_fresh_label_counter)), this_replacement(move(a_this_replacement)), generic_inferences(move(a_generic_inferences)), used_modules(move(a_used_modules)), yield_method(move(a_yield_method)){}
+Jakt::codegen::CodeGenerator::CodeGenerator(NonnullRefPtr<Jakt::compiler::Compiler> a_compiler, NonnullRefPtr<Jakt::types::CheckedProgram> a_program, Jakt::codegen::ControlFlowState a_control_flow_state, JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> a_entered_yieldable_blocks, ByteStringBuilder a_deferred_output, JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>> a_current_function, bool a_inside_defer, Jakt::codegen::CodegenDebugInfo a_debug_info, JaktInternal::DynamicArray<ByteString> a_namespace_stack, size_t a_fresh_var_counter, size_t a_fresh_label_counter, JaktInternal::Optional<ByteString> a_this_replacement, JaktInternal::Optional<JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>> a_generic_inferences, JaktInternal::Set<Jakt::ids::ModuleId> a_used_modules, JaktInternal::Optional<Jakt::codegen::YieldMethod> a_yield_method, bool a_yields_erroror): compiler(move(a_compiler)), program(move(a_program)), control_flow_state(move(a_control_flow_state)), entered_yieldable_blocks(move(a_entered_yieldable_blocks)), deferred_output(move(a_deferred_output)), current_function(move(a_current_function)), inside_defer(move(a_inside_defer)), debug_info(move(a_debug_info)), namespace_stack(move(a_namespace_stack)), fresh_var_counter(move(a_fresh_var_counter)), fresh_label_counter(move(a_fresh_label_counter)), this_replacement(move(a_this_replacement)), generic_inferences(move(a_generic_inferences)), used_modules(move(a_used_modules)), yield_method(move(a_yield_method)), yields_erroror(move(a_yields_erroror)){}
 
 ByteString Jakt::codegen::AllowedControlExits::debug_description() const {
 auto builder = ByteStringBuilder::create();
@@ -9468,19 +8611,10 @@ case 2 /* AtLoop */:break;
 }
 Jakt::codegen::AllowedControlExits Jakt::codegen::AllowedControlExits::allow_return() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::codegen::AllowedControlExits, Jakt::codegen::AllowedControlExits>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Nothing */:case 1 /* JustReturn */:return JaktInternal::ExplicitValue(Jakt::codegen::AllowedControlExits::JustReturn());
-case 2 /* AtLoop */:return JaktInternal::ExplicitValue(Jakt::codegen::AllowedControlExits::AtLoop());
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 0 /* Nothing */:case 1 /* JustReturn */:return Jakt::codegen::AllowedControlExits::JustReturn();case 2 /* AtLoop */:return Jakt::codegen::AllowedControlExits::AtLoop();default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
@@ -9510,6 +8644,9 @@ builder.appendff("label: \"{}\"", that.label);
 }
 builder.append(")"sv);
 break;}
+case 2 /* Return */: {
+return ByteString("YieldMethod::Return"sv);
+break;}
 }
 return builder.to_string();
 }
@@ -9526,6 +8663,11 @@ new (&__jakt_uninit_enum.as.AssignAndGoto.name) (decltype(name))(move(name));
 new (&__jakt_uninit_enum.as.AssignAndGoto.label) (decltype(label))(move(label));
 return __jakt_uninit_enum;
 }
+[[nodiscard]] YieldMethod YieldMethod::Return(){
+YieldMethod __jakt_uninit_enum;
+__jakt_uninit_enum.__jakt_variant_index = 3;
+return __jakt_uninit_enum;
+}
 YieldMethod& YieldMethod::operator=(YieldMethod const &rhs){
 {VERIFY(this->__jakt_variant_index != 0 && rhs.__jakt_variant_index != 0);
 if (this->__jakt_variant_index != rhs.__jakt_variant_index) {
@@ -9538,6 +8680,8 @@ case 1 /* AssignAndGoto */:
 new (&this->as.AssignAndGoto.name) (decltype(this->as.AssignAndGoto.name))(rhs.as.AssignAndGoto.name);
 new (&this->as.AssignAndGoto.label) (decltype(this->as.AssignAndGoto.label))(rhs.as.AssignAndGoto.label);
 break;
+case 2 /* Return */:
+break;
 }
 } else {
 switch (rhs.__jakt_init_index()) {
@@ -9547,6 +8691,8 @@ break;
 case 1 /* AssignAndGoto */:
 this->as.AssignAndGoto.name = rhs.as.AssignAndGoto.name;
 this->as.AssignAndGoto.label = rhs.as.AssignAndGoto.label;
+break;
+case 2 /* Return */:
 break;
 }
 }
@@ -9563,6 +8709,8 @@ case 1 /* AssignAndGoto */:
 new (&this->as.AssignAndGoto.name) (decltype(this->as.AssignAndGoto.name))(rhs.as.AssignAndGoto.name);
 new (&this->as.AssignAndGoto.label) (decltype(this->as.AssignAndGoto.label))(rhs.as.AssignAndGoto.label);
 break;
+case 2 /* Return */:
+break;
 }
 this->__jakt_variant_index = rhs.__jakt_variant_index;
 }
@@ -9578,6 +8726,8 @@ case 1 /* AssignAndGoto */:
 new (&this->as.AssignAndGoto.name) (decltype(this->as.AssignAndGoto.name))(move(rhs.as.AssignAndGoto.name));
 new (&this->as.AssignAndGoto.label) (decltype(this->as.AssignAndGoto.label))(move(rhs.as.AssignAndGoto.label));
 break;
+case 2 /* Return */:
+break;
 }
 } else {
 switch (rhs.__jakt_init_index()) {
@@ -9587,6 +8737,8 @@ break;
 case 1 /* AssignAndGoto */:
 this->as.AssignAndGoto.name = move(rhs.as.AssignAndGoto.name);
 this->as.AssignAndGoto.label = move(rhs.as.AssignAndGoto.label);
+break;
+case 2 /* Return */:
 break;
 }
 }
@@ -9604,6 +8756,8 @@ case 1 /* AssignAndGoto */:
 new (&this->as.AssignAndGoto.name) (decltype(this->as.AssignAndGoto.name))(move(rhs.as.AssignAndGoto.name));
 new (&this->as.AssignAndGoto.label) (decltype(this->as.AssignAndGoto.label))(move(rhs.as.AssignAndGoto.label));
 break;
+case 2 /* Return */:
+break;
 }
 this->__jakt_variant_index = rhs.__jakt_variant_index;
 }
@@ -9617,6 +8771,7 @@ break;
 case 1 /* AssignAndGoto */:this->as.AssignAndGoto.name.~ByteString();
 this->as.AssignAndGoto.label.~ByteString();
 break;
+case 2 /* Return */:break;
 }
 }
 }

--- a/bootstrap/stage0/codegen.h
+++ b/bootstrap/stage0/codegen.h
@@ -31,6 +31,20 @@ bool case_has_bindings(Jakt::types::CheckedMatchCase const& match_case);
 
 size_t count_match_cases(JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const& cases);
 
+bool has_cpp_value(Jakt::ids::TypeId const type_id);
+
+bool has_control_flow(Jakt::types::CheckedMatchCase const match_case, bool const include_loop_control_flow);
+
+bool has_control_flow(Jakt::types::CheckedBlock const block, bool const include_loop_control_flow);
+
+bool has_control_flow(NonnullRefPtr<typename Jakt::types::CheckedStatement> const stmt, bool const include_loop_control_flow);
+
+bool has_control_flow(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr, bool const include_loop_control_flow);
+
+bool has_control_flow(JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const dict_pair, bool const include_loop_control_flow);
+
+bool has_control_flow(JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const call_arg, bool const include_loop_control_flow);
+
 }
 namespace codegen {
 struct AllowedControlExits {
@@ -94,6 +108,7 @@ constexpr VariantData() {}
 constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ByteString debug_description() const;
 [[nodiscard]] static YieldMethod ReturnExplicitValue(ByteString ctor);
 [[nodiscard]] static YieldMethod AssignAndGoto(ByteString name, ByteString label);
+[[nodiscard]] static YieldMethod Return();
 ~YieldMethod();
 YieldMethod& operator=(YieldMethod const &);
 YieldMethod& operator=(YieldMethod &&);
@@ -106,7 +121,7 @@ YieldMethod() {};
 };
 struct CodeGenerator {
   public:
-public: NonnullRefPtr<Jakt::compiler::Compiler> compiler;public: NonnullRefPtr<Jakt::types::CheckedProgram> program;public: Jakt::codegen::ControlFlowState control_flow_state;public: JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> entered_yieldable_blocks;public: ByteStringBuilder deferred_output;public: JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>> current_function;public: bool inside_defer;public: Jakt::codegen::CodegenDebugInfo debug_info;public: JaktInternal::DynamicArray<ByteString> namespace_stack;public: size_t fresh_var_counter;public: size_t fresh_label_counter;public: JaktInternal::Optional<ByteString> this_replacement;public: JaktInternal::Optional<JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>> generic_inferences;public: JaktInternal::Set<Jakt::ids::ModuleId> used_modules;public: JaktInternal::Optional<Jakt::codegen::YieldMethod> yield_method;public: ByteString current_error_handler(bool const forward_error_with_try) const;
+public: NonnullRefPtr<Jakt::compiler::Compiler> compiler;public: NonnullRefPtr<Jakt::types::CheckedProgram> program;public: Jakt::codegen::ControlFlowState control_flow_state;public: JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> entered_yieldable_blocks;public: ByteStringBuilder deferred_output;public: JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>> current_function;public: bool inside_defer;public: Jakt::codegen::CodegenDebugInfo debug_info;public: JaktInternal::DynamicArray<ByteString> namespace_stack;public: size_t fresh_var_counter;public: size_t fresh_label_counter;public: JaktInternal::Optional<ByteString> this_replacement;public: JaktInternal::Optional<JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>> generic_inferences;public: JaktInternal::Set<Jakt::ids::ModuleId> used_modules;public: JaktInternal::Optional<Jakt::codegen::YieldMethod> yield_method;public: bool yields_erroror;public: ByteString current_error_handler(bool const forward_error_with_try);
 public: ByteString fresh_var();
 public: ByteString fresh_label();
 public: JaktInternal::DynamicArray<Jakt::ids::ModuleId> topologically_sort_modules() const;
@@ -152,10 +167,15 @@ public: ErrorOr<void> codegen_expression(NonnullRefPtr<typename Jakt::types::Che
 public: bool expr_codegens_to_this_pointer(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr) const;
 public: ErrorOr<void> codegen_prefix_unary(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr, StringView const cpp_operator, ByteStringBuilder& output, bool const syntactically_self_contained);
 public: ErrorOr<void> codegen_postfix_unary(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr, StringView const cpp_operator, ByteStringBuilder& output, bool const syntactically_self_contained);
-public: ErrorOr<void> codegen_match(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr, JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const match_cases, Jakt::ids::TypeId const type_id, bool const all_variants_constant, ByteStringBuilder& output);
-public: ErrorOr<void> codegen_generic_match(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr, JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const cases, Jakt::ids::TypeId const return_type_id, ByteString const cpp_match_result_type, bool const all_variants_constant, ByteStringBuilder& output);
+public: ErrorOr<void> codegen_match(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr, JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const match_cases, Jakt::ids::TypeId const type_id, bool const all_variants_constant, bool const forward_error_with_try, ByteStringBuilder& output);
+public: ErrorOr<void> codegen_value_match(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr, JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const match_cases, Jakt::ids::TypeId const type_id, bool const forward_error_with_try, ByteStringBuilder& output);
+public: ErrorOr<void> codegen_inner_match(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr, JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const match_cases, Jakt::ids::TypeId const type_id, ByteStringBuilder& output);
+public: ErrorOr<void> codegen_void_match(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr, JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const match_cases, Jakt::ids::TypeId const type_id, ByteStringBuilder& output);
+public: ErrorOr<void> codegen_returned_match(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr, JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const match_cases, Jakt::ids::TypeId const type_id, ByteStringBuilder& output);
+public: ErrorOr<void> codegen_generic_match(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr, JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const cases, Jakt::ids::TypeId const return_type_id, ByteStringBuilder& output);
 public: ErrorOr<void> codegen_generic_pattern_condition(Jakt::types::CheckedMatchPattern const& pattern, bool const is_parenthesized, ByteStringBuilder& output);
-public: ErrorOr<void> codegen_enum_match(Jakt::types::CheckedEnum const enum_, NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr, JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const match_cases, Jakt::ids::TypeId const type_id, ByteString const cpp_match_result_type, bool const all_variants_constant, ByteStringBuilder& output);
+public: ErrorOr<void> codegen_enum_match(Jakt::types::CheckedEnum const enum_, NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr, JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const match_cases, Jakt::ids::TypeId const type_id, ByteStringBuilder& output);
+public: ErrorOr<void> declare_pattern_defaults(JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& defaults, JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> const& variables, ByteStringBuilder& output);
 public: ErrorOr<void> codegen_match_body(Jakt::types::CheckedMatchBody const body, Jakt::ids::TypeId const return_type_id, ByteStringBuilder& output);
 public: ErrorOr<ByteString> codegen_function_return_type(NonnullRefPtr<Jakt::types::CheckedFunction> const function);
 public: ErrorOr<void> codegen_binary_expression(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expression, Jakt::ids::TypeId const type_id, NonnullRefPtr<typename Jakt::types::CheckedExpression> const lhs, NonnullRefPtr<typename Jakt::types::CheckedExpression> const rhs, Jakt::types::CheckedBinaryOperator const op, ByteStringBuilder& output, bool const forward_error_with_try, bool const syntactically_self_contained);
@@ -169,7 +189,11 @@ public: ErrorOr<void> codegen_call(Jakt::types::CheckedCall const call, ByteStri
 public: ErrorOr<void> codegen_call_unwrapped(Jakt::types::CheckedCall const call, ByteStringBuilder& output);
 public: ErrorOr<ByteString> codegen_namespace_path(Jakt::types::CheckedCall const call);
 public: ErrorOr<void> codegen_block(Jakt::types::CheckedBlock const block, ByteStringBuilder& output);
+public: StringView break_statement() const;
 public: ErrorOr<void> codegen_statement(NonnullRefPtr<typename Jakt::types::CheckedStatement> const statement, ByteStringBuilder& output);
+public: ErrorOr<void> codegen_var_decl(Jakt::ids::VarId const var_id, NonnullRefPtr<typename Jakt::types::CheckedExpression> const init, ByteStringBuilder& output);
+public: ErrorOr<void> codegen_return(JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const val, ByteStringBuilder& output);
+public: ErrorOr<void> codegen_value_return(NonnullRefPtr<typename Jakt::types::CheckedExpression> const val, ByteStringBuilder& output);
 public: ErrorOr<ByteString> codegen_type(Jakt::ids::TypeId const type_id);
 public: ErrorOr<ByteString> codegen_type_possibly_as_namespace(Jakt::ids::TypeId const type_id, bool const as_namespace);
 public: ErrorOr<ByteString> codegen_generic_type_instance(Jakt::ids::StructId const id, JaktInternal::DynamicArray<Jakt::ids::TypeId> const args, bool const as_namespace);
@@ -185,10 +209,14 @@ public: ErrorOr<void> codegen_constructor_predecl(NonnullRefPtr<Jakt::types::Che
 public: ErrorOr<void> codegen_constructor(NonnullRefPtr<Jakt::types::CheckedFunction> const function, bool const is_inline, ByteStringBuilder& output);
 public: ErrorOr<void> codegen_function_in_namespace(NonnullRefPtr<Jakt::types::CheckedFunction> const function, JaktInternal::Optional<Jakt::ids::TypeId> const containing_struct, bool const as_method, bool const skip_template, JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::ids::TypeId>> const explicit_generic_instantiation, ByteStringBuilder& output);
 public: ErrorOr<void> codegen_lambda_block(bool const can_throw, Jakt::types::CheckedBlock const block, Jakt::ids::TypeId const return_type_id, ByteStringBuilder& output);
-public: CodeGenerator(NonnullRefPtr<Jakt::compiler::Compiler> a_compiler, NonnullRefPtr<Jakt::types::CheckedProgram> a_program, Jakt::codegen::ControlFlowState a_control_flow_state, JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> a_entered_yieldable_blocks, ByteStringBuilder a_deferred_output, JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>> a_current_function, bool a_inside_defer, Jakt::codegen::CodegenDebugInfo a_debug_info, JaktInternal::DynamicArray<ByteString> a_namespace_stack, size_t a_fresh_var_counter, size_t a_fresh_label_counter, JaktInternal::Optional<ByteString> a_this_replacement, JaktInternal::Optional<JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>> a_generic_inferences, JaktInternal::Set<Jakt::ids::ModuleId> a_used_modules, JaktInternal::Optional<Jakt::codegen::YieldMethod> a_yield_method);
+public: CodeGenerator(NonnullRefPtr<Jakt::compiler::Compiler> a_compiler, NonnullRefPtr<Jakt::types::CheckedProgram> a_program, Jakt::codegen::ControlFlowState a_control_flow_state, JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> a_entered_yieldable_blocks, ByteStringBuilder a_deferred_output, JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedFunction>> a_current_function, bool a_inside_defer, Jakt::codegen::CodegenDebugInfo a_debug_info, JaktInternal::DynamicArray<ByteString> a_namespace_stack, size_t a_fresh_var_counter, size_t a_fresh_label_counter, JaktInternal::Optional<ByteString> a_this_replacement, JaktInternal::Optional<JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>> a_generic_inferences, JaktInternal::Set<Jakt::ids::ModuleId> a_used_modules, JaktInternal::Optional<Jakt::codegen::YieldMethod> a_yield_method, bool a_yields_erroror);
 
 public: ByteString debug_description() const;
-};}
+};template <typename T>
+bool has_control_flow(JaktInternal::DynamicArray<T> const any_of, bool const include_loop_control_flow);
+template <typename T>
+bool has_control_flow(JaktInternal::Optional<T> const maybe_v, bool const include_loop_control_flow);
+}
 } // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::codegen::AllowedControlExits> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::codegen::AllowedControlExits const& value) {

--- a/bootstrap/stage0/codegen_specializations.cpp
+++ b/bootstrap/stage0/codegen_specializations.cpp
@@ -1,0 +1,162 @@
+#include "codegen.h"
+namespace Jakt {
+namespace codegen {
+
+/* specialisation 0 of function has_control_flow: ["Jakt::types::CheckedMatchCase"] */
+template<> bool has_control_flow<Jakt::types::CheckedMatchCase>(JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const any_of,bool const include_loop_control_flow);
+
+/* specialisation 1 of function has_control_flow: ["NonnullRefPtr<typename Jakt::types::CheckedStatement>"] */
+template<> bool has_control_flow<NonnullRefPtr<typename Jakt::types::CheckedStatement>>(JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const any_of,bool const include_loop_control_flow);
+
+/* specialisation 0 of function has_control_flow: ["NonnullRefPtr<typename Jakt::types::CheckedStatement>"] */
+template<> bool has_control_flow<NonnullRefPtr<typename Jakt::types::CheckedStatement>>(JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const maybe_v,bool const include_loop_control_flow);
+
+/* specialisation 2 of function has_control_flow: ["NonnullRefPtr<typename Jakt::types::CheckedExpression>"] */
+template<> bool has_control_flow<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const any_of,bool const include_loop_control_flow);
+
+/* specialisation 1 of function has_control_flow: ["NonnullRefPtr<typename Jakt::types::CheckedExpression>"] */
+template<> bool has_control_flow<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const maybe_v,bool const include_loop_control_flow);
+
+/* specialisation 3 of function has_control_flow: ["JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>"] */
+template<> bool has_control_flow<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>(JaktInternal::DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>> const any_of,bool const include_loop_control_flow);
+
+/* specialisation 4 of function has_control_flow: ["JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>"] */
+template<> bool has_control_flow<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>(JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>> const any_of,bool const include_loop_control_flow);
+
+/* specialisation 2 of function has_control_flow: ["Jakt::types::CheckedBlock"] */
+template<> bool has_control_flow<Jakt::types::CheckedBlock>(JaktInternal::Optional<Jakt::types::CheckedBlock> const maybe_v,bool const include_loop_control_flow);
+template<>
+bool has_control_flow<Jakt::types::CheckedMatchCase>(JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> const any_of,bool const include_loop_control_flow) {
+{
+{
+JaktInternal::ArrayIterator<Jakt::types::CheckedMatchCase> _magic = any_of.iterator();
+for (;;){
+JaktInternal::Optional<Jakt::types::CheckedMatchCase> const _magic_value = _magic.next();
+if (!_magic_value.has_value()){
+break;
+}
+Jakt::types::CheckedMatchCase t = _magic_value.value();
+{
+if (Jakt::codegen::has_control_flow(t,include_loop_control_flow)){
+return true;
+}
+}
+
+}
+}
+
+return false;
+}
+}
+template<>
+bool has_control_flow<NonnullRefPtr<typename Jakt::types::CheckedStatement>>(JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const any_of,bool const include_loop_control_flow) {
+{
+{
+JaktInternal::ArrayIterator<NonnullRefPtr<typename Jakt::types::CheckedStatement>> _magic = any_of.iterator();
+for (;;){
+JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const _magic_value = _magic.next();
+if (!_magic_value.has_value()){
+break;
+}
+NonnullRefPtr<typename Jakt::types::CheckedStatement> t = _magic_value.value();
+{
+if (Jakt::codegen::has_control_flow(t,include_loop_control_flow)){
+return true;
+}
+}
+
+}
+}
+
+return false;
+}
+}
+template<>
+bool has_control_flow<NonnullRefPtr<typename Jakt::types::CheckedStatement>>(JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const maybe_v,bool const include_loop_control_flow) {
+{
+return maybe_v.has_value() && Jakt::codegen::has_control_flow(maybe_v.value(),include_loop_control_flow);
+}
+}
+template<>
+bool has_control_flow<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const any_of,bool const include_loop_control_flow) {
+{
+{
+JaktInternal::ArrayIterator<NonnullRefPtr<typename Jakt::types::CheckedExpression>> _magic = any_of.iterator();
+for (;;){
+JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const _magic_value = _magic.next();
+if (!_magic_value.has_value()){
+break;
+}
+NonnullRefPtr<typename Jakt::types::CheckedExpression> t = _magic_value.value();
+{
+if (Jakt::codegen::has_control_flow(t,include_loop_control_flow)){
+return true;
+}
+}
+
+}
+}
+
+return false;
+}
+}
+template<>
+bool has_control_flow<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const maybe_v,bool const include_loop_control_flow) {
+{
+return maybe_v.has_value() && Jakt::codegen::has_control_flow(maybe_v.value(),include_loop_control_flow);
+}
+}
+template<>
+bool has_control_flow<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>(JaktInternal::DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>> const any_of,bool const include_loop_control_flow) {
+{
+{
+JaktInternal::ArrayIterator<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>> _magic = any_of.iterator();
+for (;;){
+JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>> const _magic_value = _magic.next();
+if (!_magic_value.has_value()){
+break;
+}
+JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,NonnullRefPtr<typename Jakt::types::CheckedExpression>> t = _magic_value.value();
+{
+if (Jakt::codegen::has_control_flow(t,include_loop_control_flow)){
+return true;
+}
+}
+
+}
+}
+
+return false;
+}
+}
+template<>
+bool has_control_flow<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>(JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>> const any_of,bool const include_loop_control_flow) {
+{
+{
+JaktInternal::ArrayIterator<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>> _magic = any_of.iterator();
+for (;;){
+JaktInternal::Optional<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>> const _magic_value = _magic.next();
+if (!_magic_value.has_value()){
+break;
+}
+JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> t = _magic_value.value();
+{
+if (Jakt::codegen::has_control_flow(t,include_loop_control_flow)){
+return true;
+}
+}
+
+}
+}
+
+return false;
+}
+}
+template<>
+bool has_control_flow<Jakt::types::CheckedBlock>(JaktInternal::Optional<Jakt::types::CheckedBlock> const maybe_v,bool const include_loop_control_flow) {
+{
+return maybe_v.has_value() && Jakt::codegen::has_control_flow(maybe_v.value(),include_loop_control_flow);
+}
+}
+}
+} // namespace Jakt

--- a/bootstrap/stage0/compiler.cpp
+++ b/bootstrap/stage0/compiler.cpp
@@ -128,7 +128,7 @@ JaktInternal::Optional<Jakt::jakt__path::Path> Jakt::compiler::Compiler::get_fil
 if (file_id.id >= this->files.size()){
 return JaktInternal::OptionalNone();
 }
-return this->files.operator[](file_id.id);
+return this->files[file_id.id];
 }
 }
 
@@ -141,7 +141,7 @@ return this->current_file;
 JaktInternal::Optional<Jakt::jakt__path::Path> Jakt::compiler::Compiler::current_file_path() const {
 {
 if (this->current_file.has_value()){
-return this->files.operator[](this->current_file.value().id);
+return this->files[this->current_file.value().id];
 }
 return JaktInternal::OptionalNone();
 }
@@ -171,7 +171,7 @@ JaktInternal::Optional<Jakt::utility::FileId> const old_file_id = this->current_
 this->current_file = file_id;
 auto __jakt_var_3 = [&]() -> ErrorOr<void> {
 {
-NonnullRefPtr<File> file = TRY((File::open_for_reading(this->files.operator[](file_id.id).to_string())));
+NonnullRefPtr<File> file = TRY((File::open_for_reading(this->files[file_id.id].to_string())));
 this->current_file_contents = TRY((file->read_all()));
 }
 
@@ -179,23 +179,11 @@ this->current_file_contents = TRY((file->read_all()));
 return ErrorOr<void> {};}();
 if (__jakt_var_3.is_error()) {auto error = __jakt_var_3.release_error();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<bool>> {
-auto __jakt_enum_value = (error.code());
-if (__jakt_enum_value == ErrNOENT) {return ({warnln(StringView::from_string_literal("\u001b[31;1mError\u001b[0m Could not access {}: File not found"sv),this->files.operator[](file_id.id));}), JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ErrACCES) {return ({warnln(StringView::from_string_literal("\u001b[31;1mError\u001b[0m Could not access {}: Permission denied"sv),this->files.operator[](file_id.id));}), JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ErrFBIG) {return ({warnln(StringView::from_string_literal("\u001b[31;1mError\u001b[0m Could not access {}: File too big"sv),this->files.operator[](file_id.id));}), JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ErrNAMETOOLONG) {return ({warnln(StringView::from_string_literal("\u001b[31;1mError\u001b[0m Could not access {}: Name too long"sv),this->files.operator[](file_id.id));}), JaktInternal::ExplicitValue<void>();
-}else {{
+{auto __jakt_enum_value = error.code();
+if (__jakt_enum_value == ErrNOENT) {warnln(StringView::from_string_literal("\u001b[31;1mError\u001b[0m Could not access {}: File not found"sv),this->files[file_id.id]);goto __jakt_label_4;}else if (__jakt_enum_value == ErrACCES) {warnln(StringView::from_string_literal("\u001b[31;1mError\u001b[0m Could not access {}: Permission denied"sv),this->files[file_id.id]);goto __jakt_label_4;}else if (__jakt_enum_value == ErrFBIG) {warnln(StringView::from_string_literal("\u001b[31;1mError\u001b[0m Could not access {}: File too big"sv),this->files[file_id.id]);goto __jakt_label_4;}else if (__jakt_enum_value == ErrNAMETOOLONG) {warnln(StringView::from_string_literal("\u001b[31;1mError\u001b[0m Could not access {}: Name too long"sv),this->files[file_id.id]);goto __jakt_label_4;}else {{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Incurred unrecognized error while trying to open file"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_4;}}goto __jakt_label_4; __jakt_label_4:;;
 this->current_file = old_file_id;
 return false;
 }
@@ -274,17 +262,10 @@ return this->find_in_search_paths(Jakt::jakt__path::Path::from_string(module_nam
 
 ErrorOr<JaktInternal::Optional<Jakt::jakt__path::Path>> Jakt::compiler::Compiler::find_in_search_paths(Jakt::jakt__path::Path const path,bool const relative_import,size_t const parent_path_count) const {
 {
-JaktInternal::Optional<Jakt::jakt__path::Path> const current_file_path = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::jakt__path::Path>,ErrorOr<JaktInternal::Optional<Jakt::jakt__path::Path>>> {
-auto __jakt_enum_value = (relative_import);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(this->current_file_path());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(this->assume_main_file_path.value_or_lazy_evaluated_optional([&] { return this->current_file_path(); }));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+JaktInternal::Optional<Jakt::jakt__path::Path> const current_file_path = [&]() -> JaktInternal::Optional<Jakt::jakt__path::Path> { auto __jakt_enum_value = relative_import;
+if (__jakt_enum_value) {return this->current_file_path();}else if (!__jakt_enum_value) {return this->assume_main_file_path.value_or_lazy_evaluated_optional([&] { return this->current_file_path(); });}VERIFY_NOT_REACHED();
+ 
+}();
 if (current_file_path.has_value()){
 Jakt::jakt__path::Path candidate_path = TRY((current_file_path.value().absolute())).parent();
 if (relative_import && (parent_path_count > static_cast<size_t>(0ULL))){

--- a/bootstrap/stage0/error.cpp
+++ b/bootstrap/stage0/error.cpp
@@ -8,9 +8,7 @@ namespace Jakt {
 namespace error {
 void print_error_json(ByteString const file_name,Jakt::error::JaktError const error) {
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, void>{
-auto&& __jakt_match_variant = error;
+{auto&& __jakt_match_variant = error;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Message */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Message;ByteString const& message = __jakt_match_value.message;
@@ -18,8 +16,7 @@ Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 Jakt::error::display_message_with_span_json(Jakt::error::MessageSeverity::Error(),file_name,message,span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_2;};/*case end*/
 case 1 /* MessageWithHint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MessageWithHint;ByteString const& message = __jakt_match_value.message;
 Jakt::utility::Span const& span = __jakt_match_value.span;
@@ -29,23 +26,15 @@ Jakt::utility::Span const& hint_span = __jakt_match_value.hint_span;
 Jakt::error::display_message_with_span_json(Jakt::error::MessageSeverity::Error(),file_name,message,span);
 Jakt::error::display_message_with_span_json(Jakt::error::MessageSeverity::Hint(),file_name,hint,hint_span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_2;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}goto __jakt_label_2; __jakt_label_2:;;
 }
 }
 
 ErrorOr<void> print_error(ByteString const file_name,JaktInternal::Optional<JaktInternal::DynamicArray<u8>> const file_contents,Jakt::error::JaktError const error) {
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = error;
+{auto&& __jakt_match_variant = error;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Message */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Message;ByteString const& message = __jakt_match_value.message;
@@ -53,8 +42,7 @@ Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 Jakt::error::display_message_with_span(Jakt::error::MessageSeverity::Error(),file_name,file_contents,message,span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_3;};/*case end*/
 case 1 /* MessageWithHint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MessageWithHint;ByteString const& message = __jakt_match_value.message;
 Jakt::utility::Span const& span = __jakt_match_value.span;
@@ -64,15 +52,9 @@ Jakt::utility::Span const& hint_span = __jakt_match_value.hint_span;
 Jakt::error::display_message_with_span(Jakt::error::MessageSeverity::Error(),file_name,file_contents,message,span);
 Jakt::error::display_message_with_span(Jakt::error::MessageSeverity::Hint(),file_name,file_contents,hint,hint_span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_3;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}goto __jakt_label_3; __jakt_label_3:;;
 }
 return {};
 }
@@ -95,17 +77,17 @@ size_t line_index = static_cast<size_t>(0ULL);
 size_t error_start_index = static_cast<size_t>(0ULL);
 size_t largest_line_number = static_cast<size_t>(0ULL);
 while (line_index < line_spans.size()){
-if ((span.start >= line_spans.operator[](line_index).template get<0>()) && (span.start <= line_spans.operator[](line_index).template get<1>())){
+if ((span.start >= line_spans[line_index].template get<0>()) && (span.start <= line_spans[line_index].template get<1>())){
 error_start_index = line_index;
 }
-if ((span.end >= line_spans.operator[](line_index).template get<0>()) && (span.end <= line_spans.operator[](line_index).template get<1>())){
+if ((span.end >= line_spans[line_index].template get<0>()) && (span.end <= line_spans[line_index].template get<1>())){
 largest_line_number = JaktInternal::checked_add(line_index,static_cast<size_t>(2ULL));
 }
 ++line_index;
 }
 size_t const width = __jakt_format(StringView::from_string_literal("{}"sv),largest_line_number).length();
 line_index = error_start_index;
-size_t const column_index = JaktInternal::checked_sub(span.start,line_spans.operator[](line_index).template get<0>());
+size_t const column_index = JaktInternal::checked_sub(span.start,line_spans[line_index].template get<0>());
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(JaktInternal::checked_add(width,static_cast<size_t>(2ULL)))};
 for (;;){
@@ -123,12 +105,12 @@ warn(StringView::from_string_literal("─"sv));
 
 warnln(StringView::from_string_literal("┬─ \u001b[33m{}:{}:{}\u001b[0m"sv),file_name,JaktInternal::checked_add(line_index,static_cast<size_t>(1ULL)),JaktInternal::checked_add(column_index,static_cast<size_t>(1ULL)));
 if (line_index > static_cast<size_t>(0ULL)){
-Jakt::error::print_source_line(severity,file_contents,line_spans.operator[](JaktInternal::checked_sub(line_index,static_cast<size_t>(1ULL))),span,line_index,largest_line_number);
+Jakt::error::print_source_line(severity,file_contents,line_spans[JaktInternal::checked_sub(line_index,static_cast<size_t>(1ULL))],span,line_index,largest_line_number);
 }
-while ((line_index < line_spans.size()) && (span.end > line_spans.operator[](line_index).template get<0>())){
-Jakt::error::print_source_line(severity,file_contents,line_spans.operator[](line_index),span,JaktInternal::checked_add(line_index,static_cast<size_t>(1ULL)),largest_line_number);
-if (span.end <= line_spans.operator[](line_index).template get<1>()){
-Jakt::error::print_underline(severity,width,line_spans.operator[](line_index),span,JaktInternal::checked_add(line_index,static_cast<size_t>(1ULL)),largest_line_number);
+while ((line_index < line_spans.size()) && (span.end > line_spans[line_index].template get<0>())){
+Jakt::error::print_source_line(severity,file_contents,line_spans[line_index],span,JaktInternal::checked_add(line_index,static_cast<size_t>(1ULL)),largest_line_number);
+if (span.end <= line_spans[line_index].template get<1>()){
+Jakt::error::print_underline(severity,width,line_spans[line_index],span,JaktInternal::checked_add(line_index,static_cast<size_t>(1ULL)),largest_line_number);
 break;
 }
 ++line_index;
@@ -150,7 +132,7 @@ warn(StringView::from_string_literal(" "sv));
 
 warn(StringView::from_string_literal("│"sv));
 {
-JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(JaktInternal::checked_sub(span.end,line_spans.operator[](line_index).template get<0>()))};
+JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(JaktInternal::checked_sub(span.end,line_spans[line_index].template get<0>()))};
 for (;;){
 JaktInternal::Optional<size_t> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
@@ -167,7 +149,7 @@ warn(StringView::from_string_literal(" "sv));
 warnln(StringView::from_string_literal("\u001b[{}m╰─ {}\u001b[0m"sv),severity.ansi_color_code(),message);
 ++line_index;
 if (line_index < line_spans.size()){
-Jakt::error::print_source_line(severity,file_contents,line_spans.operator[](line_index),span,JaktInternal::checked_add(line_index,static_cast<size_t>(1ULL)),largest_line_number);
+Jakt::error::print_source_line(severity,file_contents,line_spans[line_index],span,JaktInternal::checked_add(line_index,static_cast<size_t>(1ULL)),largest_line_number);
 }
 warn(StringView::from_string_literal("\u001b[0m"sv));
 {
@@ -216,7 +198,7 @@ ByteStringBuilder builder = ByteStringBuilder::create();
 for (;;){
 u8 c = static_cast<u8>(u8' ');
 if (index < file_span.template get<1>()){
-c = file_contents.operator[](index);
+c = file_contents[index];
 }
 else if ((error_span.start == error_span.end) && (index == error_span.start)){
 c = static_cast<u8>(u8'_');
@@ -296,7 +278,7 @@ size_t idx = static_cast<size_t>(0ULL);
 JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,size_t>> output = DynamicArray<JaktInternal::Tuple<size_t,size_t>>::create_with({});
 size_t start = idx;
 while (idx < file_contents.size()){
-if (file_contents.operator[](idx) == static_cast<u8>(u8'\n')){
+if (file_contents[idx] == static_cast<u8>(u8'\n')){
 output.push(Tuple{start, idx});
 start = JaktInternal::checked_add(idx,static_cast<size_t>(1ULL));
 }
@@ -476,49 +458,31 @@ break;
 }
 Jakt::utility::Span Jakt::error::JaktError::span() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::utility::Span, Jakt::utility::Span>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Message */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Message;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 1 /* MessageWithHint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MessageWithHint;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 ByteString Jakt::error::JaktError::message() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ByteString>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Message */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Message;ByteString const& message = __jakt_match_value.message;
-return JaktInternal::ExplicitValue(message);
-};/*case end*/
+return message;};/*case end*/
 case 1 /* MessageWithHint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MessageWithHint;ByteString const& message = __jakt_match_value.message;
-return JaktInternal::ExplicitValue(message);
-};/*case end*/
+return message;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -617,37 +581,19 @@ case 1 /* Error */:break;
 }
 ByteString Jakt::error::MessageSeverity::name() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ByteString>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Hint */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Hint"sv));
-case 1 /* Error */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Error"sv));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 0 /* Hint */:return ByteString::from_utf8_without_validation("Hint"sv);case 1 /* Error */:return ByteString::from_utf8_without_validation("Error"sv);default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
 ByteString Jakt::error::MessageSeverity::ansi_color_code() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ByteString>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Hint */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("94"sv));
-case 1 /* Error */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("31"sv));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 0 /* Hint */:return ByteString::from_utf8_without_validation("94"sv);case 1 /* Error */:return ByteString::from_utf8_without_validation("31"sv);default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 

--- a/bootstrap/stage0/formatter.cpp
+++ b/bootstrap/stage0/formatter.cpp
@@ -12,10 +12,10 @@ i64 i = static_cast<i64>(0LL);
 while (i < JaktInternal::checked_sub(infallible_integer_cast<i64>(values.size()),static_cast<i64>(1LL))){
 i64 j = static_cast<i64>(0LL);
 while (j < JaktInternal::checked_sub(JaktInternal::checked_sub(infallible_integer_cast<i64>(values.size()),i),static_cast<i64>(1LL))){
-if (values.operator[](j) > values.operator[](JaktInternal::checked_add(j,static_cast<i64>(1LL)))){
-ByteString const tmp = values.operator[](j);
-values.operator[](j) = values.operator[](JaktInternal::checked_add(j,static_cast<i64>(1LL)));
-values.operator[](JaktInternal::checked_add(j,static_cast<i64>(1LL))) = tmp;
+if (values[j] > values[JaktInternal::checked_add(j,static_cast<i64>(1LL))]){
+ByteString const tmp = values[j];
+values[j] = values[JaktInternal::checked_add(j,static_cast<i64>(1LL))];
+values[JaktInternal::checked_add(j,static_cast<i64>(1LL))] = tmp;
 }
 ++j;
 }
@@ -38,173 +38,40 @@ builder.appendff("preceding_trivia: {}", preceding_trivia);
 builder.append(")"sv);return builder.to_string(); }
 ErrorOr<ByteString> Jakt::formatter::FormattedToken::debug_text() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = this->token;
+{auto&& __jakt_match_variant = this->token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("Identifier: {}"sv),name));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("Identifier: {}"sv),name);};/*case end*/
 case 55 /* Eol */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eol;JaktInternal::Optional<ByteString> const& comment = __jakt_match_value.comment;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("Eol: {}"sv),comment.value_or_lazy_evaluated([&] { return ByteString::from_utf8_without_validation(""sv); })));
-};/*case end*/
-case 56 /* Eof */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Eof"sv));
-default:return JaktInternal::ExplicitValue(TRY((this->token_text())));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return __jakt_format(StringView::from_string_literal("Eol: {}"sv),comment.value_or_lazy_evaluated([&] { return ByteString::from_utf8_without_validation(""sv); }));};/*case end*/
+case 56 /* Eof */:return ByteString::from_utf8_without_validation("Eof"sv);default:return this->token_text();}/*switch end*/
+}
 }
 }
 
 ErrorOr<ByteString> Jakt::formatter::FormattedToken::token_text() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = this->token;
+{auto&& __jakt_match_variant = this->token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;ByteString const& quote = __jakt_match_value.quote;
 JaktInternal::Optional<ByteString> const& prefix = __jakt_match_value.prefix;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}'{}'"sv),prefix.value_or_lazy_evaluated([&] { return ByteString::from_utf8_without_validation(""sv); }),quote));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}'{}'"sv),prefix.value_or_lazy_evaluated([&] { return ByteString::from_utf8_without_validation(""sv); }),quote);};/*case end*/
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;ByteString const& quote = __jakt_match_value.quote;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("\"{}\""sv),quote));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("\"{}\""sv),quote);};/*case end*/
 case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;Jakt::lexer::LiteralPrefix const& prefix = __jakt_match_value.prefix;
 ByteString const& number = __jakt_match_value.number;
 Jakt::lexer::LiteralSuffix const& suffix = __jakt_match_value.suffix;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}{}{}"sv),prefix.to_string(),number,suffix.to_string()));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}{}{}"sv),prefix.to_string(),number,suffix.to_string());};/*case end*/
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(name);
-};/*case end*/
-case 4 /* Semicolon */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(";"sv));
-case 5 /* Colon */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(":"sv));
-case 6 /* ColonColon */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("::"sv));
-case 7 /* LParen */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("("sv));
-case 8 /* RParen */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(")"sv));
-case 9 /* LCurly */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("{"sv));
-case 10 /* RCurly */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("}"sv));
-case 11 /* LSquare */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("["sv));
-case 12 /* RSquare */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("]"sv));
-case 13 /* PercentSign */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("%"sv));
-case 14 /* Plus */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("+"sv));
-case 15 /* Minus */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("-"sv));
-case 16 /* Equal */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("="sv));
-case 17 /* PlusEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("+="sv));
-case 18 /* PlusPlus */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("++"sv));
-case 19 /* MinusEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("-="sv));
-case 20 /* MinusMinus */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("--"sv));
-case 21 /* AsteriskEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("*="sv));
-case 22 /* ForwardSlashEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("/="sv));
-case 23 /* PercentSignEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("%="sv));
-case 24 /* NotEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("!="sv));
-case 25 /* DoubleEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("=="sv));
-case 26 /* GreaterThan */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(">"sv));
-case 27 /* GreaterThanOrEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(">="sv));
-case 28 /* LessThan */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("<"sv));
-case 29 /* LessThanOrEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("<="sv));
-case 30 /* LeftArithmeticShift */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("<<<"sv));
-case 31 /* LeftShift */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("<<"sv));
-case 32 /* LeftShiftEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("<<="sv));
-case 33 /* RightShift */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(">>"sv));
-case 34 /* RightArithmeticShift */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(">>>"sv));
-case 35 /* RightShiftEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(">>="sv));
-case 36 /* Asterisk */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("*"sv));
-case 37 /* Ampersand */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("&"sv));
-case 38 /* AmpersandEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("&="sv));
-case 39 /* AmpersandAmpersand */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("&&"sv));
-case 40 /* Pipe */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("|"sv));
-case 41 /* PipeEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("|="sv));
-case 42 /* PipePipe */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("||"sv));
-case 43 /* Caret */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("^"sv));
-case 44 /* CaretEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("^="sv));
-case 45 /* Dollar */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("$"sv));
-case 46 /* Tilde */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("~"sv));
-case 47 /* ForwardSlash */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("/"sv));
-case 48 /* ExclamationPoint */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("!"sv));
-case 49 /* QuestionMark */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("?"sv));
-case 50 /* QuestionMarkQuestionMark */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("??"sv));
-case 51 /* QuestionMarkQuestionMarkEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("??="sv));
-case 52 /* Comma */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(","sv));
-case 53 /* Dot */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("."sv));
-case 54 /* DotDot */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(".."sv));
-case 55 /* Eol */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-case 56 /* Eof */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-case 57 /* FatArrow */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("=>"sv));
-case 58 /* Arrow */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("->"sv));
-case 59 /* And */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("and"sv));
-case 60 /* Anon */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("anon"sv));
-case 61 /* As */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("as"sv));
-case 62 /* Boxed */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("boxed"sv));
-case 63 /* Break */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("break"sv));
-case 64 /* Catch */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("catch"sv));
-case 65 /* Class */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("class"sv));
-case 66 /* Continue */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("continue"sv));
-case 67 /* Cpp */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("cpp"sv));
-case 68 /* Defer */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("defer"sv));
-case 69 /* Destructor */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("destructor"sv));
-case 70 /* Else */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("else"sv));
-case 71 /* Enum */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("enum"sv));
-case 72 /* Extern */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("extern"sv));
-case 73 /* Export */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("export"sv));
-case 74 /* False */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("false"sv));
-case 75 /* For */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("for"sv));
-case 76 /* Fn */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("fn"sv));
-case 77 /* Comptime */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("comptime"sv));
-case 78 /* If */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("if"sv));
-case 79 /* Import */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("import"sv));
-case 80 /* Relative */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("relative"sv));
-case 81 /* In */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("in"sv));
-case 82 /* Is */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("is"sv));
-case 83 /* Let */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("let"sv));
-case 84 /* Loop */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("loop"sv));
-case 85 /* Match */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("match"sv));
-case 87 /* Mut */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("mut"sv));
-case 88 /* Namespace */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("namespace"sv));
-case 89 /* Not */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("not"sv));
-case 90 /* Or */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("or"sv));
-case 92 /* Private */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("private"sv));
-case 93 /* Public */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("public"sv));
-case 94 /* Raw */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("raw"sv));
-case 96 /* Return */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("return"sv));
-case 97 /* Restricted */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("restricted"sv));
-case 98 /* Sizeof */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("sizeof"sv));
-case 99 /* Struct */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("struct"sv));
-case 100 /* This */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("this"sv));
-case 101 /* Throw */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("throw"sv));
-case 102 /* Throws */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("throws"sv));
-case 103 /* True */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("true"sv));
-case 104 /* Try */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("try"sv));
-case 105 /* Unsafe */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("unsafe"sv));
-case 107 /* Weak */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("weak"sv));
-case 108 /* While */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("while"sv));
-case 109 /* Yield */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("yield"sv));
-case 110 /* Guard */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("guard"sv));
-case 91 /* Override */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("override"sv));
-case 106 /* Virtual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("virtual"sv));
-case 111 /* Implements */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("implements"sv));
-case 112 /* Requires */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("requires"sv));
-case 113 /* Trait */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("trait"sv));
-case 86 /* Must */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("must"sv));
-case 95 /* Reflect */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("reflect"sv));
-case 114 /* Garbage */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return name;};/*case end*/
+case 4 /* Semicolon */:return ByteString::from_utf8_without_validation(";"sv);case 5 /* Colon */:return ByteString::from_utf8_without_validation(":"sv);case 6 /* ColonColon */:return ByteString::from_utf8_without_validation("::"sv);case 7 /* LParen */:return ByteString::from_utf8_without_validation("("sv);case 8 /* RParen */:return ByteString::from_utf8_without_validation(")"sv);case 9 /* LCurly */:return ByteString::from_utf8_without_validation("{"sv);case 10 /* RCurly */:return ByteString::from_utf8_without_validation("}"sv);case 11 /* LSquare */:return ByteString::from_utf8_without_validation("["sv);case 12 /* RSquare */:return ByteString::from_utf8_without_validation("]"sv);case 13 /* PercentSign */:return ByteString::from_utf8_without_validation("%"sv);case 14 /* Plus */:return ByteString::from_utf8_without_validation("+"sv);case 15 /* Minus */:return ByteString::from_utf8_without_validation("-"sv);case 16 /* Equal */:return ByteString::from_utf8_without_validation("="sv);case 17 /* PlusEqual */:return ByteString::from_utf8_without_validation("+="sv);case 18 /* PlusPlus */:return ByteString::from_utf8_without_validation("++"sv);case 19 /* MinusEqual */:return ByteString::from_utf8_without_validation("-="sv);case 20 /* MinusMinus */:return ByteString::from_utf8_without_validation("--"sv);case 21 /* AsteriskEqual */:return ByteString::from_utf8_without_validation("*="sv);case 22 /* ForwardSlashEqual */:return ByteString::from_utf8_without_validation("/="sv);case 23 /* PercentSignEqual */:return ByteString::from_utf8_without_validation("%="sv);case 24 /* NotEqual */:return ByteString::from_utf8_without_validation("!="sv);case 25 /* DoubleEqual */:return ByteString::from_utf8_without_validation("=="sv);case 26 /* GreaterThan */:return ByteString::from_utf8_without_validation(">"sv);case 27 /* GreaterThanOrEqual */:return ByteString::from_utf8_without_validation(">="sv);case 28 /* LessThan */:return ByteString::from_utf8_without_validation("<"sv);case 29 /* LessThanOrEqual */:return ByteString::from_utf8_without_validation("<="sv);case 30 /* LeftArithmeticShift */:return ByteString::from_utf8_without_validation("<<<"sv);case 31 /* LeftShift */:return ByteString::from_utf8_without_validation("<<"sv);case 32 /* LeftShiftEqual */:return ByteString::from_utf8_without_validation("<<="sv);case 33 /* RightShift */:return ByteString::from_utf8_without_validation(">>"sv);case 34 /* RightArithmeticShift */:return ByteString::from_utf8_without_validation(">>>"sv);case 35 /* RightShiftEqual */:return ByteString::from_utf8_without_validation(">>="sv);case 36 /* Asterisk */:return ByteString::from_utf8_without_validation("*"sv);case 37 /* Ampersand */:return ByteString::from_utf8_without_validation("&"sv);case 38 /* AmpersandEqual */:return ByteString::from_utf8_without_validation("&="sv);case 39 /* AmpersandAmpersand */:return ByteString::from_utf8_without_validation("&&"sv);case 40 /* Pipe */:return ByteString::from_utf8_without_validation("|"sv);case 41 /* PipeEqual */:return ByteString::from_utf8_without_validation("|="sv);case 42 /* PipePipe */:return ByteString::from_utf8_without_validation("||"sv);case 43 /* Caret */:return ByteString::from_utf8_without_validation("^"sv);case 44 /* CaretEqual */:return ByteString::from_utf8_without_validation("^="sv);case 45 /* Dollar */:return ByteString::from_utf8_without_validation("$"sv);case 46 /* Tilde */:return ByteString::from_utf8_without_validation("~"sv);case 47 /* ForwardSlash */:return ByteString::from_utf8_without_validation("/"sv);case 48 /* ExclamationPoint */:return ByteString::from_utf8_without_validation("!"sv);case 49 /* QuestionMark */:return ByteString::from_utf8_without_validation("?"sv);case 50 /* QuestionMarkQuestionMark */:return ByteString::from_utf8_without_validation("??"sv);case 51 /* QuestionMarkQuestionMarkEqual */:return ByteString::from_utf8_without_validation("??="sv);case 52 /* Comma */:return ByteString::from_utf8_without_validation(","sv);case 53 /* Dot */:return ByteString::from_utf8_without_validation("."sv);case 54 /* DotDot */:return ByteString::from_utf8_without_validation(".."sv);case 55 /* Eol */:return ByteString::from_utf8_without_validation(""sv);case 56 /* Eof */:return ByteString::from_utf8_without_validation(""sv);case 57 /* FatArrow */:return ByteString::from_utf8_without_validation("=>"sv);case 58 /* Arrow */:return ByteString::from_utf8_without_validation("->"sv);case 59 /* And */:return ByteString::from_utf8_without_validation("and"sv);case 60 /* Anon */:return ByteString::from_utf8_without_validation("anon"sv);case 61 /* As */:return ByteString::from_utf8_without_validation("as"sv);case 62 /* Boxed */:return ByteString::from_utf8_without_validation("boxed"sv);case 63 /* Break */:return ByteString::from_utf8_without_validation("break"sv);case 64 /* Catch */:return ByteString::from_utf8_without_validation("catch"sv);case 65 /* Class */:return ByteString::from_utf8_without_validation("class"sv);case 66 /* Continue */:return ByteString::from_utf8_without_validation("continue"sv);case 67 /* Cpp */:return ByteString::from_utf8_without_validation("cpp"sv);case 68 /* Defer */:return ByteString::from_utf8_without_validation("defer"sv);case 69 /* Destructor */:return ByteString::from_utf8_without_validation("destructor"sv);case 70 /* Else */:return ByteString::from_utf8_without_validation("else"sv);case 71 /* Enum */:return ByteString::from_utf8_without_validation("enum"sv);case 72 /* Extern */:return ByteString::from_utf8_without_validation("extern"sv);case 73 /* Export */:return ByteString::from_utf8_without_validation("export"sv);case 74 /* False */:return ByteString::from_utf8_without_validation("false"sv);case 75 /* For */:return ByteString::from_utf8_without_validation("for"sv);case 76 /* Fn */:return ByteString::from_utf8_without_validation("fn"sv);case 77 /* Comptime */:return ByteString::from_utf8_without_validation("comptime"sv);case 78 /* If */:return ByteString::from_utf8_without_validation("if"sv);case 79 /* Import */:return ByteString::from_utf8_without_validation("import"sv);case 80 /* Relative */:return ByteString::from_utf8_without_validation("relative"sv);case 81 /* In */:return ByteString::from_utf8_without_validation("in"sv);case 82 /* Is */:return ByteString::from_utf8_without_validation("is"sv);case 83 /* Let */:return ByteString::from_utf8_without_validation("let"sv);case 84 /* Loop */:return ByteString::from_utf8_without_validation("loop"sv);case 85 /* Match */:return ByteString::from_utf8_without_validation("match"sv);case 87 /* Mut */:return ByteString::from_utf8_without_validation("mut"sv);case 88 /* Namespace */:return ByteString::from_utf8_without_validation("namespace"sv);case 89 /* Not */:return ByteString::from_utf8_without_validation("not"sv);case 90 /* Or */:return ByteString::from_utf8_without_validation("or"sv);case 92 /* Private */:return ByteString::from_utf8_without_validation("private"sv);case 93 /* Public */:return ByteString::from_utf8_without_validation("public"sv);case 94 /* Raw */:return ByteString::from_utf8_without_validation("raw"sv);case 96 /* Return */:return ByteString::from_utf8_without_validation("return"sv);case 97 /* Restricted */:return ByteString::from_utf8_without_validation("restricted"sv);case 98 /* Sizeof */:return ByteString::from_utf8_without_validation("sizeof"sv);case 99 /* Struct */:return ByteString::from_utf8_without_validation("struct"sv);case 100 /* This */:return ByteString::from_utf8_without_validation("this"sv);case 101 /* Throw */:return ByteString::from_utf8_without_validation("throw"sv);case 102 /* Throws */:return ByteString::from_utf8_without_validation("throws"sv);case 103 /* True */:return ByteString::from_utf8_without_validation("true"sv);case 104 /* Try */:return ByteString::from_utf8_without_validation("try"sv);case 105 /* Unsafe */:return ByteString::from_utf8_without_validation("unsafe"sv);case 107 /* Weak */:return ByteString::from_utf8_without_validation("weak"sv);case 108 /* While */:return ByteString::from_utf8_without_validation("while"sv);case 109 /* Yield */:return ByteString::from_utf8_without_validation("yield"sv);case 110 /* Guard */:return ByteString::from_utf8_without_validation("guard"sv);case 91 /* Override */:return ByteString::from_utf8_without_validation("override"sv);case 106 /* Virtual */:return ByteString::from_utf8_without_validation("virtual"sv);case 111 /* Implements */:return ByteString::from_utf8_without_validation("implements"sv);case 112 /* Requires */:return ByteString::from_utf8_without_validation("requires"sv);case 113 /* Trait */:return ByteString::from_utf8_without_validation("trait"sv);case 86 /* Must */:return ByteString::from_utf8_without_validation("must"sv);case 95 /* Reflect */:return ByteString::from_utf8_without_validation("reflect"sv);case 114 /* Garbage */:return ByteString::from_utf8_without_validation(""sv);default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
@@ -263,20 +130,13 @@ return Jakt::formatter::FormattedToken(token,this->indent,trailing_trivia,preced
 
 Jakt::lexer::Token Jakt::formatter::Stage0::peek(i64 const offset) const {
 {
-size_t const effective_index = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,Jakt::lexer::Token> {
-auto __jakt_enum_value = (offset);
-if (__jakt_enum_value == static_cast<i64>(0LL)) {return JaktInternal::ExplicitValue(this->index);
-}else {return JaktInternal::ExplicitValue(infallible_integer_cast<size_t>(JaktInternal::checked_sub(JaktInternal::checked_add(infallible_integer_cast<i64>(this->index),offset),static_cast<i64>(1LL))));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+size_t const effective_index = [&]() -> size_t { auto __jakt_enum_value = offset;
+if (__jakt_enum_value == static_cast<i64>(0LL)) {return this->index;}else {return infallible_integer_cast<size_t>(JaktInternal::checked_sub(JaktInternal::checked_add(infallible_integer_cast<i64>(this->index),offset),static_cast<i64>(1LL)));} 
+}();
 if (effective_index >= this->tokens.size()){
 return Jakt::lexer::Token::Eof(this->tokens.last().value().span());
 }
-return this->tokens.operator[](effective_index);
+return this->tokens[effective_index];
 }
 }
 
@@ -299,7 +159,7 @@ return false;
 
 Jakt::lexer::Token Jakt::formatter::Stage0::consume() {
 {
-return this->tokens.operator[](this->index++);
+return this->tokens[this->index++];
 }
 }
 
@@ -354,7 +214,7 @@ return res;
 
 ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter::Stage0::formatted_peek() {
 {
-JaktInternal::DynamicArray<Jakt::formatter::State> const states_cache = this->states.operator[](JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}).to_array();
+JaktInternal::DynamicArray<Jakt::formatter::State> const states_cache = this->states[JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}].to_array();
 size_t const index_cache = this->index;
 JaktInternal::Optional<Jakt::formatter::FormattedToken> const token = TRY((this->next_impl(true)));
 this->index = index_cache;
@@ -371,9 +231,7 @@ return this->next_impl(false);
 
 ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter::Stage0::next_in_extern_context(Jakt::lexer::Token const token) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 99 /* Struct */:case 65 /* Class */:{
 TRY((this->push_state(Jakt::formatter::State::EntityDeclaration(Jakt::formatter::Entity::from_token(token),!(token.__jakt_init_index() == 88 /* Namespace */),false,static_cast<size_t>(0ULL),true))));
@@ -381,50 +239,34 @@ JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({
 if ((token.__jakt_init_index() == 88 /* Namespace */) || (!(this->peek(static_cast<i64>(0LL)).__jakt_init_index() == 28 /* LessThan */))){
 trailing_trivia.push(static_cast<u8>(u8' '));
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 default:{
 this->pop_state();
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter::Stage0::next_in_toplevel_context(size_t const open_parens,size_t const open_curlies,size_t const open_squares,bool const is_extern,Jakt::lexer::Token const token) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 72 /* Extern */:{
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
+{auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 65 /* Class */:case 99 /* Struct */:{
 TRY((this->push_state(Jakt::formatter::State::Extern())));
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_188;default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+goto __jakt_label_188;}/*switch end*/
+}goto __jakt_label_188; __jakt_label_188:;;
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 3 /* Identifier */: {
@@ -434,7 +276,7 @@ if ((name == ByteString::from_utf8_without_validation("type"sv)) && (this->peek(
 TRY((this->push_state(Jakt::formatter::State::EntityDeclaration(Jakt::formatter::Entity::from_token(token),true,false,static_cast<size_t>(0ULL),is_extern))));
 return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -444,12 +286,12 @@ JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({
 if ((token.__jakt_init_index() == 88 /* Namespace */) || (!(this->peek(static_cast<i64>(0LL)).__jakt_init_index() == 28 /* LessThan */))){
 trailing_trivia.push(static_cast<u8>(u8' '));
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 11 /* LSquare */:{
 TRY((this->replace_state(Jakt::formatter::State::Toplevel(open_parens,open_curlies,JaktInternal::checked_add(open_squares,static_cast<size_t>(1ULL)),is_extern))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 12 /* RSquare */:{
@@ -459,12 +301,12 @@ this->index--;
 return this->next_impl(true);
 }
 TRY((this->replace_state(Jakt::formatter::State::Toplevel(open_parens,open_curlies,JaktInternal::checked_sub(open_squares,static_cast<size_t>(1ULL)),is_extern))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 7 /* LParen */:{
 TRY((this->replace_state(Jakt::formatter::State::Toplevel(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,is_extern))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 8 /* RParen */:{
@@ -474,12 +316,12 @@ this->index--;
 return this->next_impl(true);
 }
 TRY((this->replace_state(Jakt::formatter::State::Toplevel(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,is_extern))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 9 /* LCurly */:{
 TRY((this->replace_state(Jakt::formatter::State::Toplevel(open_parens,JaktInternal::checked_add(open_curlies,static_cast<size_t>(1ULL)),open_squares,is_extern))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
 }
 VERIFY_NOT_REACHED();
 case 10 /* RCurly */:{
@@ -489,50 +331,39 @@ this->index -= static_cast<size_t>(1ULL);
 return this->next_impl(true);
 }
 TRY((this->replace_state(Jakt::formatter::State::Toplevel(open_parens,JaktInternal::checked_sub(open_curlies,static_cast<size_t>(1ULL)),open_squares,is_extern))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 5 /* Colon */:{
 TRY((this->push_state(Jakt::formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 79 /* Import */:{
 TRY((this->push_state(Jakt::formatter::State::Import(this->peek(static_cast<i64>(0LL)).__jakt_init_index() == 72 /* Extern */))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
-case 93 /* Public */:case 92 /* Private */:case 106 /* Virtual */:case 91 /* Override */:case 62 /* Boxed */:case 105 /* Unsafe */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
-case 97 /* Restricted */:{
+case 93 /* Public */:case 92 /* Private */:case 106 /* Virtual */:case 91 /* Override */:case 62 /* Boxed */:case 105 /* Unsafe */:return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));case 97 /* Restricted */:{
 TRY((this->push_state(Jakt::formatter::State::RestrictionList())));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
-case 52 /* Comma */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
-case 16 /* Equal */:{
+case 52 /* Comma */:return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));case 16 /* Equal */:{
 TRY((this->push_state(Jakt::formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false,Jakt::formatter::ExpressionMode::AtExpressionStart(),static_cast<size_t>(0ULL)))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
 }
 VERIFY_NOT_REACHED();
-default:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));}/*switch end*/
+}
 }
 }
 
 ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter::Stage0::next_in_import_context(bool const is_extern,Jakt::lexer::Token const token) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 72 /* Extern */:case 61 /* As */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
-case 3 /* Identifier */:{
+case 72 /* Extern */:case 61 /* As */:return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));case 3 /* Identifier */:{
 if ((!is_extern) && (this->peek(static_cast<i64>(0LL)).__jakt_init_index() == 7 /* LParen */)){
 return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
@@ -542,11 +373,10 @@ return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArra
 if ((!is_extern) && ((!(this->peek(static_cast<i64>(0LL)).__jakt_init_index() == 9 /* LCurly */)) && (!(this->peek(static_cast<i64>(0LL)).__jakt_init_index() == 61 /* As */)))){
 this->pop_state();
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
-case 7 /* LParen */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-case 9 /* LCurly */:{
+case 7 /* LParen */:return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));case 9 /* LCurly */:{
 if (is_extern){
 TRY((this->push_state(Jakt::formatter::State::Toplevel(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),is_extern))));
 }
@@ -554,69 +384,44 @@ else {
 TRY((this->push_state(Jakt::formatter::State::ImportList(true))));
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 10 /* RCurly */:{
 this->pop_state();
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 52 /* Comma */:{
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
+return this->formatted_token(token,[&]() -> JaktInternal::DynamicArray<u8> { auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 55 /* Eol */:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-default:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),DynamicArray<u8>::create_with({})));
+case 55 /* Eol */:return DynamicArray<u8>::create_with({});default:return DynamicArray<u8>::create_with({static_cast<u8>(u8' ')});}/*switch end*/
+ 
+}(),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
-case 6 /* ColonColon */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-default:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 6 /* ColonColon */:return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));default:return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));}/*switch end*/
+}
 }
 }
 
 ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter::Stage0::next_in_implements_context(Jakt::lexer::Token const token) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* RParen */:{
 this->pop_state();
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
-default:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));}/*switch end*/
+}
 }
 }
 
 ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter::Stage0::next_in_import_list_context(bool const emitted_comma,Jakt::lexer::Token const token) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* RCurly */:{
 this->pop_state();
@@ -625,7 +430,7 @@ return this->next_impl(true);
 }
 case 52 /* Comma */:{
 TRY((this->replace_state(Jakt::formatter::State::ImportList(true))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 55 /* Eol */:{
@@ -637,9 +442,9 @@ ByteString output = ByteString::from_utf8_without_validation(""sv);
 Jakt::utility::Span const span = token.span();
 Jakt::lexer::Token local_token = token;
 while (!(local_token.__jakt_init_index() == 10 /* RCurly */)){
-Jakt::lexer::Token __jakt_tmp419 = local_token;
-if (__jakt_tmp419.__jakt_init_index() == 3 /* Identifier */){
-ByteString const name = __jakt_tmp419.as.Identifier.name;
+Jakt::lexer::Token __jakt_tmp284 = local_token;
+if (__jakt_tmp284.__jakt_init_index() == 3 /* Identifier */){
+ByteString const name = __jakt_tmp284.as.Identifier.name;
 collection.push(name);
 }
 local_token = this->consume();
@@ -738,30 +543,23 @@ output = ((ByteString::from_utf8_without_validation(" "sv) + output) + ByteStrin
 
 this->pop_state();
 this->index--;
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(Jakt::lexer::Token::Identifier(output,span),DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(Jakt::lexer::Token::Identifier(output,span),DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter::Stage0::next_in_entity_declaration_context(Jakt::formatter::Entity const entity,bool const accept_generics,bool const has_generics,size_t const generic_nesting,bool const is_extern,Jakt::lexer::Token const token) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 28 /* LessThan */:{
 if (accept_generics){
 TRY((this->replace_state(Jakt::formatter::State::EntityDeclaration(entity,accept_generics,true,JaktInternal::checked_add(generic_nesting,static_cast<size_t>(1ULL)),is_extern))));
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 26 /* GreaterThan */:{
@@ -774,7 +572,7 @@ TRY((this->replace_state(Jakt::formatter::State::EntityDefinition(entity,is_exte
 }
 
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 3 /* Identifier */:{
@@ -785,99 +583,58 @@ if (this->peek(static_cast<i64>(0LL)).__jakt_init_index() == 111 /* Implements *
 TRY((this->push_state(Jakt::formatter::State::Implements())));
 return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
-case 52 /* Comma */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
-case 10 /* RCurly */:{
+case 52 /* Comma */:return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));case 10 /* RCurly */:{
 this->pop_state();
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 55 /* Eol */:{
 this->pop_state();
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
-case 93 /* Public */:case 92 /* Private */:case 106 /* Virtual */:case 91 /* Override */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
-case 97 /* Restricted */:{
+case 93 /* Public */:case 92 /* Private */:case 106 /* Virtual */:case 91 /* Override */:return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));case 97 /* Restricted */:{
 TRY((this->push_state(Jakt::formatter::State::RestrictionList())));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
-case 112 /* Requires */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')})));
-default:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 112 /* Requires */:return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));default:return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));}/*switch end*/
+}
 }
 }
 
 ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter::Stage0::next_in_entity_definition_context(Jakt::formatter::Entity const entity,bool const is_extern,i64& indent_change,Jakt::lexer::Token const token) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = entity;
+{auto&& __jakt_match_variant = entity;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 1 /* Enum */:case 0 /* Struct */:case 2 /* Namespace */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+case 1 /* Enum */:case 0 /* Struct */:case 2 /* Namespace */:{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* RCurly */:{
 this->pop_state();
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(-static_cast<i64>(1LL));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),[&]() -> JaktInternal::DynamicArray<u8> { auto&& __jakt_match_variant = this->peek(-static_cast<i64>(1LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 55 /* Eol */:case 9 /* LCurly */:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-default:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-})));
+case 55 /* Eol */:case 9 /* LCurly */:return DynamicArray<u8>::create_with({});default:return DynamicArray<u8>::create_with({static_cast<u8>(u8' ')});}/*switch end*/
+ 
+}());
 }
 VERIFY_NOT_REACHED();
 case 9 /* LCurly */:{
 TRY((this->push_state(Jakt::formatter::State::Toplevel(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),is_extern))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
+return this->formatted_token(token,[&]() -> JaktInternal::DynamicArray<u8> { auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 55 /* Eol */:case 10 /* RCurly */:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-default:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')})));
+case 55 /* Eol */:case 10 /* RCurly */:return DynamicArray<u8>::create_with({});default:return DynamicArray<u8>::create_with({static_cast<u8>(u8' ')});}/*switch end*/
+ 
+}(),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
 }
 VERIFY_NOT_REACHED();
-case 5 /* Colon */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
-case 16 /* Equal */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')})));
-case 3 /* Identifier */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-default:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 3 /* Function */: {
+case 5 /* Colon */:return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));case 16 /* Equal */:return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));case 3 /* Identifier */:return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));default:return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));}/*switch end*/
+}case 3 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;bool const& arrow = __jakt_match_value.arrow;
 bool const& indented = __jakt_match_value.indented;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 57 /* FatArrow */:{
 bool const next_is_eol = this->peek(static_cast<i64>(0LL)).__jakt_init_index() == 55 /* Eol */;
@@ -888,47 +645,38 @@ this->already_seen_enclosure_in_current_line = true;
 this->dedents_to_skip.push(static_cast<size_t>(0ULL));
 }
 indent_change += static_cast<i64>(1LL);
-this->dedents_to_skip.operator[](JaktInternal::checked_sub(this->dedents_to_skip.size(),static_cast<size_t>(1ULL))) += static_cast<size_t>(1ULL);
+this->dedents_to_skip[JaktInternal::checked_sub(this->dedents_to_skip.size(),static_cast<size_t>(1ULL))] += static_cast<size_t>(1ULL);
 }
 size_t eols_allowed = static_cast<size_t>(0ULL);
 if (next_is_eol){
 eols_allowed = static_cast<size_t>(1ULL);
 }
 TRY((this->push_state(Jakt::formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),eols_allowed,false,Jakt::formatter::ExpressionMode::BeforeExpressions(),static_cast<size_t>(0ULL)))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
 }
 VERIFY_NOT_REACHED();
 case 58 /* Arrow */:{
 TRY((this->push_state(Jakt::formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
 }
 VERIFY_NOT_REACHED();
 case 7 /* LParen */:{
 TRY((this->push_state(Jakt::formatter::State::ParameterList(static_cast<size_t>(0ULL)))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
-case 8 /* RParen */:return JaktInternal::ExplicitValue(this->formatted_token(token,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
+case 8 /* RParen */:return this->formatted_token(token,[&]() -> JaktInternal::DynamicArray<u8> { auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 102 /* Throws */:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-default:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),DynamicArray<u8>::create_with({})));
-case 9 /* LCurly */:{
+case 102 /* Throws */:return DynamicArray<u8>::create_with({static_cast<u8>(u8' ')});default:return DynamicArray<u8>::create_with({});}/*switch end*/
+ 
+}(),DynamicArray<u8>::create_with({}));case 9 /* LCurly */:{
 TRY((this->push_state(Jakt::formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),JaktInternal::OptionalNone(),false,Jakt::formatter::ExpressionMode::OutsideExpression(),static_cast<size_t>(0ULL)))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
 }
 VERIFY_NOT_REACHED();
 case 10 /* RCurly */:{
 this->pop_state();
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 55 /* Eol */:{
@@ -945,41 +693,27 @@ JaktInternal::Optional<size_t> const dummy = this->dedents_to_skip.pop();
 indent_change -= static_cast<i64>(1LL);
 }
 else if (this->dedents_to_skip.last().value() > static_cast<size_t>(0ULL)){
-this->dedents_to_skip.operator[](JaktInternal::checked_sub(this->dedents_to_skip.size(),static_cast<size_t>(1ULL))) -= static_cast<size_t>(1ULL);
+this->dedents_to_skip[JaktInternal::checked_sub(this->dedents_to_skip.size(),static_cast<size_t>(1ULL))] -= static_cast<size_t>(1ULL);
 }
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
-default:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));}/*switch end*/
+}};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter::Stage0::next_in_statement_context(size_t const open_parens,size_t const open_curlies,size_t const open_squares,size_t const arrow_indents,JaktInternal::Optional<size_t> const allow_eol,bool const inserted_comma,Jakt::formatter::ExpressionMode const expression_mode,size_t const dedents_on_open_curly,i64& indent_change,Jakt::lexer::Token const token) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 83 /* Let */:{
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly))));
 TRY((this->push_state(Jakt::formatter::State::VariableDeclaration(static_cast<size_t>(0ULL)))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 87 /* Mut */:{
@@ -987,62 +721,39 @@ TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,op
 if (expression_mode.__jakt_init_index() == 0 /* OutsideExpression */){
 TRY((this->push_state(Jakt::formatter::State::VariableDeclaration(static_cast<size_t>(0ULL)))));
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 85 /* Match */:case 75 /* For */:case 108 /* While */:case 78 /* If */:case 104 /* Try */:case 84 /* Loop */:case 110 /* Guard */:case 68 /* Defer */:{
-size_t const added_indent = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+size_t const added_indent = [&]() -> size_t { auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 85 /* Match */:case 75 /* For */:case 108 /* While */:case 78 /* If */:case 110 /* Guard */:{
 size_t indent = static_cast<size_t>(1ULL);
 if (this->line_has_indent()){
 indent = static_cast<size_t>(0ULL);
 }
-return JaktInternal::ExplicitValue<size_t>(indent);
+return indent;
 }
 VERIFY_NOT_REACHED();
-default:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return static_cast<size_t>(0ULL);}/*switch end*/
+ 
+}();
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_add(dedents_on_open_curly,added_indent)))));
 indent_change += infallible_integer_cast<i64>(added_indent);
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 64 /* Catch */:case 70 /* Else */:{
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
+return this->formatted_token(token,[&]() -> JaktInternal::DynamicArray<u8> { auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 55 /* Eol */:case 57 /* FatArrow */:case 7 /* LParen */:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-default:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(-static_cast<i64>(1LL));
+case 55 /* Eol */:case 57 /* FatArrow */:case 7 /* LParen */:return DynamicArray<u8>::create_with({});default:return DynamicArray<u8>::create_with({static_cast<u8>(u8' ')});}/*switch end*/
+ 
+}(),[&]() -> JaktInternal::DynamicArray<u8> { auto&& __jakt_match_variant = this->peek(-static_cast<i64>(1LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 55 /* Eol */:case 40 /* Pipe */:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-default:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-})));
+case 55 /* Eol */:case 40 /* Pipe */:return DynamicArray<u8>::create_with({});default:return DynamicArray<u8>::create_with({static_cast<u8>(u8' ')});}/*switch end*/
+ 
+}());
 }
 VERIFY_NOT_REACHED();
 case 55 /* Eol */:{
@@ -1072,60 +783,43 @@ JaktInternal::Optional<size_t> const dummy = this->dedents_to_skip.pop();
 indent_change -= static_cast<i64>(1LL);
 }
 else if (this->dedents_to_skip.last().value() > static_cast<size_t>(0ULL)){
-this->dedents_to_skip.operator[](JaktInternal::checked_sub(this->dedents_to_skip.size(),static_cast<size_t>(1ULL))) -= static_cast<size_t>(1ULL);
+this->dedents_to_skip[JaktInternal::checked_sub(this->dedents_to_skip.size(),static_cast<size_t>(1ULL))] -= static_cast<size_t>(1ULL);
 }
 new_arrow_indents--;
 }
 }
 
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,open_squares,new_arrow_indents,new_allow_eol,inserted_comma,new_expression_mode,dedents_on_open_curly))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 76 /* Fn */:{
 TRY((this->push_state(Jakt::formatter::State::FunctionTypeContext(false))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 52 /* Comma */:{
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
+{auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 55 /* Eol */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-default:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+case 55 /* Eol */:return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));default:return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));}/*switch end*/
+}
 }
 VERIFY_NOT_REACHED();
-case 96 /* Return */:case 101 /* Throw */:case 109 /* Yield */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
+case 96 /* Return */:case 101 /* Throw */:case 109 /* Yield */:{auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* Semicolon */:case 55 /* Eol */:{
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 default:{
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 57 /* FatArrow */:{
+}case 57 /* FatArrow */:{
 bool const next_is_eol = this->peek(static_cast<i64>(0LL)).__jakt_init_index() == 55 /* Eol */;
 size_t new_arrow_indents = arrow_indents;
 if (next_is_eol){
@@ -1134,28 +828,20 @@ this->already_seen_enclosure_in_current_line = true;
 this->dedents_to_skip.push(static_cast<size_t>(0ULL));
 }
 indent_change += static_cast<i64>(1LL);
-this->dedents_to_skip.operator[](JaktInternal::checked_sub(this->dedents_to_skip.size(),static_cast<size_t>(1ULL))) += static_cast<size_t>(1ULL);
+this->dedents_to_skip[JaktInternal::checked_sub(this->dedents_to_skip.size(),static_cast<size_t>(1ULL))] += static_cast<size_t>(1ULL);
 new_arrow_indents++;
 }
-TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,open_squares,new_arrow_indents,allow_eol,inserted_comma,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::formatter::ExpressionMode, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
+TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,open_squares,new_arrow_indents,allow_eol,inserted_comma,[&]() -> Jakt::formatter::ExpressionMode { auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 9 /* LCurly */:return JaktInternal::ExplicitValue(Jakt::formatter::ExpressionMode::OutsideExpression());
-default:return JaktInternal::ExplicitValue(Jakt::formatter::ExpressionMode::BeforeExpressions());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),dedents_on_open_curly))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')})));
+case 9 /* LCurly */:return Jakt::formatter::ExpressionMode::OutsideExpression();default:return Jakt::formatter::ExpressionMode::BeforeExpressions();}/*switch end*/
+ 
+}(),dedents_on_open_curly))));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
 }
 VERIFY_NOT_REACHED();
 case 11 /* LSquare */:{
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,JaktInternal::checked_add(open_squares,static_cast<size_t>(1ULL)),arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 12 /* RSquare */:{
@@ -1165,12 +851,12 @@ this->index--;
 return this->next_impl(true);
 }
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,JaktInternal::checked_sub(open_squares,static_cast<size_t>(1ULL)),arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 7 /* LParen */:{
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 8 /* RParen */:{
@@ -1180,7 +866,7 @@ this->index--;
 return this->next_impl(true);
 }
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::InExpression(),dedents_on_open_curly))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 9 /* LCurly */:{
@@ -1190,43 +876,18 @@ this->indent -= static_cast<size_t>(1ULL);
 dedented = static_cast<size_t>(1ULL);
 }
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,JaktInternal::checked_add(open_curlies,static_cast<size_t>(1ULL)),open_squares,arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_sub(dedents_on_open_curly,dedented)))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = expression_mode;
+return this->formatted_token(token,[&]() -> JaktInternal::DynamicArray<u8> { auto&& __jakt_match_variant = expression_mode;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* AtExpressionStart */:case 1 /* BeforeExpressions */:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
+case 2 /* AtExpressionStart */:case 1 /* BeforeExpressions */:return DynamicArray<u8>::create_with({});default:{auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 55 /* Eol */:case 10 /* RCurly */:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-default:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(-static_cast<i64>(1LL));
+case 55 /* Eol */:case 10 /* RCurly */:return DynamicArray<u8>::create_with({});default:return DynamicArray<u8>::create_with({static_cast<u8>(u8' ')});}/*switch end*/
+}}/*switch end*/
+ 
+}(),[&]() -> JaktInternal::DynamicArray<u8> { auto&& __jakt_match_variant = this->peek(-static_cast<i64>(1LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 70 /* Else */:case 104 /* Try */:case 64 /* Catch */:case 16 /* Equal */:case 57 /* FatArrow */:case 84 /* Loop */:case 68 /* Defer */:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-default:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-})));
+case 70 /* Else */:case 104 /* Try */:case 64 /* Catch */:case 16 /* Equal */:case 57 /* FatArrow */:case 84 /* Loop */:case 68 /* Defer */:return DynamicArray<u8>::create_with({});default:return DynamicArray<u8>::create_with({static_cast<u8>(u8' ')});}/*switch end*/
+ 
+}());
 }
 VERIFY_NOT_REACHED();
 case 10 /* RCurly */:{
@@ -1236,102 +897,59 @@ this->index -= static_cast<size_t>(1ULL);
 return this->next_impl(true);
 }
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,JaktInternal::checked_sub(open_curlies,static_cast<size_t>(1ULL)),open_squares,arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::InExpression(),dedents_on_open_curly))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(-static_cast<i64>(1LL));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),[&]() -> JaktInternal::DynamicArray<u8> { auto&& __jakt_match_variant = this->peek(-static_cast<i64>(1LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 55 /* Eol */:case 9 /* LCurly */:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-default:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-})));
+case 55 /* Eol */:case 9 /* LCurly */:return DynamicArray<u8>::create_with({});default:return DynamicArray<u8>::create_with({static_cast<u8>(u8' ')});}/*switch end*/
+ 
+}());
 }
 VERIFY_NOT_REACHED();
 case 89 /* Not */:{
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 98 /* Sizeof */:{
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 5 /* Colon */:{
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
+return this->formatted_token(token,[&]() -> JaktInternal::DynamicArray<u8> { auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 12 /* RSquare */:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-default:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),DynamicArray<u8>::create_with({})));
+case 12 /* RSquare */:return DynamicArray<u8>::create_with({});default:return DynamicArray<u8>::create_with({static_cast<u8>(u8' ')});}/*switch end*/
+ 
+}(),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 15 /* Minus */:case 36 /* Asterisk */:case 37 /* Ampersand */:{
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly))));
-JaktInternal::DynamicArray<u8> const trivia = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = expression_mode;
+JaktInternal::DynamicArray<u8> const trivia = [&]() -> JaktInternal::DynamicArray<u8> { auto&& __jakt_match_variant = expression_mode;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 3 /* InExpression */:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-default:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,trivia,trivia));
+case 3 /* InExpression */:return DynamicArray<u8>::create_with({static_cast<u8>(u8' ')});default:return DynamicArray<u8>::create_with({});}/*switch end*/
+ 
+}();
+return this->formatted_token(token,trivia,trivia);
 }
 VERIFY_NOT_REACHED();
 case 13 /* PercentSign */:case 14 /* Plus */:case 16 /* Equal */:case 40 /* Pipe */:case 17 /* PlusEqual */:case 19 /* MinusEqual */:case 21 /* AsteriskEqual */:case 22 /* ForwardSlashEqual */:case 23 /* PercentSignEqual */:case 24 /* NotEqual */:case 25 /* DoubleEqual */:case 26 /* GreaterThan */:case 27 /* GreaterThanOrEqual */:case 28 /* LessThan */:case 29 /* LessThanOrEqual */:case 30 /* LeftArithmeticShift */:case 31 /* LeftShift */:case 33 /* RightShift */:case 32 /* LeftShiftEqual */:case 34 /* RightArithmeticShift */:case 35 /* RightShiftEqual */:case 38 /* AmpersandEqual */:case 41 /* PipeEqual */:case 43 /* Caret */:case 44 /* CaretEqual */:case 47 /* ForwardSlash */:case 50 /* QuestionMarkQuestionMark */:case 51 /* QuestionMarkQuestionMarkEqual */:case 59 /* And */:case 81 /* In */:case 90 /* Or */:{
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
 }
 VERIFY_NOT_REACHED();
 case 82 /* Is */:{
 TRY((this->push_state(Jakt::formatter::State::MatchPattern(static_cast<size_t>(0ULL),false))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
 }
 VERIFY_NOT_REACHED();
-case 61 /* As */:return JaktInternal::ExplicitValue(this->formatted_token(token,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
+case 61 /* As */:return this->formatted_token(token,[&]() -> JaktInternal::DynamicArray<u8> { auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 49 /* QuestionMark */:case 48 /* ExclamationPoint */:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-default:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')})));
-case 49 /* QuestionMark */:case 48 /* ExclamationPoint */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(-static_cast<i64>(1LL));
+case 49 /* QuestionMark */:case 48 /* ExclamationPoint */:return DynamicArray<u8>::create_with({});default:return DynamicArray<u8>::create_with({static_cast<u8>(u8' ')});}/*switch end*/
+ 
+}(),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));case 49 /* QuestionMark */:case 48 /* ExclamationPoint */:{auto&& __jakt_match_variant = this->peek(-static_cast<i64>(1LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 61 /* As */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
-default:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 3 /* Identifier */:case 2 /* Number */:{
+case 61 /* As */:return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));default:return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));}/*switch end*/
+}case 3 /* Identifier */:case 2 /* Number */:{
 if ((this->peek(-static_cast<i64>(1LL)).__jakt_init_index() == 3 /* Identifier */) && (!inserted_comma)){
 this->index--;
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,true,Jakt::formatter::ExpressionMode::InExpression(),dedents_on_open_curly))));
@@ -1347,96 +965,65 @@ return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArra
 i64 open_angles = static_cast<i64>(1LL);
 i64 lookahead_index = static_cast<i64>(2LL);
 while (open_angles > static_cast<i64>(0LL)){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(lookahead_index++);
+{auto&& __jakt_match_variant = this->peek(lookahead_index++);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 28 /* LessThan */:{
 open_angles += static_cast<i64>(1LL);
 }
-return JaktInternal::ExplicitValue<void>();
-case 26 /* GreaterThan */:{
+goto __jakt_label_189;case 26 /* GreaterThan */:{
 open_angles -= static_cast<i64>(1LL);
 }
-return JaktInternal::ExplicitValue<void>();
-case 55 /* Eol */:case 13 /* PercentSign */:case 14 /* Plus */:case 15 /* Minus */:case 16 /* Equal */:case 17 /* PlusEqual */:case 19 /* MinusEqual */:case 21 /* AsteriskEqual */:case 22 /* ForwardSlashEqual */:case 23 /* PercentSignEqual */:case 24 /* NotEqual */:case 25 /* DoubleEqual */:case 27 /* GreaterThanOrEqual */:case 29 /* LessThanOrEqual */:case 30 /* LeftArithmeticShift */:case 31 /* LeftShift */:case 33 /* RightShift */:case 32 /* LeftShiftEqual */:case 34 /* RightArithmeticShift */:case 35 /* RightShiftEqual */:case 36 /* Asterisk */:case 38 /* AmpersandEqual */:case 40 /* Pipe */:case 41 /* PipeEqual */:case 43 /* Caret */:case 44 /* CaretEqual */:case 47 /* ForwardSlash */:case 50 /* QuestionMarkQuestionMark */:case 51 /* QuestionMarkQuestionMarkEqual */:case 59 /* And */:case 81 /* In */:case 82 /* Is */:case 90 /* Or */:{
-return JaktInternal::LoopBreak{};
+goto __jakt_label_189;case 55 /* Eol */:case 13 /* PercentSign */:case 14 /* Plus */:case 15 /* Minus */:case 16 /* Equal */:case 17 /* PlusEqual */:case 19 /* MinusEqual */:case 21 /* AsteriskEqual */:case 22 /* ForwardSlashEqual */:case 23 /* PercentSignEqual */:case 24 /* NotEqual */:case 25 /* DoubleEqual */:case 27 /* GreaterThanOrEqual */:case 29 /* LessThanOrEqual */:case 30 /* LeftArithmeticShift */:case 31 /* LeftShift */:case 33 /* RightShift */:case 32 /* LeftShiftEqual */:case 34 /* RightArithmeticShift */:case 35 /* RightShiftEqual */:case 36 /* Asterisk */:case 38 /* AmpersandEqual */:case 40 /* Pipe */:case 41 /* PipeEqual */:case 43 /* Caret */:case 44 /* CaretEqual */:case 47 /* ForwardSlash */:case 50 /* QuestionMarkQuestionMark */:case 51 /* QuestionMarkQuestionMarkEqual */:case 59 /* And */:case 81 /* In */:case 82 /* Is */:case 90 /* Or */:{
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_189;default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_189;}/*switch end*/
+break;}goto __jakt_label_189; __jakt_label_189:;;
 }
 if ((open_angles == static_cast<i64>(0LL)) && (this->peek(lookahead_index).__jakt_init_index() == 7 /* LParen */)){
 TRY((this->push_state(Jakt::formatter::State::GenericCallTypeParams(static_cast<size_t>(0ULL)))));
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 4 /* Semicolon */:{
 if (open_squares == static_cast<size_t>(0ULL)){
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
+{auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 55 /* Eol */:return JaktInternal::ExplicitValue(TRY((this->next())));
-default:return JaktInternal::ExplicitValue(this->formatted_token(Jakt::lexer::Token::Eol(JaktInternal::OptionalNone(),token.span()),DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 55 /* Eol */:return this->next();default:return this->formatted_token(Jakt::lexer::Token::Eol(JaktInternal::OptionalNone(),token.span()),DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));}/*switch end*/
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+}
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 94 /* Raw */:{
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 95 /* Reflect */:{
 TRY((this->replace_state(Jakt::formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(Jakt::formatter::FormattedToken(token,this->indent,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return Jakt::formatter::FormattedToken(token,this->indent,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 default:{
 TRY((this->replace_state(Jakt::formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,Jakt::formatter::ExpressionMode::InExpression(),dedents_on_open_curly))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter::Stage0::next_in_generic_call_type_params_context(size_t const open_angles,Jakt::lexer::Token const token) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 28 /* LessThan */:{
 TRY((this->push_state(Jakt::formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 26 /* GreaterThan */:{
@@ -1447,39 +1034,31 @@ else {
 TRY((this->replace_state(Jakt::formatter::State::GenericCallTypeParams(JaktInternal::checked_sub(open_angles,static_cast<size_t>(1ULL))))));
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 52 /* Comma */:{
 TRY((this->push_state(Jakt::formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
-default:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));}/*switch end*/
+}
 }
 }
 
 ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter::Stage0::next_in_variable_declaration_context(size_t const open_parens,Jakt::lexer::Token const token) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* Colon */:{
 TRY((this->push_state(Jakt::formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 7 /* LParen */:{
 TRY((this->replace_state(Jakt::formatter::State::VariableDeclaration(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL))))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 8 /* RParen */:{
@@ -1489,74 +1068,55 @@ this->index--;
 return this->next_impl(true);
 }
 TRY((this->replace_state(Jakt::formatter::State::VariableDeclaration(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL))))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 16 /* Equal */:{
 this->pop_state();
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
 }
 VERIFY_NOT_REACHED();
-case 52 /* Comma */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
-default:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 52 /* Comma */:return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));default:return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));}/*switch end*/
+}
 }
 }
 
 ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter::Stage0::next_in_restriction_list_context(Jakt::lexer::Token const token) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 52 /* Comma */:{
 TRY((this->push_state(Jakt::formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 8 /* RParen */:{
 this->pop_state();
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
-default:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));}/*switch end*/
+}
 }
 }
 
 ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter::Stage0::next_in_parameter_list_context(size_t const open_parens,Jakt::lexer::Token const token) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 60 /* Anon */:case 87 /* Mut */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
-case 5 /* Colon */:{
+case 60 /* Anon */:case 87 /* Mut */:return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));case 5 /* Colon */:{
 TRY((this->push_state(Jakt::formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
-case 52 /* Comma */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
-case 16 /* Equal */:{
+case 52 /* Comma */:return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));case 16 /* Equal */:{
 TRY((this->push_state(Jakt::formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false,Jakt::formatter::ExpressionMode::AtExpressionStart(),static_cast<size_t>(0ULL)))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
 }
 VERIFY_NOT_REACHED();
 case 7 /* LParen */:{
 TRY((this->replace_state(Jakt::formatter::State::ParameterList(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL))))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 8 /* RParen */:{
@@ -1566,34 +1126,26 @@ this->index--;
 return this->next_impl(true);
 }
 TRY((this->replace_state(Jakt::formatter::State::ParameterList(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL))))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
-default:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));}/*switch end*/
+}
 }
 }
 
 ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter::Stage0::next_in_type_context(size_t const open_parens,size_t const open_curlies,size_t const open_squares,size_t const open_angles,bool const seen_start,Jakt::lexer::Token const token) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* Colon */:{
 TRY((this->push_state(Jakt::formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 28 /* LessThan */:{
 TRY((this->replace_state(Jakt::formatter::State::TypeContext(open_parens,open_curlies,open_squares,JaktInternal::checked_add(open_angles,static_cast<size_t>(1ULL)),seen_start))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 26 /* GreaterThan */:{
@@ -1603,7 +1155,7 @@ this->index--;
 return this->next_impl(true);
 }
 TRY((this->replace_state(Jakt::formatter::State::TypeContext(open_parens,open_curlies,open_squares,JaktInternal::checked_sub(open_angles,static_cast<size_t>(1ULL)),seen_start))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 55 /* Eol */:{
@@ -1612,7 +1164,7 @@ this->pop_state();
 this->index--;
 return this->next_impl(true);
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 11 /* LSquare */:{
@@ -1623,7 +1175,7 @@ return this->next_impl(true);
 }
 TRY((this->replace_state(Jakt::formatter::State::TypeContext(open_parens,open_curlies,JaktInternal::checked_add(open_squares,static_cast<size_t>(1ULL)),open_angles,true))));
 TRY((this->push_state(Jakt::formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 12 /* RSquare */:{
@@ -1633,7 +1185,7 @@ this->index--;
 return this->next_impl(true);
 }
 TRY((this->replace_state(Jakt::formatter::State::TypeContext(open_parens,open_curlies,JaktInternal::checked_sub(open_squares,static_cast<size_t>(1ULL)),open_angles,seen_start))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 7 /* LParen */:{
@@ -1644,7 +1196,7 @@ return this->next_impl(true);
 }
 TRY((this->replace_state(Jakt::formatter::State::TypeContext(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,open_angles,true))));
 TRY((this->push_state(Jakt::formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 8 /* RParen */:{
@@ -1654,7 +1206,7 @@ this->index--;
 return this->next_impl(true);
 }
 TRY((this->replace_state(Jakt::formatter::State::TypeContext(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,open_angles,seen_start))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 9 /* LCurly */:{
@@ -1665,7 +1217,7 @@ return this->next_impl(true);
 }
 TRY((this->replace_state(Jakt::formatter::State::TypeContext(open_parens,JaktInternal::checked_add(open_curlies,static_cast<size_t>(1ULL)),open_squares,open_angles,true))));
 TRY((this->push_state(Jakt::formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 10 /* RCurly */:{
@@ -1675,23 +1227,23 @@ this->index -= static_cast<size_t>(1ULL);
 return this->next_impl(true);
 }
 TRY((this->replace_state(Jakt::formatter::State::TypeContext(open_parens,JaktInternal::checked_sub(open_curlies,static_cast<size_t>(1ULL)),open_squares,open_angles,seen_start))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 94 /* Raw */:case 87 /* Mut */:{
 TRY((this->replace_state(Jakt::formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 37 /* Ampersand */:{
 TRY((this->replace_state(Jakt::formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 76 /* Fn */:{
 TRY((this->replace_state(Jakt::formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true))));
 TRY((this->push_state(Jakt::formatter::State::FunctionTypeContext(false))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 52 /* Comma */:{
@@ -1701,65 +1253,49 @@ this->pop_state();
 return this->next_impl(true);
 }
 TRY((this->push_state(Jakt::formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 3 /* Identifier */:{
 TRY((this->replace_state(Jakt::formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
-case 107 /* Weak */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
-case 16 /* Equal */:case 58 /* Arrow */:case 57 /* FatArrow */:{
+case 107 /* Weak */:return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));case 16 /* Equal */:case 58 /* Arrow */:case 57 /* FatArrow */:{
 this->pop_state();
 this->index--;
 return this->next_impl(true);
 }
-default:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));}/*switch end*/
+}
 }
 }
 
 ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter::Stage0::next_in_capture_list_context(Jakt::lexer::Token const token) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* RSquare */:{
 this->pop_state();
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 52 /* Comma */:case 87 /* Mut */:{
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 default:{
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter::Stage0::next_in_function_type_context(bool const seen_final_type,Jakt::lexer::Token const token) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 57 /* FatArrow */:case 9 /* LCurly */:{
 this->pop_state();
@@ -1774,12 +1310,12 @@ return this->next_impl(true);
 }
 TRY((this->replace_state(Jakt::formatter::State::FunctionTypeContext(true))));
 TRY((this->push_state(Jakt::formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
 }
 VERIFY_NOT_REACHED();
 case 11 /* LSquare */:{
 TRY((this->push_state(Jakt::formatter::State::CaptureList())));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 7 /* LParen */:{
@@ -1789,7 +1325,7 @@ this->index--;
 return this->next_impl(true);
 }
 TRY((this->push_state(Jakt::formatter::State::ParameterList(static_cast<size_t>(0ULL)))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 8 /* RParen */:{
@@ -1798,51 +1334,35 @@ this->pop_state();
 this->index--;
 return this->next_impl(true);
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
+return this->formatted_token(token,[&]() -> JaktInternal::DynamicArray<u8> { auto&& __jakt_match_variant = this->peek(static_cast<i64>(0LL));
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 102 /* Throws */:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-default:return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),DynamicArray<u8>::create_with({})));
+case 102 /* Throws */:return DynamicArray<u8>::create_with({static_cast<u8>(u8' ')});default:return DynamicArray<u8>::create_with({});}/*switch end*/
+ 
+}(),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
-case 102 /* Throws */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-default:{
+case 102 /* Throws */:return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));default:{
 if (seen_final_type){
 this->pop_state();
 this->index--;
 return this->next_impl(true);
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter::Stage0::next_in_match_pattern_context(size_t const open_parens,bool const allow_multiple,Jakt::lexer::Token const token) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* LParen */:{
 TRY((this->replace_state(Jakt::formatter::State::MatchPattern(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)),allow_multiple))));
 TRY((this->push_state(Jakt::formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false,Jakt::formatter::ExpressionMode::OutsideExpression(),static_cast<size_t>(0ULL)))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 8 /* RParen */:{
@@ -1852,7 +1372,7 @@ this->index -= static_cast<size_t>(1ULL);
 return this->next_impl(true);
 }
 TRY((this->replace_state(Jakt::formatter::State::MatchPattern(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL)),allow_multiple))));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
 case 55 /* Eol */:{
@@ -1861,17 +1381,16 @@ this->pop_state();
 this->index -= static_cast<size_t>(1ULL);
 return this->next_impl(true);
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 }
 VERIFY_NOT_REACHED();
-case 3 /* Identifier */:return JaktInternal::ExplicitValue(this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})));
-case 40 /* Pipe */:{
+case 3 /* Identifier */:return this->formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));case 40 /* Pipe */:{
 if (!allow_multiple){
 this->pop_state();
 this->index -= static_cast<size_t>(1ULL);
 return this->next_impl(true);
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::formatter::FormattedToken>>(this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')})));
+return this->formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
 }
 VERIFY_NOT_REACHED();
 default:{
@@ -1880,12 +1399,7 @@ this->index -= static_cast<size_t>(1ULL);
 return this->next_impl(true);
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -1909,7 +1423,7 @@ else if (token.__jakt_init_index() == 55 /* Eol */){
 this->already_seen_enclosure_in_current_line = false;
 }
 if (((token.__jakt_init_index() == 7 /* LParen */) || (token.__jakt_init_index() == 9 /* LCurly */)) || (token.__jakt_init_index() == 11 /* LSquare */)){
-this->dedents_to_skip.operator[](JaktInternal::checked_sub(this->dedents_to_skip.size(),static_cast<size_t>(1ULL)))++;
+this->dedents_to_skip[JaktInternal::checked_sub(this->dedents_to_skip.size(),static_cast<size_t>(1ULL))]++;
 }
 if (((token.__jakt_init_index() == 8 /* RParen */) || (token.__jakt_init_index() == 10 /* RCurly */)) || (token.__jakt_init_index() == 12 /* RSquare */)){
 if (this->dedents_to_skip.last().value() == static_cast<size_t>(1ULL)){
@@ -1920,7 +1434,7 @@ this->indent -= static_cast<size_t>(1ULL);
 this->already_seen_enclosure_in_current_line = false;
 }
 else if (this->dedents_to_skip.last().value() > static_cast<size_t>(0ULL)){
-this->dedents_to_skip.operator[](JaktInternal::checked_sub(this->dedents_to_skip.size(),static_cast<size_t>(1ULL))) -= static_cast<size_t>(1ULL);
+this->dedents_to_skip[JaktInternal::checked_sub(this->dedents_to_skip.size(),static_cast<size_t>(1ULL))] -= static_cast<size_t>(1ULL);
 }
 }
 }
@@ -1955,40 +1469,31 @@ warnln(StringView::from_string_literal("- State: {}"sv),state);
 
 warnln();
 }
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = this->state();
+{auto&& __jakt_match_variant = this->state();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Toplevel */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Toplevel;size_t const& open_parens = __jakt_match_value.open_parens;
 size_t const& open_curlies = __jakt_match_value.open_curlies;
 size_t const& open_squares = __jakt_match_value.open_squares;
 bool const& is_extern = __jakt_match_value.is_extern;
-return JaktInternal::ExplicitValue(TRY((this->next_in_toplevel_context(open_parens,open_curlies,open_squares,is_extern,token))));
-};/*case end*/
-case 1 /* Extern */:return JaktInternal::ExplicitValue(TRY((this->next_in_extern_context(token))));
-case 2 /* Import */: {
+return this->next_in_toplevel_context(open_parens,open_curlies,open_squares,is_extern,token);};/*case end*/
+case 1 /* Extern */:return this->next_in_extern_context(token);case 2 /* Import */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Import;bool const& is_extern = __jakt_match_value.is_extern;
-return JaktInternal::ExplicitValue(TRY((this->next_in_import_context(is_extern,token))));
-};/*case end*/
+return this->next_in_import_context(is_extern,token);};/*case end*/
 case 3 /* ImportList */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ImportList;bool const& emitted_comma = __jakt_match_value.emitted_comma;
-return JaktInternal::ExplicitValue(TRY((this->next_in_import_list_context(emitted_comma,token))));
-};/*case end*/
-case 5 /* Implements */:return JaktInternal::ExplicitValue(TRY((this->next_in_implements_context(token))));
-case 4 /* EntityDeclaration */: {
+return this->next_in_import_list_context(emitted_comma,token);};/*case end*/
+case 5 /* Implements */:return this->next_in_implements_context(token);case 4 /* EntityDeclaration */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EntityDeclaration;Jakt::formatter::Entity const& entity = __jakt_match_value.entity;
 bool const& accept_generics = __jakt_match_value.accept_generics;
 bool const& has_generics = __jakt_match_value.has_generics;
 size_t const& generic_nesting = __jakt_match_value.generic_nesting;
 bool const& is_extern = __jakt_match_value.is_extern;
-return JaktInternal::ExplicitValue(TRY((this->next_in_entity_declaration_context(entity,accept_generics,has_generics,generic_nesting,is_extern,token))));
-};/*case end*/
+return this->next_in_entity_declaration_context(entity,accept_generics,has_generics,generic_nesting,is_extern,token);};/*case end*/
 case 9 /* EntityDefinition */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EntityDefinition;Jakt::formatter::Entity const& entity = __jakt_match_value.entity;
 bool const& is_extern = __jakt_match_value.is_extern;
-return JaktInternal::ExplicitValue(TRY((this->next_in_entity_definition_context(entity,is_extern,indent_change,token))));
-};/*case end*/
+return this->next_in_entity_definition_context(entity,is_extern,indent_change,token);};/*case end*/
 case 10 /* StatementContext */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StatementContext;size_t const& open_parens = __jakt_match_value.open_parens;
 size_t const& open_curlies = __jakt_match_value.open_curlies;
@@ -1998,46 +1503,32 @@ JaktInternal::Optional<size_t> const& allow_eol = __jakt_match_value.allow_eol;
 bool const& inserted_comma = __jakt_match_value.inserted_comma;
 Jakt::formatter::ExpressionMode const& expression_mode = __jakt_match_value.expression_mode;
 size_t const& dedents_on_open_curly = __jakt_match_value.dedents_on_open_curly;
-return JaktInternal::ExplicitValue(TRY((this->next_in_statement_context(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,expression_mode,dedents_on_open_curly,indent_change,token))));
-};/*case end*/
+return this->next_in_statement_context(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,expression_mode,dedents_on_open_curly,indent_change,token);};/*case end*/
 case 13 /* GenericCallTypeParams */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericCallTypeParams;size_t const& open_angles = __jakt_match_value.open_angles;
-return JaktInternal::ExplicitValue(TRY((this->next_in_generic_call_type_params_context(open_angles,token))));
-};/*case end*/
+return this->next_in_generic_call_type_params_context(open_angles,token);};/*case end*/
 case 12 /* VariableDeclaration */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.VariableDeclaration;size_t const& open_parens = __jakt_match_value.open_parens;
-return JaktInternal::ExplicitValue(TRY((this->next_in_variable_declaration_context(open_parens,token))));
-};/*case end*/
-case 8 /* RestrictionList */:return JaktInternal::ExplicitValue(TRY((this->next_in_restriction_list_context(token))));
-case 6 /* CaptureList */:return JaktInternal::ExplicitValue(TRY((this->next_in_capture_list_context(token))));
-case 7 /* ParameterList */: {
+return this->next_in_variable_declaration_context(open_parens,token);};/*case end*/
+case 8 /* RestrictionList */:return this->next_in_restriction_list_context(token);case 6 /* CaptureList */:return this->next_in_capture_list_context(token);case 7 /* ParameterList */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ParameterList;size_t const& open_parens = __jakt_match_value.open_parens;
-return JaktInternal::ExplicitValue(TRY((this->next_in_parameter_list_context(open_parens,token))));
-};/*case end*/
+return this->next_in_parameter_list_context(open_parens,token);};/*case end*/
 case 14 /* TypeContext */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeContext;size_t const& open_parens = __jakt_match_value.open_parens;
 size_t const& open_curlies = __jakt_match_value.open_curlies;
 size_t const& open_squares = __jakt_match_value.open_squares;
 size_t const& open_angles = __jakt_match_value.open_angles;
 bool const& seen_start = __jakt_match_value.seen_start;
-return JaktInternal::ExplicitValue(TRY((this->next_in_type_context(open_parens,open_curlies,open_squares,open_angles,seen_start,token))));
-};/*case end*/
+return this->next_in_type_context(open_parens,open_curlies,open_squares,open_angles,seen_start,token);};/*case end*/
 case 15 /* FunctionTypeContext */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.FunctionTypeContext;bool const& seen_final_type = __jakt_match_value.seen_final_type;
-return JaktInternal::ExplicitValue(TRY((this->next_in_function_type_context(seen_final_type,token))));
-};/*case end*/
+return this->next_in_function_type_context(seen_final_type,token);};/*case end*/
 case 11 /* MatchPattern */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MatchPattern;size_t const& open_parens = __jakt_match_value.open_parens;
 bool const& allow_multiple = __jakt_match_value.allow_multiple;
-return JaktInternal::ExplicitValue(TRY((this->next_in_match_pattern_context(open_parens,allow_multiple,token))));
-};/*case end*/
+return this->next_in_match_pattern_context(open_parens,allow_multiple,token);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -2093,9 +1584,7 @@ return Jakt::formatter::Formatter(TRY((Jakt::formatter::Stage0::for_tokens(token
 ErrorOr<size_t> Jakt::formatter::Formatter::token_length(Jakt::formatter::FormattedToken const token) const {
 {
 size_t length = token.preceding_trivia.size();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<size_t>>{
-auto&& __jakt_match_variant = token.token;
+{auto&& __jakt_match_variant = token.token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 55 /* Eol */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eol;JaktInternal::Optional<ByteString> const& comment = __jakt_match_value.comment;
@@ -2105,33 +1594,19 @@ u8 next_char = static_cast<u8>(u8' ');
 if (comment.value().length() != static_cast<size_t>(0ULL)){
 next_char = comment.value().byte_at(static_cast<size_t>(0ULL));
 }
-size_t const space = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<size_t>> {
-auto __jakt_enum_value = (next_char);
-if ((__jakt_enum_value == static_cast<u8>(u8' '))||(__jakt_enum_value == static_cast<u8>(u8'\t'))||(__jakt_enum_value == static_cast<u8>(u8'/'))) {return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-}else {return JaktInternal::ExplicitValue(static_cast<size_t>(1ULL));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+size_t const space = [&]() -> size_t { auto __jakt_enum_value = next_char;
+if ((__jakt_enum_value == static_cast<u8>(u8' '))||(__jakt_enum_value == static_cast<u8>(u8'\t'))||(__jakt_enum_value == static_cast<u8>(u8'/'))) {return static_cast<size_t>(0ULL);}else {return static_cast<size_t>(1ULL);} 
+}();
 length += space;
 length += comment.value().length();
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_190;};/*case end*/
 default:{
 length += TRY((token.token_text())).length();
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_190;}/*switch end*/
+}goto __jakt_label_190; __jakt_label_190:;;
 length += token.trailing_trivia.size();
 return length;
 }
@@ -2145,9 +1620,9 @@ return;
 size_t i = static_cast<size_t>(0ULL);
 size_t j = JaktInternal::checked_sub(this->tokens_to_reflow.size(),static_cast<size_t>(1ULL));
 while (i < j){
-Jakt::formatter::ReflowState const a = this->tokens_to_reflow.operator[](i);
-this->tokens_to_reflow.operator[](i) = this->tokens_to_reflow.operator[](j);
-this->tokens_to_reflow.operator[](j) = a;
+Jakt::formatter::ReflowState const a = this->tokens_to_reflow[i];
+this->tokens_to_reflow[i] = this->tokens_to_reflow[j];
+this->tokens_to_reflow[j] = a;
 i += static_cast<size_t>(1ULL);
 j -= static_cast<size_t>(1ULL);
 }
@@ -2181,7 +1656,7 @@ void Jakt::formatter::Formatter::fixup_closing_enclosures(JaktInternal::DynamicA
 if (line.is_empty()){
 return;
 }
-line.operator[](static_cast<i64>(0LL)).token.preceding_trivia = DynamicArray<u8>::create_with({});
+line[static_cast<i64>(0LL)].token.preceding_trivia = DynamicArray<u8>::create_with({});
 size_t enclosure_run_length = static_cast<size_t>(0ULL);
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(JaktInternal::checked_sub(line.size(),static_cast<size_t>(1ULL))),static_cast<size_t>(static_cast<size_t>(0ULL))};
@@ -2192,15 +1667,12 @@ break;
 }
 size_t i = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, void>{
-auto&& __jakt_match_variant = line.operator[](i).token.token;
+{auto&& __jakt_match_variant = line[i].token.token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* RParen */:case 10 /* RCurly */:case 12 /* RSquare */:{
 enclosure_run_length += static_cast<size_t>(1ULL);
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_191;default:{
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(enclosure_run_length)};
 for (;;){
@@ -2210,7 +1682,7 @@ break;
 }
 size_t j = _magic_value.value();
 {
-line.operator[](JaktInternal::checked_sub(i,j)).token = Jakt::formatter::FormattedToken(line.operator[](JaktInternal::checked_sub(i,j)).token.token,line.operator[](JaktInternal::checked_sub(i,enclosure_run_length)).token.indent,line.operator[](JaktInternal::checked_sub(i,j)).token.trailing_trivia,line.operator[](JaktInternal::checked_sub(i,j)).token.preceding_trivia);
+line[JaktInternal::checked_sub(i,j)].token = Jakt::formatter::FormattedToken(line[JaktInternal::checked_sub(i,j)].token.token,line[JaktInternal::checked_sub(i,enclosure_run_length)].token.indent,line[JaktInternal::checked_sub(i,j)].token.trailing_trivia,line[JaktInternal::checked_sub(i,j)].token.preceding_trivia);
 }
 
 }
@@ -2218,18 +1690,8 @@ line.operator[](JaktInternal::checked_sub(i,j)).token = Jakt::formatter::Formatt
 
 enclosure_run_length = static_cast<size_t>(0ULL);
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_191;}/*switch end*/
+break;}goto __jakt_label_191; __jakt_label_191:;;
 }
 
 }
@@ -2244,7 +1706,7 @@ break;
 }
 size_t j = _magic_value.value();
 {
-line.operator[](j).token = Jakt::formatter::FormattedToken(line.operator[](j).token.token,line.operator[](enclosure_run_length).token.indent,line.operator[](j).token.trailing_trivia,line.operator[](j).token.preceding_trivia);
+line[j].token = Jakt::formatter::FormattedToken(line[j].token.token,line[enclosure_run_length].token.indent,line[j].token.trailing_trivia,line[j].token.preceding_trivia);
 }
 
 }
@@ -2269,7 +1731,7 @@ ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> Jakt::formatter
 {
 JaktInternal::Optional<Jakt::formatter::ReflowState> reflown_token = JaktInternal::OptionalNone();
 if (this->tokens_to_reflow.size() > static_cast<size_t>(0ULL)){
-reflown_token = this->tokens_to_reflow.operator[](JaktInternal::checked_sub(this->tokens_to_reflow.size(),static_cast<size_t>(1ULL)));
+reflown_token = this->tokens_to_reflow[JaktInternal::checked_sub(this->tokens_to_reflow.size(),static_cast<size_t>(1ULL))];
 }
 return TRY((reflown_token.map([](auto& _value) { return _value.token; }).try_value_or_lazy_evaluated_optional([&]() -> ErrorOr<JaktInternal::Optional<Jakt::formatter::FormattedToken>> { return TRY((this->token_provider.formatted_peek())); })));
 }
@@ -2292,9 +1754,7 @@ if ((this->in_condition_expr && (next_underlying_token.__jakt_init_index() == 9 
 this->in_condition_expr = false;
 this->in_condition_expr_indented = false;
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::formatter::FormattedToken>>>>{
-auto&& __jakt_match_variant = next_underlying_token;
+{auto&& __jakt_match_variant = next_underlying_token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* LParen */:case 9 /* LCurly */:case 11 /* LSquare */:{
 accepted_at_least_one_token = true;
@@ -2305,98 +1765,33 @@ JaktInternal::Optional<Jakt::formatter::FormattedToken> const next_token = TRY((
 JaktInternal::Optional<Jakt::formatter::BreakablePoint> breakable_point = JaktInternal::OptionalNone();
 if (next_token.has_value()){
 i64 const a = static_cast<i64>(1LL);
-breakable_point = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::BreakablePoint>, ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::formatter::FormattedToken>>>>{
-auto&& __jakt_match_variant = next_underlying_token;
+breakable_point = [&]() -> JaktInternal::Optional<Jakt::formatter::BreakablePoint> { auto&& __jakt_match_variant = next_underlying_token;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 7 /* LParen */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::BreakablePoint>, ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::formatter::FormattedToken>>>>{
-auto&& __jakt_match_variant = next_token.value().token;
+case 7 /* LParen */:{auto&& __jakt_match_variant = next_token.value().token;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 8 /* RParen */:return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-default:return JaktInternal::ExplicitValue(Jakt::formatter::BreakablePoint::Paren(this->current_line.size(),this->current_line_length));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
-case 9 /* LCurly */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::BreakablePoint>, ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::formatter::FormattedToken>>>>{
-auto&& __jakt_match_variant = next_token.value().token;
+case 8 /* RParen */:return JaktInternal::OptionalNone();default:return Jakt::formatter::BreakablePoint::Paren(this->current_line.size(),this->current_line_length);}/*switch end*/
+}case 9 /* LCurly */:{auto&& __jakt_match_variant = next_token.value().token;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 10 /* RCurly */:return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-default:return JaktInternal::ExplicitValue(Jakt::formatter::BreakablePoint::Curly(this->current_line.size(),this->current_line_length));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
-case 11 /* LSquare */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::BreakablePoint>, ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::formatter::FormattedToken>>>>{
-auto&& __jakt_match_variant = next_token.value().token;
+case 10 /* RCurly */:return JaktInternal::OptionalNone();default:return Jakt::formatter::BreakablePoint::Curly(this->current_line.size(),this->current_line_length);}/*switch end*/
+}case 11 /* LSquare */:{auto&& __jakt_match_variant = next_token.value().token;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 12 /* RSquare */:return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-default:return JaktInternal::ExplicitValue(Jakt::formatter::BreakablePoint::Square(this->current_line.size(),this->current_line_length));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
-default:{
+case 12 /* RSquare */:return JaktInternal::OptionalNone();default:return Jakt::formatter::BreakablePoint::Square(this->current_line.size(),this->current_line_length);}/*switch end*/
+}default:{
 Jakt::abort();
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+ 
+}();
 }
 else {
-breakable_point = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::formatter::BreakablePoint>, ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::formatter::FormattedToken>>>>{
-auto&& __jakt_match_variant = next_underlying_token;
+breakable_point = [&]() -> JaktInternal::Optional<Jakt::formatter::BreakablePoint> { auto&& __jakt_match_variant = next_underlying_token;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 7 /* LParen */:return JaktInternal::ExplicitValue(Jakt::formatter::BreakablePoint::Paren(this->current_line.size(),this->current_line_length));
-case 9 /* LCurly */:return JaktInternal::ExplicitValue(Jakt::formatter::BreakablePoint::Curly(this->current_line.size(),this->current_line_length));
-case 11 /* LSquare */:return JaktInternal::ExplicitValue(Jakt::formatter::BreakablePoint::Square(this->current_line.size(),this->current_line_length));
-default:{
+case 7 /* LParen */:return Jakt::formatter::BreakablePoint::Paren(this->current_line.size(),this->current_line_length);case 9 /* LCurly */:return Jakt::formatter::BreakablePoint::Curly(this->current_line.size(),this->current_line_length);case 11 /* LSquare */:return Jakt::formatter::BreakablePoint::Square(this->current_line.size(),this->current_line_length);default:{
 Jakt::abort();
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+ 
+}();
 }
 
 if (breakable_point.has_value()){
@@ -2410,8 +1805,7 @@ this->enclosures_to_ignore += static_cast<size_t>(1ULL);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-case 8 /* RParen */:case 10 /* RCurly */:case 12 /* RSquare */:{
+goto __jakt_label_192;case 8 /* RParen */:case 10 /* RCurly */:case 12 /* RSquare */:{
 bool ignore = false;
 if (this->enclosures_to_ignore > static_cast<size_t>(0ULL)){
 this->enclosures_to_ignore -= static_cast<size_t>(1ULL);
@@ -2426,7 +1820,7 @@ if (replacement.__jakt_init_index() == 55 /* Eol */){
 this->tokens_to_reflow.push(Jakt::formatter::ReflowState(maybe_next_underlying_token.value(),current_state,this->enclosures_to_ignore));
 JaktInternal::Optional<Jakt::lexer::Token> const none = JaktInternal::OptionalNone();
 this->replace_commas_in_enclosure.push(none);
-return JaktInternal::LoopBreak{};
+break;
 }
 }
 else {
@@ -2436,8 +1830,7 @@ this->current_line_length += TRY((this->token_length(maybe_next_underlying_token
 
 accepted_at_least_one_token = true;
 }
-return JaktInternal::ExplicitValue<void>();
-case 52 /* Comma */:{
+goto __jakt_label_192;case 52 /* Comma */:{
 accepted_at_least_one_token = true;
 if (!Jakt::formatter::Formatter::should_ignore_state(current_state)){
 Jakt::lexer::Token const replacement = Jakt::formatter::collapse<Jakt::lexer::Token>(this->replace_commas_in_enclosure.last()).value_or_lazy_evaluated([&] { return next_underlying_token; });
@@ -2445,7 +1838,7 @@ Jakt::formatter::FormattedToken const new_token = Jakt::formatter::FormattedToke
 this->current_line.push(Jakt::formatter::ReflowState(new_token,current_state,this->enclosures_to_ignore));
 this->current_line_length += TRY((this->token_length(new_token)));
 if (replacement.__jakt_init_index() == 55 /* Eol */){
-return JaktInternal::LoopBreak{};
+break;
 }
 }
 else {
@@ -2454,12 +1847,9 @@ this->current_line_length += TRY((this->token_length(maybe_next_underlying_token
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_192;default:{
 Jakt::lexer::Token const newline = Jakt::lexer::Token::Eol(JaktInternal::OptionalNone(),next_underlying_token.span());
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::formatter::FormattedToken>>>>{
-auto&& __jakt_match_variant = next_underlying_token;
+{auto&& __jakt_match_variant = next_underlying_token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 85 /* Match */:case 75 /* For */:case 108 /* While */:case 78 /* If */:case 110 /* Guard */:{
 this->in_condition_expr = true;
@@ -2471,54 +1861,43 @@ this->in_condition_expr_indented = true;
 }
 }
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_193;default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+goto __jakt_label_193;}/*switch end*/
+break;}goto __jakt_label_193; __jakt_label_193:;;
 if (this->logical_break_indent.has_value() && ((next_underlying_token.__jakt_init_index() == 59 /* And */) || (next_underlying_token.__jakt_init_index() == 90 /* Or */))){
 this->current_line.push(Jakt::formatter::ReflowState(maybe_next_underlying_token.value(),current_state,this->enclosures_to_ignore));
 this->current_line_length += TRY((this->token_length(maybe_next_underlying_token.value())));
 Jakt::formatter::FormattedToken const new_token = Jakt::formatter::FormattedToken(newline,this->logical_break_indent.value(),DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({}));
 this->current_line.push(Jakt::formatter::ReflowState(new_token,current_state,this->enclosures_to_ignore));
 this->current_line_length += TRY((this->token_length(new_token)));
-return JaktInternal::LoopBreak{};
+break;
 }
 size_t const real_line_length = JaktInternal::checked_add(JaktInternal::checked_add(this->current_line_length,projected_added_length),maybe_next_underlying_token.value().indent);
 size_t const most_desirable_breaking_point_index = this->pick_breaking_point_index();
-if (accepted_at_least_one_token && ((real_line_length > this->max_allowed_line_length) && ((!this->breakable_points_in_current_line.is_empty()) && ((this->breakable_points_in_current_line.operator[](most_desirable_breaking_point_index).point() < this->current_line.size()) && (!Jakt::formatter::Formatter::should_ignore_state(current_state)))))){
-Jakt::formatter::BreakablePoint const breakable_point = this->breakable_points_in_current_line.operator[](most_desirable_breaking_point_index);
+if (accepted_at_least_one_token && ((real_line_length > this->max_allowed_line_length) && ((!this->breakable_points_in_current_line.is_empty()) && ((this->breakable_points_in_current_line[most_desirable_breaking_point_index].point() < this->current_line.size()) && (!Jakt::formatter::Formatter::should_ignore_state(current_state)))))){
+Jakt::formatter::BreakablePoint const breakable_point = this->breakable_points_in_current_line[most_desirable_breaking_point_index];
 if (!this->replace_commas_in_enclosure.is_empty()){
-this->replace_commas_in_enclosure.operator[](JaktInternal::checked_sub(this->replace_commas_in_enclosure.size(),static_cast<size_t>(1ULL))) = newline;
+this->replace_commas_in_enclosure[JaktInternal::checked_sub(this->replace_commas_in_enclosure.size(),static_cast<size_t>(1ULL))] = newline;
 }
 size_t const point = breakable_point.point();
 if (breakable_point.__jakt_init_index() == 3 /* Logical */){
 if (!this->logical_break_indent.has_value()){
-this->logical_break_indent = this->current_line.operator[](point).token.indent;
+this->logical_break_indent = this->current_line[point].token.indent;
 if (!this->in_condition_expr_indented){
 this->logical_break_indent.value() += static_cast<size_t>(1ULL);
 }
 }
 }
-this->tokens_to_reflow = this->current_line.operator[](JaktInternal::Range<size_t>{static_cast<size_t>(point),static_cast<size_t>(9223372036854775807LL)}).to_array();
+this->tokens_to_reflow = this->current_line[JaktInternal::Range<size_t>{static_cast<size_t>(point),static_cast<size_t>(9223372036854775807LL)}].to_array();
 this->tokens_to_reflow.push(Jakt::formatter::ReflowState(maybe_next_underlying_token.value(),current_state,this->enclosures_to_ignore));
 this->fixup_tokens_to_reflow();
-Jakt::formatter::State const final_state = this->current_line.operator[](point).state;
-this->enclosures_to_ignore = this->current_line.operator[](point).enclosures_to_ignore;
-this->current_line = this->current_line.operator[](JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(point)}).to_array();
+Jakt::formatter::State const final_state = this->current_line[point].state;
+this->enclosures_to_ignore = this->current_line[point].enclosures_to_ignore;
+this->current_line = this->current_line[JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(point)}].to_array();
 this->current_line.push(Jakt::formatter::ReflowState(Jakt::formatter::FormattedToken(newline,maybe_next_underlying_token.value().indent,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({})),final_state,this->enclosures_to_ignore));
 this->current_line_length = static_cast<size_t>(0ULL);
-return JaktInternal::LoopBreak{};
+break;
 }
 accepted_at_least_one_token = true;
 this->current_line.push(Jakt::formatter::ReflowState(maybe_next_underlying_token.value(),current_state,this->enclosures_to_ignore));
@@ -2527,18 +1906,8 @@ if (this->in_condition_expr && ((next_underlying_token.__jakt_init_index() == 59
 this->breakable_points_in_current_line.push(Jakt::formatter::BreakablePoint::Logical(this->current_line.size(),this->current_line_length));
 }
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_192;}/*switch end*/
+break;}goto __jakt_label_192; __jakt_label_192:;;
 if (this->tokens_to_reflow.is_empty()){
 maybe_next_underlying_token = TRY((this->token_provider.next()));
 current_state = this->token_provider.state();
@@ -2554,20 +1923,11 @@ break;
 }
 next_underlying_token = maybe_next_underlying_token.value().token;
 }
-size_t const allowed_empty_lines_in_state = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::formatter::FormattedToken>>>>{
-auto&& __jakt_match_variant = current_state;
+size_t const allowed_empty_lines_in_state = [&]() -> size_t { auto&& __jakt_match_variant = current_state;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 14 /* TypeContext */:case 3 /* ImportList */:case 7 /* ParameterList */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 0 /* Toplevel */:return JaktInternal::ExplicitValue(static_cast<size_t>(2ULL));
-default:return JaktInternal::ExplicitValue(static_cast<size_t>(1ULL));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 14 /* TypeContext */:case 3 /* ImportList */:case 7 /* ParameterList */:return static_cast<size_t>(0ULL);case 0 /* Toplevel */:return static_cast<size_t>(2ULL);default:return static_cast<size_t>(1ULL);}/*switch end*/
+ 
+}();
 JaktInternal::DynamicArray<Jakt::formatter::ReflowState> line = this->current_line;
 this->current_line = DynamicArray<Jakt::formatter::ReflowState>::create_with({});
 this->breakable_points_in_current_line = DynamicArray<Jakt::formatter::BreakablePoint>::create_with({});
@@ -2580,9 +1940,7 @@ if (line.is_empty() || (!(line.last().value().token.token.__jakt_init_index() ==
 line.push(Jakt::formatter::ReflowState(maybe_next_underlying_token.value(),current_state,this->enclosures_to_ignore));
 }
 if (line.size() == static_cast<size_t>(1ULL)){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::formatter::FormattedToken>>>>{
-auto&& __jakt_match_variant = line.last().value().token.token;
+{auto&& __jakt_match_variant = line.last().value().token.token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 55 /* Eol */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eol;JaktInternal::Optional<ByteString> const& comment = __jakt_match_value.comment;
@@ -2598,29 +1956,22 @@ this->empty_line_count += static_cast<size_t>(1ULL);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_194;};/*case end*/
 default:{
 this->empty_line_count = static_cast<size_t>(0ULL);
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_194;}/*switch end*/
+}goto __jakt_label_194; __jakt_label_194:;;
 }
 else {
 this->empty_line_count = static_cast<size_t>(0ULL);
 }
 
 if (line.size() > static_cast<size_t>(1ULL)){
-line.operator[](JaktInternal::checked_sub(line.size(),static_cast<size_t>(2ULL))).token.trailing_trivia = DynamicArray<u8>::create_with({});
+line[JaktInternal::checked_sub(line.size(),static_cast<size_t>(2ULL))].token.trailing_trivia = DynamicArray<u8>::create_with({});
 }
-line.operator[](JaktInternal::checked_sub(line.size(),static_cast<size_t>(1ULL))).token.preceding_trivia = DynamicArray<u8>::create_with({});
-line.operator[](JaktInternal::checked_sub(line.size(),static_cast<size_t>(1ULL))).token.trailing_trivia = DynamicArray<u8>::create_with({});
+line[JaktInternal::checked_sub(line.size(),static_cast<size_t>(1ULL))].token.preceding_trivia = DynamicArray<u8>::create_with({});
+line[JaktInternal::checked_sub(line.size(),static_cast<size_t>(1ULL))].token.trailing_trivia = DynamicArray<u8>::create_with({});
 this->fixup_closing_enclosures(line);
 JaktInternal::DynamicArray<Jakt::formatter::FormattedToken> result = DynamicArray<Jakt::formatter::FormattedToken>::create_with({});
 {
@@ -2837,22 +2188,10 @@ case 3 /* Function */:break;
 }
 Jakt::formatter::Entity Jakt::formatter::Entity::from_token(Jakt::lexer::Token const& token) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::formatter::Entity, Jakt::formatter::Entity>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 99 /* Struct */:case 65 /* Class */:case 113 /* Trait */:return JaktInternal::ExplicitValue(Jakt::formatter::Entity::Struct());
-case 71 /* Enum */:return JaktInternal::ExplicitValue(Jakt::formatter::Entity::Enum());
-case 88 /* Namespace */:return JaktInternal::ExplicitValue(Jakt::formatter::Entity::Namespace());
-case 77 /* Comptime */:case 76 /* Fn */:return JaktInternal::ExplicitValue(Jakt::formatter::Entity::Function(false,false));
-default:return JaktInternal::ExplicitValue(Jakt::formatter::Entity::Struct());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 99 /* Struct */:case 65 /* Class */:case 113 /* Trait */:return Jakt::formatter::Entity::Struct();case 71 /* Enum */:return Jakt::formatter::Entity::Enum();case 88 /* Namespace */:return Jakt::formatter::Entity::Namespace();case 77 /* Comptime */:case 76 /* Fn */:return Jakt::formatter::Entity::Function(false,false);default:return Jakt::formatter::Entity::Struct();}/*switch end*/
+}
 }
 }
 
@@ -3744,40 +3083,17 @@ case 15 /* FunctionTypeContext */:break;
 }
 ByteString Jakt::formatter::State::name() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ByteString>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Toplevel */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("toplevel"sv));
-case 1 /* Extern */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("extern"sv));
-case 2 /* Import */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("import"sv));
-case 3 /* ImportList */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("import list"sv));
-case 5 /* Implements */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("implements"sv));
-case 4 /* EntityDeclaration */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("entity declaration"sv));
-case 6 /* CaptureList */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("capture list"sv));
-case 7 /* ParameterList */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("parameter list"sv));
-case 8 /* RestrictionList */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("restriction list"sv));
-case 9 /* EntityDefinition */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("entity definition"sv));
-case 10 /* StatementContext */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("statement context"sv));
-case 11 /* MatchPattern */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("match pattern"sv));
-case 12 /* VariableDeclaration */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("variable declaration"sv));
-case 13 /* GenericCallTypeParams */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("generic call type params"sv));
-case 14 /* TypeContext */: {
+case 0 /* Toplevel */:return ByteString::from_utf8_without_validation("toplevel"sv);case 1 /* Extern */:return ByteString::from_utf8_without_validation("extern"sv);case 2 /* Import */:return ByteString::from_utf8_without_validation("import"sv);case 3 /* ImportList */:return ByteString::from_utf8_without_validation("import list"sv);case 5 /* Implements */:return ByteString::from_utf8_without_validation("implements"sv);case 4 /* EntityDeclaration */:return ByteString::from_utf8_without_validation("entity declaration"sv);case 6 /* CaptureList */:return ByteString::from_utf8_without_validation("capture list"sv);case 7 /* ParameterList */:return ByteString::from_utf8_without_validation("parameter list"sv);case 8 /* RestrictionList */:return ByteString::from_utf8_without_validation("restriction list"sv);case 9 /* EntityDefinition */:return ByteString::from_utf8_without_validation("entity definition"sv);case 10 /* StatementContext */:return ByteString::from_utf8_without_validation("statement context"sv);case 11 /* MatchPattern */:return ByteString::from_utf8_without_validation("match pattern"sv);case 12 /* VariableDeclaration */:return ByteString::from_utf8_without_validation("variable declaration"sv);case 13 /* GenericCallTypeParams */:return ByteString::from_utf8_without_validation("generic call type params"sv);case 14 /* TypeContext */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeContext;size_t const& open_parens = __jakt_match_value.open_parens;
 size_t const& open_curlies = __jakt_match_value.open_curlies;
 size_t const& open_squares = __jakt_match_value.open_squares;
 size_t const& open_angles = __jakt_match_value.open_angles;
 bool const& seen_start = __jakt_match_value.seen_start;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("type context (p{} c{} s{} a{} s:{})"sv),open_parens,open_curlies,open_squares,open_angles,seen_start));
-};/*case end*/
-case 15 /* FunctionTypeContext */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("function type context"sv));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return __jakt_format(StringView::from_string_literal("type context (p{} c{} s{} a{} s:{})"sv),open_parens,open_curlies,open_squares,open_angles,seen_start);};/*case end*/
+case 15 /* FunctionTypeContext */:return ByteString::from_utf8_without_validation("function type context"sv);default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
@@ -4014,65 +3330,43 @@ case 3 /* Logical */:break;
 }
 size_t Jakt::formatter::BreakablePoint::point() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, size_t>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Paren */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Paren;size_t const& point = __jakt_match_value.point;
-return JaktInternal::ExplicitValue(point);
-};/*case end*/
+return point;};/*case end*/
 case 1 /* Curly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Curly;size_t const& point = __jakt_match_value.point;
-return JaktInternal::ExplicitValue(point);
-};/*case end*/
+return point;};/*case end*/
 case 2 /* Square */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Square;size_t const& point = __jakt_match_value.point;
-return JaktInternal::ExplicitValue(point);
-};/*case end*/
+return point;};/*case end*/
 case 3 /* Logical */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Logical;size_t const& point = __jakt_match_value.point;
-return JaktInternal::ExplicitValue(point);
-};/*case end*/
+return point;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 size_t Jakt::formatter::BreakablePoint::length() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, size_t>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Paren */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Paren;size_t const& length = __jakt_match_value.length;
-return JaktInternal::ExplicitValue(length);
-};/*case end*/
+return length;};/*case end*/
 case 1 /* Curly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Curly;size_t const& length = __jakt_match_value.length;
-return JaktInternal::ExplicitValue(length);
-};/*case end*/
+return length;};/*case end*/
 case 2 /* Square */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Square;size_t const& length = __jakt_match_value.length;
-return JaktInternal::ExplicitValue(length);
-};/*case end*/
+return length;};/*case end*/
 case 3 /* Logical */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Logical;size_t const& length = __jakt_match_value.length;
-return JaktInternal::ExplicitValue(length);
-};/*case end*/
+return length;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 

--- a/bootstrap/stage0/formatter_specializations.cpp
+++ b/bootstrap/stage0/formatter_specializations.cpp
@@ -7,17 +7,9 @@ template<> JaktInternal::Optional<Jakt::lexer::Token> collapse<Jakt::lexer::Toke
 template<>
 JaktInternal::Optional<Jakt::lexer::Token> collapse<Jakt::lexer::Token>(JaktInternal::Optional<JaktInternal::Optional<Jakt::lexer::Token>> const x) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::lexer::Token>,JaktInternal::Optional<Jakt::lexer::Token>> {
-auto __jakt_enum_value = (x.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(x.value());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = x.has_value();
+if (__jakt_enum_value) {return x.value();}else if (!__jakt_enum_value) {return JaktInternal::OptionalNone();}VERIFY_NOT_REACHED();
+}
 }
 }
 }

--- a/bootstrap/stage0/git.cpp
+++ b/bootstrap/stage0/git.cpp
@@ -6,7 +6,7 @@ namespace Jakt {
 namespace git {
 ErrorOr<ByteString> commit_hash() {
 {
-ByteString const hash = ByteString::from_utf8_without_validation("d1fb6cc0e91e3f0164a412b5cdebe7183ad798f5"sv);
+ByteString const hash = ByteString::from_utf8_without_validation("4fbe58fe99988156bf36ca4e8db4312a29d2c471"sv);
 return hash;
 }
 }

--- a/bootstrap/stage0/ide.cpp
+++ b/bootstrap/stage0/ide.cpp
@@ -84,9 +84,7 @@ Jakt::ide::JaktSymbol record_to_symbol(Jakt::parser::ParsedRecord const record) 
 {
 JaktInternal::DynamicArray<Jakt::ide::JaktSymbol> children = DynamicArray<Jakt::ide::JaktSymbol>::create_with({});
 Jakt::utility::Span record_span = record.name_span;
-ByteString const record_kind = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, Jakt::ide::JaktSymbol>{
-auto&& __jakt_match_variant = record.record_type;
+ByteString const record_kind = [&]() -> ByteString { auto&& __jakt_match_variant = record.record_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::parser::ParsedField> const& fields = __jakt_match_value.fields;
@@ -106,7 +104,7 @@ children.push(Jakt::ide::JaktSymbol(field.var_decl.name,JaktInternal::OptionalNo
 }
 }
 
-return JaktInternal::ExplicitValue<ByteString>(ByteString::from_utf8_without_validation("struct"sv));
+return ByteString::from_utf8_without_validation("struct"sv);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -128,7 +126,7 @@ children.push(Jakt::ide::JaktSymbol(field.var_decl.name,JaktInternal::OptionalNo
 }
 }
 
-return JaktInternal::ExplicitValue<ByteString>(ByteString::from_utf8_without_validation("class"sv));
+return ByteString::from_utf8_without_validation("class"sv);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -150,7 +148,7 @@ children.push(Jakt::ide::JaktSymbol(variant.name,JaktInternal::OptionalNone(),By
 }
 }
 
-return JaktInternal::ExplicitValue<ByteString>(ByteString::from_utf8_without_validation("enum"sv));
+return ByteString::from_utf8_without_validation("enum"sv);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -196,18 +194,13 @@ children.push(Jakt::ide::JaktSymbol(variant.name,JaktInternal::OptionalNone(),By
 }
 }
 
-return JaktInternal::ExplicitValue<ByteString>(ByteString::from_utf8_without_validation("enum"sv));
+return ByteString::from_utf8_without_validation("enum"sv);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-case 4 /* Garbage */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("garbage"sv));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 4 /* Garbage */:return ByteString::from_utf8_without_validation("garbage"sv);default: VERIFY_NOT_REACHED();}/*switch end*/
+ 
+}();
 {
 JaktInternal::ArrayIterator<Jakt::parser::ParsedMethod> _magic = record.methods.iterator();
 for (;;){
@@ -255,34 +248,22 @@ ErrorOr<Jakt::utility::Span> find_definition_in_program(NonnullRefPtr<Jakt::type
 {
 JaktInternal::Optional<Jakt::ide::Usage> const result = TRY((Jakt::ide::find_span_in_program(program,span)));
 if (result.has_value()){
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::utility::Span, ErrorOr<Jakt::utility::Span>>{
-auto&& __jakt_match_variant = result.value();
+{auto&& __jakt_match_variant = result.value();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Variable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Variable;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 1 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::ids::FunctionId const& function_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_function(function_id)->name_span);
-};/*case end*/
+return program->get_function(function_id)->name_span;};/*case end*/
 case 2 /* Typename */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typename;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_type_definition_for_type_id(program,type_id,span))));
-};/*case end*/
-case 3 /* NameSet */:return JaktInternal::ExplicitValue(span);
-case 4 /* EnumVariant */: {
+return Jakt::ide::find_type_definition_for_type_id(program,type_id,span);};/*case end*/
+case 3 /* NameSet */:return span;case 4 /* EnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 else {
 return span;
@@ -300,94 +281,56 @@ Jakt::ids::StructId const range_struct_id = TRY((program->find_struct_in_prelude
 Jakt::ids::StructId const set_struct_id = TRY((program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Set"sv))));
 Jakt::ids::StructId const tuple_struct_id = TRY((program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Tuple"sv))));
 Jakt::ids::StructId const weak_ptr_struct_id = TRY((program->find_struct_in_prelude(ByteString::from_utf8_without_validation("WeakPtr"sv))));
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::utility::Span, ErrorOr<Jakt::utility::Span>>{
-auto&& __jakt_match_variant = *program->get_type(type_id);
+{auto&& __jakt_match_variant = *program->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 17 /* Never */:return JaktInternal::ExplicitValue(span);
-case 10 /* F32 */:return JaktInternal::ExplicitValue(span);
-case 11 /* F64 */:return JaktInternal::ExplicitValue(span);
-case 6 /* I8 */:return JaktInternal::ExplicitValue(span);
-case 7 /* I16 */:return JaktInternal::ExplicitValue(span);
-case 8 /* I32 */:return JaktInternal::ExplicitValue(span);
-case 9 /* I64 */:return JaktInternal::ExplicitValue(span);
-case 2 /* U8 */:return JaktInternal::ExplicitValue(span);
-case 3 /* U16 */:return JaktInternal::ExplicitValue(span);
-case 4 /* U32 */:return JaktInternal::ExplicitValue(span);
-case 5 /* U64 */:return JaktInternal::ExplicitValue(span);
-case 12 /* Usize */:return JaktInternal::ExplicitValue(span);
-case 14 /* CChar */:return JaktInternal::ExplicitValue(span);
-case 15 /* CInt */:return JaktInternal::ExplicitValue(span);
-case 1 /* Bool */:return JaktInternal::ExplicitValue(span);
-case 0 /* Void */:return JaktInternal::ExplicitValue(span);
-case 16 /* Unknown */:return JaktInternal::ExplicitValue(span);
-case 13 /* JaktString */:return JaktInternal::ExplicitValue(span);
-case 29 /* Function */:return JaktInternal::ExplicitValue(span);
-case 26 /* Trait */: {
+case 17 /* Never */:return span;case 10 /* F32 */:return span;case 11 /* F64 */:return span;case 6 /* I8 */:return span;case 7 /* I16 */:return span;case 8 /* I32 */:return span;case 9 /* I64 */:return span;case 2 /* U8 */:return span;case 3 /* U16 */:return span;case 4 /* U32 */:return span;case 5 /* U64 */:return span;case 12 /* Usize */:return span;case 14 /* CChar */:return span;case 15 /* CInt */:return span;case 1 /* Bool */:return span;case 0 /* Void */:return span;case 16 /* Unknown */:return span;case 13 /* JaktString */:return span;case 29 /* Function */:return span;case 26 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_trait(id)->name_span);
-};/*case end*/
-case 30 /* Self */:return JaktInternal::ExplicitValue(span);
-case 19 /* Dependent */:return JaktInternal::ExplicitValue(span);
-case 31 /* Const */: {
+return program->get_trait(id)->name_span;};/*case end*/
+case 30 /* Self */:return span;case 19 /* Dependent */:return span;case 31 /* Const */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Const;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value.span);
-};/*case end*/
+return value.span;};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& struct_id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
 {
 Jakt::utility::Span output = span;
 if (((((struct_id.equals(array_struct_id) || struct_id.equals(optional_struct_id)) || struct_id.equals(range_struct_id)) || struct_id.equals(set_struct_id)) || struct_id.equals(tuple_struct_id)) || struct_id.equals(weak_ptr_struct_id)){
-output = TRY((Jakt::ide::find_type_definition_for_type_id(program,args.operator[](static_cast<i64>(0LL)),span)));
+output = TRY((Jakt::ide::find_type_definition_for_type_id(program,args[static_cast<i64>(0LL)],span)));
 }
 else if (struct_id.equals(dictionary_struct_id)){
-output = TRY((Jakt::ide::find_type_definition_for_type_id(program,args.operator[](static_cast<i64>(1LL)),span)));
+output = TRY((Jakt::ide::find_type_definition_for_type_id(program,args[static_cast<i64>(1LL)],span)));
 }
 else {
 output = program->get_struct(struct_id).name_span;
 }
 
-return JaktInternal::ExplicitValue<Jakt::utility::Span>(output);
+return output;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_struct(struct_id).name_span);
-};/*case end*/
+return program->get_struct(struct_id).name_span;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(program->get_enum(id).name_span);
-};/*case end*/
+return program->get_enum(id).name_span;};/*case end*/
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(program->get_trait(id)->name_span);
-};/*case end*/
+return program->get_trait(id)->name_span;};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_enum(id).name_span);
-};/*case end*/
+return program->get_enum(id).name_span;};/*case end*/
 case 25 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_type_definition_for_type_id(program,type_id,span))));
-};/*case end*/
-case 18 /* TypeVariable */:return JaktInternal::ExplicitValue(span);
-case 27 /* Reference */: {
+return Jakt::ide::find_type_definition_for_type_id(program,type_id,span);};/*case end*/
+case 18 /* TypeVariable */:return span;case 27 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_type_definition_for_type_id(program,type_id,span))));
-};/*case end*/
+return Jakt::ide::find_type_definition_for_type_id(program,type_id,span);};/*case end*/
 case 28 /* MutableReference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MutableReference;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_type_definition_for_type_id(program,type_id,span))));
-};/*case end*/
+return Jakt::ide::find_type_definition_for_type_id(program,type_id,span);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -395,44 +338,35 @@ ErrorOr<Jakt::utility::Span> find_type_definition_in_program(NonnullRefPtr<Jakt:
 {
 JaktInternal::Optional<Jakt::ide::Usage> const result = TRY((Jakt::ide::find_span_in_program(program,span)));
 if (result.has_value()){
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::utility::Span, ErrorOr<Jakt::utility::Span>>{
-auto&& __jakt_match_variant = result.value();
+{auto&& __jakt_match_variant = result.value();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Variable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Variable;Jakt::utility::Span const& span = __jakt_match_value.span;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
-return JaktInternal::ExplicitValue<Jakt::utility::Span>(TRY((Jakt::ide::find_type_definition_for_type_id(program,type_id,span))));
+return Jakt::ide::find_type_definition_for_type_id(program,type_id,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 1 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::ids::FunctionId const& function_id = __jakt_match_value.value;
 {
-return JaktInternal::ExplicitValue<Jakt::utility::Span>(program->get_function(function_id)->name_span);
+return program->get_function(function_id)->name_span;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 2 /* Typename */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typename;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
 {
-return JaktInternal::ExplicitValue<Jakt::utility::Span>(TRY((Jakt::ide::find_type_definition_for_type_id(program,type_id,span))));
+return Jakt::ide::find_type_definition_for_type_id(program,type_id,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-case 3 /* NameSet */:return JaktInternal::ExplicitValue(span);
-case 4 /* EnumVariant */: {
+case 3 /* NameSet */:return span;case 4 /* EnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 else {
 return span;
@@ -445,9 +379,7 @@ ErrorOr<JaktInternal::Optional<ByteString>> find_typename_in_program(NonnullRefP
 {
 JaktInternal::Optional<Jakt::ide::Usage> const result = TRY((Jakt::ide::find_span_in_program(program,span)));
 if (result.has_value()){
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>, ErrorOr<JaktInternal::Optional<ByteString>>>{
-auto&& __jakt_match_variant = result.value();
+{auto&& __jakt_match_variant = result.value();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Variable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Variable;ByteString const& name = __jakt_match_value.name;
@@ -458,7 +390,7 @@ Jakt::ide::VarVisibility const& visibility = __jakt_match_value.visibility;
 JaktInternal::Optional<Jakt::ids::TypeId> const& struct_type_id = __jakt_match_value.struct_type_id;
 {
 ByteString const result = TRY((Jakt::ide::get_var_signature(program,name,type_id,mutability,var_type,visibility,struct_type_id)));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<ByteString>>(static_cast<JaktInternal::Optional<ByteString>>(result));
+return static_cast<JaktInternal::Optional<ByteString>>(result);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -466,7 +398,7 @@ case 1 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::ids::FunctionId const& function_id = __jakt_match_value.value;
 {
 ByteString const result = TRY((Jakt::ide::get_function_signature(program,function_id)));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<ByteString>>(static_cast<JaktInternal::Optional<ByteString>>(result));
+return static_cast<JaktInternal::Optional<ByteString>>(result);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -474,7 +406,7 @@ case 2 /* Typename */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typename;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
 {
 ByteString const result = TRY((Jakt::ide::get_type_signature(program,type_id)));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<ByteString>>(static_cast<JaktInternal::Optional<ByteString>>(result));
+return static_cast<JaktInternal::Optional<ByteString>>(result);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -513,7 +445,7 @@ self = (self + rhs);
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Optional<ByteString>>(static_cast<JaktInternal::Optional<ByteString>>(output));
+return static_cast<JaktInternal::Optional<ByteString>>(output);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -524,17 +456,12 @@ JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString
 JaktInternal::Optional<Jakt::types::NumberConstant> const& number_constant = __jakt_match_value.number_constant;
 {
 ByteString const result = TRY((Jakt::ide::get_enum_variant_signature(program,name,type_id,variants,number_constant)));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<ByteString>>(static_cast<JaktInternal::Optional<ByteString>>(result));
+return static_cast<JaktInternal::Optional<ByteString>>(result);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 else {
 return JaktInternal::OptionalNone();
@@ -547,9 +474,7 @@ ErrorOr<JaktInternal::DynamicArray<ByteString>> completions_for_type_id(NonnullR
 {
 JaktInternal::Set<ByteString> output = Set<ByteString>::create_with_values({});
 NonnullRefPtr<typename Jakt::types::Type> const ty = program->get_type(type_id);
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::DynamicArray<ByteString>>>{
-auto&& __jakt_match_variant = *ty;
+{auto&& __jakt_match_variant = *ty;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
@@ -572,16 +497,15 @@ output.add(entry);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_195;};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& struct_id = __jakt_match_value.id;
 {
 JaktInternal::DynamicArray<Jakt::types::CheckedStruct> structs = DynamicArray<Jakt::types::CheckedStruct>::create_with({program->get_struct(struct_id)});
 for (;;){
-JaktInternal::Optional<Jakt::ids::StructId> __jakt_tmp421 = structs.last().value().super_struct_id;
-if (__jakt_tmp421.has_value()){
-Jakt::ids::StructId const x = __jakt_tmp421.value();
+JaktInternal::Optional<Jakt::ids::StructId> __jakt_tmp285 = structs.last().value().super_struct_id;
+if (__jakt_tmp285.has_value()){
+Jakt::ids::StructId const x = __jakt_tmp285.value();
 structs.push(program->get_struct(x));
 }
 else {
@@ -636,16 +560,15 @@ output.add(entry);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_195;};/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
 {
 JaktInternal::DynamicArray<Jakt::types::CheckedStruct> structs = DynamicArray<Jakt::types::CheckedStruct>::create_with({program->get_struct(struct_id)});
 for (;;){
-JaktInternal::Optional<Jakt::ids::StructId> __jakt_tmp421 = structs.last().value().super_struct_id;
-if (__jakt_tmp421.has_value()){
-Jakt::ids::StructId const x = __jakt_tmp421.value();
+JaktInternal::Optional<Jakt::ids::StructId> __jakt_tmp285 = structs.last().value().super_struct_id;
+if (__jakt_tmp285.has_value()){
+Jakt::ids::StructId const x = __jakt_tmp285.value();
 structs.push(program->get_struct(x));
 }
 else {
@@ -700,18 +623,11 @@ output.add(entry);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_195;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_195;}/*switch end*/
+}goto __jakt_label_195; __jakt_label_195:;;
 JaktInternal::DynamicArray<ByteString> result = DynamicArray<ByteString>::create_with({});
 {
 JaktInternal::SetIterator<ByteString> _magic = output.iterator();
@@ -827,14 +743,12 @@ ErrorOr<JaktInternal::DynamicArray<ByteString>> find_dot_completions(NonnullRefP
 {
 JaktInternal::Optional<Jakt::ide::Usage> const result = TRY((Jakt::ide::find_span_in_program(program,span)));
 if (result.has_value()){
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<ByteString>, ErrorOr<JaktInternal::DynamicArray<ByteString>>>{
-auto&& __jakt_match_variant = result.value();
+{auto&& __jakt_match_variant = result.value();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Variable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Variable;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
-return JaktInternal::ExplicitValue<JaktInternal::DynamicArray<ByteString>>(TRY((Jakt::ide::completions_for_type_id(program,type_id))));
+return Jakt::ide::completions_for_type_id(program,type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -842,18 +756,12 @@ case 1 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::ids::FunctionId const& function_id = __jakt_match_value.value;
 {
 Jakt::ids::TypeId const result_type_id = program->get_function(function_id)->return_type_id;
-return JaktInternal::ExplicitValue<JaktInternal::DynamicArray<ByteString>>(TRY((Jakt::ide::completions_for_type_id(program,result_type_id))));
+return Jakt::ide::completions_for_type_id(program,result_type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return DynamicArray<ByteString>::create_with({});}/*switch end*/
+}
 }
 else {
 return DynamicArray<ByteString>::create_with({});
@@ -1016,9 +924,7 @@ break;
 }
 Jakt::types::CheckedEnumVariant variant = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>>>{
-auto&& __jakt_match_variant = variant;
+{auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;ByteString const& name = __jakt_match_value.name;
@@ -1047,8 +953,7 @@ if (variant_span.contains(span)){
 return static_cast<JaktInternal::Optional<Jakt::ide::Usage>>(Jakt::ide::Usage::EnumVariant(span,name,checked_enum.type_id,DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::ids::TypeId>>::create_with({}),JaktInternal::OptionalNone()));
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_196;};/*case end*/
 case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;ByteString const& name = __jakt_match_value.name;
 Jakt::utility::Span const& variant_span = __jakt_match_value.span;
@@ -1057,8 +962,7 @@ if (variant_span.contains(span)){
 return static_cast<JaktInternal::Optional<Jakt::ide::Usage>>(Jakt::ide::Usage::EnumVariant(variant_span,name,checked_enum.type_id,Jakt::ide::enum_variant_fields(program,variant),JaktInternal::OptionalNone()));
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_196;};/*case end*/
 case 0 /* Untyped */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Untyped;ByteString const& name = __jakt_match_value.name;
 Jakt::utility::Span const& variant_span = __jakt_match_value.span;
@@ -1067,8 +971,7 @@ if (variant_span.contains(span)){
 return static_cast<JaktInternal::Optional<Jakt::ide::Usage>>(Jakt::ide::Usage::EnumVariant(variant_span,name,checked_enum.type_id,DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::ids::TypeId>>::create_with({}),JaktInternal::OptionalNone()));
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_196;};/*case end*/
 case 2 /* WithValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.WithValue;ByteString const& name = __jakt_match_value.name;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
@@ -1078,19 +981,9 @@ if (variant_span.contains(span)){
 return static_cast<JaktInternal::Optional<Jakt::ide::Usage>>(Jakt::ide::Usage::EnumVariant(variant_span,name,checked_enum.type_id,Jakt::ide::enum_variant_fields(program,variant),expr->to_number_constant(program)));
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_196;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+break;}goto __jakt_label_196; __jakt_label_196:;;
 }
 
 }
@@ -1182,22 +1075,17 @@ return JaktInternal::OptionalNone();
 ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>> find_span_in_statement(NonnullRefPtr<Jakt::types::CheckedProgram> const program,NonnullRefPtr<typename Jakt::types::CheckedStatement> const statement,Jakt::utility::Span const span) {
 {
 JaktInternal::Optional<Jakt::ide::Usage> const none = JaktInternal::OptionalNone();
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ide::Usage>, ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>>>{
-auto&& __jakt_match_variant = *statement;
+{auto&& __jakt_match_variant = *statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_block(program,block,span))));
-};/*case end*/
+return Jakt::ide::find_span_in_block(program,block,span);};/*case end*/
 case 1 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;NonnullRefPtr<typename Jakt::types::CheckedStatement> const& statement = __jakt_match_value.statement;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_statement(program,statement,span))));
-};/*case end*/
+return Jakt::ide::find_span_in_statement(program,statement,span);};/*case end*/
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_expression(program,expr,span))));
-};/*case end*/
+return Jakt::ide::find_span_in_expression(program,expr,span);};/*case end*/
 case 4 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& condition = __jakt_match_value.condition;
 Jakt::types::CheckedBlock const& then_block = __jakt_match_value.then_block;
@@ -1214,36 +1102,25 @@ return found;
 if (else_statement.has_value()){
 return Jakt::ide::find_span_in_statement(program,else_statement.value(),span);
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(none);
+return none;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 13 /* InlineCpp */:{
 JaktInternal::Optional<Jakt::ide::Usage> const output = JaktInternal::OptionalNone();
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(output);
+return output;
 }
 VERIFY_NOT_REACHED();
 case 6 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_block(program,block,span))));
-};/*case end*/
+return Jakt::ide::find_span_in_block(program,block,span);};/*case end*/
 case 8 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ide::Usage>,ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>>> {
-auto __jakt_enum_value = (val.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_expression(program,val.value(),span))));
-}else {return JaktInternal::ExplicitValue(none);
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+{auto __jakt_enum_value = val.has_value();
+if (__jakt_enum_value) {return Jakt::ide::find_span_in_expression(program,val.value(),span);}else {return none;}}};/*case end*/
 case 11 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_expression(program,expr,span))));
-};/*case end*/
+return Jakt::ide::find_span_in_expression(program,expr,span);};/*case end*/
 case 3 /* VarDecl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.VarDecl;Jakt::ids::VarId const& var_id = __jakt_match_value.var_id;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const& init = __jakt_match_value.init;
@@ -1260,20 +1137,13 @@ return static_cast<JaktInternal::Optional<Jakt::ide::Usage>>(Jakt::ide::Usage::T
 }
 }
 if (checked_var->definition_span.contains(span)){
-Jakt::ide::Mutability const mutability = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ide::Mutability,ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>>> {
-auto __jakt_enum_value = (checked_var->is_mutable);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::ide::Mutability::Mutable());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::ide::Mutability::Immutable());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+Jakt::ide::Mutability const mutability = [&]() -> Jakt::ide::Mutability { auto __jakt_enum_value = checked_var->is_mutable;
+if (__jakt_enum_value) {return Jakt::ide::Mutability::Mutable();}else if (!__jakt_enum_value) {return Jakt::ide::Mutability::Immutable();}VERIFY_NOT_REACHED();
+ 
+}();
 return static_cast<JaktInternal::Optional<Jakt::ide::Usage>>(Jakt::ide::Usage::Variable(checked_var->definition_span,checked_var->name,checked_var->type_id,mutability,Jakt::ide::VarType::Variable(),Jakt::ide::VarVisibility::DoesNotApply(),JaktInternal::OptionalNone()));
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(none);
+return none;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1285,7 +1155,7 @@ JaktInternal::Optional<Jakt::ide::Usage> const found = TRY((Jakt::ide::find_span
 if (found.has_value()){
 return found;
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(TRY((Jakt::ide::find_span_in_block(program,block,span))));
+return Jakt::ide::find_span_in_block(program,block,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1311,41 +1181,24 @@ return found;
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(TRY((Jakt::ide::find_span_in_statement(program,var_decl,span))));
+return Jakt::ide::find_span_in_statement(program,var_decl,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 12 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ide::Usage>,ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>>> {
-auto __jakt_enum_value = (expr.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_expression(program,expr.value(),span))));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(none);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-case 9 /* Break */:case 10 /* Continue */:case 14 /* Garbage */:return JaktInternal::ExplicitValue(none);
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = expr.has_value();
+if (__jakt_enum_value) {return Jakt::ide::find_span_in_expression(program,expr.value(),span);}else if (!__jakt_enum_value) {return none;}VERIFY_NOT_REACHED();
+}};/*case end*/
+case 9 /* Break */:case 10 /* Continue */:case 14 /* Garbage */:return none;default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
 ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>> find_span_in_expression(NonnullRefPtr<Jakt::types::CheckedProgram> const program,NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr,Jakt::utility::Span const span) {
 {
 JaktInternal::Optional<Jakt::ide::Usage> const none = JaktInternal::OptionalNone();
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ide::Usage>, ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>>>{
-auto&& __jakt_match_variant = *expr;
+{auto&& __jakt_match_variant = *expr;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* BinaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.BinaryOp;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& lhs = __jakt_match_value.lhs;
@@ -1356,7 +1209,7 @@ JaktInternal::Optional<Jakt::ide::Usage> const found = TRY((Jakt::ide::find_span
 if (found.has_value()){
 return found;
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(TRY((Jakt::ide::find_span_in_expression(program,rhs,span))));
+return Jakt::ide::find_span_in_expression(program,rhs,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1385,14 +1238,13 @@ return found;
 if (repeat.has_value()){
 return Jakt::ide::find_span_in_expression(program,repeat.value(),span);
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(none);
+return none;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 28 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_block(program,block,span))));
-};/*case end*/
+return Jakt::ide::find_span_in_block(program,block,span);};/*case end*/
 case 21 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::types::CheckedCall const& call = __jakt_match_value.call;
 Jakt::utility::Span const& call_span = __jakt_match_value.span;
@@ -1422,7 +1274,7 @@ return found;
 if (call.function_id.has_value() && call_span.contains(span)){
 return static_cast<JaktInternal::Optional<Jakt::ide::Usage>>(Jakt::ide::Usage::Call(call.function_id.value()));
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(none);
+return none;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1455,7 +1307,7 @@ return found;
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(none);
+return none;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1471,7 +1323,7 @@ found = TRY((Jakt::ide::find_span_in_expression(program,index,span)));
 if (found.has_value()){
 return found;
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(none);
+return none;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1491,9 +1343,9 @@ JaktInternal::Optional<Jakt::ids::TypeId> result_type = JaktInternal::OptionalNo
 if (!known_type_id.equals(Jakt::types::unknown_type_id())){
 result_type = static_cast<JaktInternal::Optional<Jakt::ids::TypeId>>(known_type_id);
 }
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp422 = program->get_type(type_id);
-if (__jakt_tmp422->__jakt_init_index() == 23 /* Struct */){
-Jakt::ids::StructId const struct_id = __jakt_tmp422->as.Struct.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp286 = program->get_type(type_id);
+if (__jakt_tmp286->__jakt_init_index() == 23 /* Struct */){
+Jakt::ids::StructId const struct_id = __jakt_tmp286->as.Struct.value;
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<Jakt::types::CheckedField>> _magic = program->get_struct(struct_id).fields.iterator();
 for (;;){
@@ -1511,24 +1363,11 @@ return !(self == rhs);
 (name,var->name)){
 continue;
 }
-return Jakt::ide::Usage::Variable(var->definition_span,name,result_type.value_or_lazy_evaluated([&] { return var->type_id; }),Jakt::ide::Mutability::DoesNotApply(),Jakt::ide::VarType::Field(),({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ide::VarVisibility, ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>>>{
-auto&& __jakt_match_variant = var->visibility;
+return Jakt::ide::Usage::Variable(var->definition_span,name,result_type.value_or_lazy_evaluated([&] { return var->type_id; }),Jakt::ide::Mutability::DoesNotApply(),Jakt::ide::VarType::Field(),[&]() -> Jakt::ide::VarVisibility { auto&& __jakt_match_variant = var->visibility;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Public */:return JaktInternal::ExplicitValue(Jakt::ide::VarVisibility::Public());
-case 1 /* Private */:return JaktInternal::ExplicitValue(Jakt::ide::VarVisibility::Private());
-case 2 /* Restricted */:return JaktInternal::ExplicitValue(Jakt::ide::VarVisibility::Restricted());
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-}),type_id);
+case 0 /* Public */:return Jakt::ide::VarVisibility::Public();case 1 /* Private */:return Jakt::ide::VarVisibility::Private();case 2 /* Restricted */:return Jakt::ide::VarVisibility::Restricted();default: VERIFY_NOT_REACHED();}/*switch end*/
+ 
+}(),type_id);
 }
 
 }
@@ -1536,7 +1375,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 
 }
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(none);
+return none;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1548,7 +1387,7 @@ JaktInternal::Optional<Jakt::ide::Usage> const found = TRY((Jakt::ide::find_span
 if (found.has_value()){
 return found;
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(TRY((Jakt::ide::find_span_in_expression(program,index,span))));
+return Jakt::ide::find_span_in_expression(program,index,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1586,35 +1425,22 @@ auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;ByteString const
 JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> const& args = __jakt_match_value.args;
 Jakt::ids::TypeId const& subject_type_id = __jakt_match_value.subject_type_id;
 size_t const& index = __jakt_match_value.index;
-Jakt::ids::ScopeId const& scope_id = __jakt_match_value.scope_id;
-Jakt::utility::Span const& marker_span = __jakt_match_value.marker_span;
+Jakt::utility::Span const& marker_span = __jakt_match_variant.common.init_common.marker_span;
 {
 if (marker_span.contains(span)){
 return static_cast<JaktInternal::Optional<Jakt::ide::Usage>>(Jakt::ide::get_enum_variant_usage_from_type_id_and_name(program,subject_type_id,name));
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ide::Usage>, ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>>>{
-auto&& __jakt_match_variant = body;
+return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(TRY(([&]() -> ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>> { auto&& __jakt_match_variant = body;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& block = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_block(program,block,span))));
-};/*case end*/
+return Jakt::ide::find_span_in_block(program,block,span);};/*case end*/
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_expression(program,expr,span))));
-};/*case end*/
+return Jakt::ide::find_span_in_expression(program,expr,span);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
+ 
+}())));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1625,41 +1451,25 @@ JaktInternal::Optional<Jakt::ide::Usage> const found = TRY((Jakt::ide::find_span
 if (found.has_value()){
 return found;
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ide::Usage>, ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>>>{
-auto&& __jakt_match_variant = body;
+return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(TRY(([&]() -> ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>> { auto&& __jakt_match_variant = body;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& block = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_block(program,block,span))));
-};/*case end*/
+return Jakt::ide::find_span_in_block(program,block,span);};/*case end*/
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_expression(program,expr,span))));
-};/*case end*/
+return Jakt::ide::find_span_in_expression(program,expr,span);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
+ 
+}())));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 3 /* CatchAll */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;Jakt::utility::Span const& marker_span = __jakt_match_value.marker_span;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ide::Usage>,ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>>> {
-auto __jakt_enum_value = (marker_span.contains(span));
+auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;Jakt::utility::Span const& marker_span = __jakt_match_variant.common.init_common.marker_span;
+return JaktInternal::ExplicitValue(TRY(([&]() -> ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>> { auto __jakt_enum_value = marker_span.contains(span);
 if (__jakt_enum_value) {{
-JaktInternal::Set<ByteString> const all_cases = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Set<ByteString>, ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>>>{
-auto&& __jakt_match_variant = *program->get_type(type_id);
+JaktInternal::Set<ByteString> const all_cases = TRY(([&]() -> ErrorOr<JaktInternal::Set<ByteString>> { auto&& __jakt_match_variant = *program->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
@@ -1681,7 +1491,7 @@ names.add(variant.name());
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Set<ByteString>>(names);
+return names;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1705,25 +1515,17 @@ names.add(variant.name());
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Set<ByteString>>(names);
+return names;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
-return JaktInternal::ExplicitValue<JaktInternal::Set<ByteString>>(Set<ByteString>::create_with_values({__jakt_format(StringView::from_string_literal("else ({})"sv),TRY((program->type_name(type_id,false))))}));
+return Set<ByteString>::create_with_values({__jakt_format(StringView::from_string_literal("else ({})"sv),TRY((program->type_name(type_id,false))))});
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+ 
+}()));
 JaktInternal::Set<ByteString> remaining_cases = all_cases;
 {
 JaktInternal::ArrayIterator<Jakt::types::CheckedMatchCase> _magic = match_cases.iterator();
@@ -1743,9 +1545,9 @@ break;
 }
 Jakt::types::CheckedMatchPattern pattern = _magic_value.value();
 {
-Jakt::types::CheckedMatchPattern __jakt_tmp423 = pattern;
-if (__jakt_tmp423.__jakt_init_index() == 0 /* EnumVariant */){
-ByteString const name = __jakt_tmp423.as.EnumVariant.name;
+Jakt::types::CheckedMatchPattern __jakt_tmp287 = pattern;
+if (__jakt_tmp287.__jakt_init_index() == 0 /* EnumVariant */){
+ByteString const name = __jakt_tmp287.as.EnumVariant.name;
 remaining_cases.remove(name);
 }
 }
@@ -1758,9 +1560,7 @@ remaining_cases.remove(name);
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ide::Usage>,ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>>> {
-auto __jakt_enum_value = (remaining_cases.is_empty());
+{auto __jakt_enum_value = remaining_cases.is_empty();
 if (!__jakt_enum_value) {{
 JaktInternal::DynamicArray<ByteString> cases_array = DynamicArray<ByteString>::create_with({});
 cases_array.ensure_capacity(remaining_cases.size());
@@ -1779,93 +1579,39 @@ cases_array.push(name);
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(static_cast<JaktInternal::Optional<Jakt::ide::Usage>>(Jakt::ide::Usage::NameSet(cases_array)));
+return static_cast<JaktInternal::Optional<Jakt::ide::Usage>>(Jakt::ide::Usage::NameSet(cases_array));
 }
 VERIFY_NOT_REACHED();
-}else if (__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
+}else if (__jakt_enum_value) {return JaktInternal::OptionalNone();}VERIFY_NOT_REACHED();
+}
 }
 VERIFY_NOT_REACHED();
-}else {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ide::Usage>, ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>>>{
-auto&& __jakt_match_variant = body;
+}else {{auto&& __jakt_match_variant = body;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& block = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_block(program,block,span))));
-};/*case end*/
+return Jakt::ide::find_span_in_block(program,block,span);};/*case end*/
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_expression(program,expr,span))));
-};/*case end*/
+return Jakt::ide::find_span_in_expression(program,expr,span);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
+}} 
+}())));
 };/*case end*/
 case 2 /* ClassInstance */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.ClassInstance;Jakt::utility::Span const& marker_span = __jakt_match_value.marker_span;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ide::Usage>,ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>>> {
-auto __jakt_enum_value = (marker_span.contains(span));
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}else {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ide::Usage>, ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>>>{
-auto&& __jakt_match_variant = body;
+auto&& __jakt_match_value = __jakt_match_variant.as.ClassInstance;Jakt::utility::Span const& marker_span = __jakt_match_variant.common.init_common.marker_span;
+return JaktInternal::ExplicitValue(TRY(([&]() -> ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>> { auto __jakt_enum_value = marker_span.contains(span);
+if (__jakt_enum_value) {return JaktInternal::OptionalNone();}else {{auto&& __jakt_match_variant = body;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& block = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_block(program,block,span))));
-};/*case end*/
+return Jakt::ide::find_span_in_block(program,block,span);};/*case end*/
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_expression(program,expr,span))));
-};/*case end*/
+return Jakt::ide::find_span_in_expression(program,expr,span);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
+}} 
+}())));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -1891,18 +1637,16 @@ return found;
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(TRY((Jakt::ide::find_span_in_expression(program,expr,span))));
+return Jakt::ide::find_span_in_expression(program,expr,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 27 /* ForcedUnwrap */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForcedUnwrap;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_expression(program,expr,span))));
-};/*case end*/
+return Jakt::ide::find_span_in_expression(program,expr,span);};/*case end*/
 case 6 /* UnaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_expression(program,expr,span))));
-};/*case end*/
+return Jakt::ide::find_span_in_expression(program,expr,span);};/*case end*/
 case 22 /* MethodCall */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MethodCall;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 Jakt::types::CheckedCall const& call = __jakt_match_value.call;
@@ -1947,16 +1691,9 @@ Jakt::utility::Span const& var_span = __jakt_match_value.span;
 {
 JaktInternal::Optional<Jakt::ids::TypeId> const none_type_id = JaktInternal::OptionalNone();
 if (var_span.contains(span)){
-Jakt::ide::Mutability const mutability = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ide::Mutability,ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>>> {
-auto __jakt_enum_value = (var->is_mutable);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::ide::Mutability::Mutable());
-}else {return JaktInternal::ExplicitValue(Jakt::ide::Mutability::Immutable());
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+Jakt::ide::Mutability const mutability = [&]() -> Jakt::ide::Mutability { auto __jakt_enum_value = var->is_mutable;
+if (__jakt_enum_value) {return Jakt::ide::Mutability::Mutable();}else {return Jakt::ide::Mutability::Immutable();} 
+}();
 return static_cast<JaktInternal::Optional<Jakt::ide::Usage>>(Jakt::ide::Usage::Variable(var->definition_span,var->name,var->type_id,mutability,Jakt::ide::VarType::Variable(),Jakt::ide::VarVisibility::DoesNotApply(),none_type_id));
 }
 return none;
@@ -1977,7 +1714,7 @@ return static_cast<JaktInternal::Optional<Jakt::ide::Usage>>(Jakt::ide::get_enum
 }
 }
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(none);
+return none;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1990,7 +1727,7 @@ JaktInternal::Optional<Jakt::ide::Usage> const found = TRY((Jakt::ide::find_span
 if (found.has_value()){
 return found;
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(TRY((Jakt::ide::find_span_in_block(program,catch_block,span))));
+return Jakt::ide::find_span_in_block(program,catch_block,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -2002,17 +1739,9 @@ JaktInternal::Optional<Jakt::ide::Usage> const found = TRY((Jakt::ide::find_span
 if (found.has_value()){
 return found;
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ide::Usage>,ErrorOr<JaktInternal::Optional<Jakt::ide::Usage>>> {
-auto __jakt_enum_value = (catch_block.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((Jakt::ide::find_span_in_block(program,catch_block.value(),span))));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(none);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+{auto __jakt_enum_value = catch_block.has_value();
+if (__jakt_enum_value) {return Jakt::ide::find_span_in_block(program,catch_block.value(),span);}else if (!__jakt_enum_value) {return none;}VERIFY_NOT_REACHED();
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -2029,48 +1758,32 @@ return found;
 if (to.has_value()){
 return Jakt::ide::find_span_in_expression(program,to.value(),span);
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ide::Usage>>(none);
+return none;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(none);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return none;}/*switch end*/
+}
 }
 }
 
 ErrorOr<ByteString> get_function_signature(NonnullRefPtr<Jakt::types::CheckedProgram> const program,Jakt::ids::FunctionId const function_id) {
 {
 NonnullRefPtr<Jakt::types::CheckedFunction> const checked_function = program->get_function(function_id);
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = checked_function->type;
+{auto&& __jakt_match_variant = checked_function->type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* ImplicitEnumConstructor */:{
 Jakt::ids::TypeId const type_id = checked_function->return_type_id;
 ByteString const name = checked_function->name;
 return Jakt::ide::get_enum_variant_signature_from_type_id_and_name(program,type_id,name);
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* ImplicitConstructor */:{
+goto __jakt_label_197;case 3 /* ImplicitConstructor */:{
 return Jakt::ide::get_constructor_signature(program,function_id);
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_197;default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_197;}/*switch end*/
+}goto __jakt_label_197; __jakt_label_197:;;
 ByteString generic_parameters = ByteString::from_utf8_without_validation(""sv);
 bool is_first_param = true;
 if (!checked_function->generics->params.is_empty()){
@@ -2089,21 +1802,10 @@ break;
 Jakt::types::FunctionGenericParameter parameter = _magic_value.value();
 {
 ByteString const generic_type = TRY((program->type_name(parameter.type_id(),false)));
-ByteString const separator = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (is_first_param);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(", "sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ByteString const separator = [&]() -> ByteString { auto __jakt_enum_value = is_first_param;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation(""sv);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation(", "sv);}VERIFY_NOT_REACHED();
+ 
+}();
 [](ByteString& self, ByteString rhs) -> void {{
 self = (self + rhs);
 }
@@ -2132,36 +1834,14 @@ break;
 }
 Jakt::types::CheckedParameter param = _magic_value.value();
 {
-ByteString const anon_value = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (param.requires_label);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("anon "sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
-ByteString const is_mutable = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (param.variable->is_mutable);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("mut "sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ByteString const anon_value = [&]() -> ByteString { auto __jakt_enum_value = param.requires_label;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation(""sv);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation("anon "sv);}VERIFY_NOT_REACHED();
+ 
+}();
+ByteString const is_mutable = [&]() -> ByteString { auto __jakt_enum_value = param.variable->is_mutable;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation("mut "sv);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation(""sv);}VERIFY_NOT_REACHED();
+ 
+}();
 ByteString variable_type = TRY((program->type_name(param.variable->type_id,false)));
 if ([](ByteString const& self, ByteString rhs) -> bool {{
 return !(self == rhs);
@@ -2174,21 +1854,10 @@ else {
 variable_type = ByteString::from_utf8_without_validation(""sv);
 }
 
-ByteString const separator = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (is_first_param);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(", "sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ByteString const separator = [&]() -> ByteString { auto __jakt_enum_value = is_first_param;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation(""sv);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation(", "sv);}VERIFY_NOT_REACHED();
+ 
+}();
 [](ByteString& self, ByteString rhs) -> void {{
 self = (self + rhs);
 }
@@ -2217,17 +1886,10 @@ self = (self + rhs);
 }
 
 }
-ByteString const throws_str = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (checked_function->can_throw);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(" throws"sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const throws_str = [&]() -> ByteString { auto __jakt_enum_value = checked_function->can_throw;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation(" throws"sv);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation(""sv);}VERIFY_NOT_REACHED();
+ 
+}();
 ByteString returns = TRY((program->type_name(checked_function->return_type_id,false)));
 if ([](ByteString const& self, ByteString rhs) -> bool {{
 return !(self == rhs);
@@ -2246,27 +1908,16 @@ return __jakt_format(StringView::from_string_literal("fn {}{}({}){}{}"sv),checke
 
 ErrorOr<ByteString> get_var_signature(NonnullRefPtr<Jakt::types::CheckedProgram> const program,ByteString const name,Jakt::ids::TypeId const var_type_id,Jakt::ide::Mutability const mutability,Jakt::ide::VarType const var_type,Jakt::ide::VarVisibility const visibility,JaktInternal::Optional<Jakt::ids::TypeId> const struct_type_id) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = var_type;
+{auto&& __jakt_match_variant = var_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Variable */:{
-ByteString const mut_string = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = mutability;
+ByteString const mut_string = [&]() -> ByteString { auto&& __jakt_match_variant = mutability;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* Mutable */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("mut"sv));
-case 1 /* Immutable */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("let"sv));
-default:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 2 /* Mutable */:return ByteString::from_utf8_without_validation("mut"sv);case 1 /* Immutable */:return ByteString::from_utf8_without_validation("let"sv);default:return ByteString::from_utf8_without_validation(""sv);}/*switch end*/
+ 
+}();
 ByteString const type_name = TRY((Jakt::ide::get_type_signature(program,var_type_id)));
-return JaktInternal::ExplicitValue<ByteString>(__jakt_format(StringView::from_string_literal("{} {}: {}"sv),mut_string,name,type_name));
+return __jakt_format(StringView::from_string_literal("{} {}: {}"sv),mut_string,name,type_name);
 }
 VERIFY_NOT_REACHED();
 case 1 /* Field */:{
@@ -2274,20 +1925,11 @@ ByteString record_string = ByteString::from_utf8_without_validation(""sv);
 if (struct_type_id.has_value()){
 record_string = TRY((Jakt::ide::get_type_signature(program,struct_type_id.value())));
 }
-ByteString const visibility_string = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = visibility;
+ByteString const visibility_string = [&]() -> ByteString { auto&& __jakt_match_variant = visibility;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 1 /* Public */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("public "sv));
-case 2 /* Private */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("private "sv));
-default:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 1 /* Public */:return ByteString::from_utf8_without_validation("public "sv);case 2 /* Private */:return ByteString::from_utf8_without_validation("private "sv);default:return ByteString::from_utf8_without_validation(""sv);}/*switch end*/
+ 
+}();
 ByteString const type_name = TRY((Jakt::ide::get_type_signature(program,var_type_id)));
 if ([](ByteString const& self, ByteString rhs) -> bool {{
 return !(self == rhs);
@@ -2302,12 +1944,7 @@ return __jakt_format(StringView::from_string_literal("{}{}: {}"sv),visibility_st
 
 }
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -2321,46 +1958,21 @@ Jakt::ids::StructId const set_struct_id = TRY((program->find_struct_in_prelude(B
 Jakt::ids::StructId const tuple_struct_id = TRY((program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Tuple"sv))));
 Jakt::ids::StructId const weak_ptr_struct_id = TRY((program->find_struct_in_prelude(ByteString::from_utf8_without_validation("WeakPtr"sv))));
 NonnullRefPtr<typename Jakt::types::Type> const type = program->get_type(type_id);
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = *type;
+{auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 17 /* Never */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("never"sv));
-case 0 /* Void */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("void"sv));
-case 1 /* Bool */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("bool"sv));
-case 2 /* U8 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u8"sv));
-case 3 /* U16 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u16"sv));
-case 4 /* U32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u32"sv));
-case 5 /* U64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u64"sv));
-case 6 /* I8 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i8"sv));
-case 7 /* I16 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i16"sv));
-case 8 /* I32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i32"sv));
-case 9 /* I64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i64"sv));
-case 10 /* F32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("f32"sv));
-case 11 /* F64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("f64"sv));
-case 12 /* Usize */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("usize"sv));
-case 13 /* JaktString */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("String"sv));
-case 15 /* CInt */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("c_int"sv));
-case 14 /* CChar */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("c_char"sv));
-case 18 /* TypeVariable */: {
+case 17 /* Never */:return ByteString::from_utf8_without_validation("never"sv);case 0 /* Void */:return ByteString::from_utf8_without_validation("void"sv);case 1 /* Bool */:return ByteString::from_utf8_without_validation("bool"sv);case 2 /* U8 */:return ByteString::from_utf8_without_validation("u8"sv);case 3 /* U16 */:return ByteString::from_utf8_without_validation("u16"sv);case 4 /* U32 */:return ByteString::from_utf8_without_validation("u32"sv);case 5 /* U64 */:return ByteString::from_utf8_without_validation("u64"sv);case 6 /* I8 */:return ByteString::from_utf8_without_validation("i8"sv);case 7 /* I16 */:return ByteString::from_utf8_without_validation("i16"sv);case 8 /* I32 */:return ByteString::from_utf8_without_validation("i32"sv);case 9 /* I64 */:return ByteString::from_utf8_without_validation("i64"sv);case 10 /* F32 */:return ByteString::from_utf8_without_validation("f32"sv);case 11 /* F64 */:return ByteString::from_utf8_without_validation("f64"sv);case 12 /* Usize */:return ByteString::from_utf8_without_validation("usize"sv);case 13 /* JaktString */:return ByteString::from_utf8_without_validation("String"sv);case 15 /* CInt */:return ByteString::from_utf8_without_validation("c_int"sv);case 14 /* CChar */:return ByteString::from_utf8_without_validation("c_char"sv);case 18 /* TypeVariable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeVariable;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(name);
-};/*case end*/
-case 16 /* Unknown */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-case 30 /* Self */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Self"sv));
-case 26 /* Trait */: {
+return name;};/*case end*/
+case 16 /* Unknown */:return ByteString::from_utf8_without_validation(""sv);case 30 /* Self */:return ByteString::from_utf8_without_validation("Self"sv);case 26 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& trait_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_trait(trait_id)->name);
-};/*case end*/
+return program->get_trait(trait_id)->name;};/*case end*/
 case 19 /* Dependent */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dependent;Jakt::ids::TypeId const& namespace_type = __jakt_match_value.namespace_type;
 ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}::{}"sv),TRY((program->type_name(namespace_type,false))),name));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}::{}"sv),TRY((program->type_name(namespace_type,false))),name);};/*case end*/
 case 31 /* Const */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Const;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((Jakt::types::comptime_format_impl(ByteString::from_utf8_without_validation("const {}"sv),DynamicArray<Jakt::types::Value>::create_with({value}).operator[](JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}),program))));
-};/*case end*/
+return Jakt::types::comptime_format_impl(ByteString::from_utf8_without_validation("const {}"sv),DynamicArray<Jakt::types::Value>::create_with({value})[JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}],program);};/*case end*/
 case 29 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& params = __jakt_match_value.params;
 Jakt::ids::TypeId const& return_type_id = __jakt_match_value.return_type_id;
@@ -2382,28 +1994,20 @@ param_names.push(TRY((program->type_name(x,false))));
 }
 
 ByteString const return_type = TRY((program->type_name(return_type_id,false)));
-return JaktInternal::ExplicitValue<ByteString>(__jakt_format(StringView::from_string_literal("fn({}) -> {}"sv),Jakt::utility::join(param_names,ByteString::from_utf8_without_validation(", "sv)),return_type));
+return __jakt_format(StringView::from_string_literal("fn({}) -> {}"sv),Jakt::utility::join(param_names,ByteString::from_utf8_without_validation(", "sv)),return_type);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 25 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("raw "sv) + TRY((Jakt::ide::get_type_signature(program,type_id))));
-};/*case end*/
+return ByteString::from_utf8_without_validation("raw "sv) + TRY((Jakt::ide::get_type_signature(program,type_id)));};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
 {
 Jakt::types::CheckedEnum const enum_ = program->get_enum(id);
-return JaktInternal::ExplicitValue<ByteString>((({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (enum_.is_boxed);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("boxed "sv));
-}else {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}) + ByteString::from_utf8_without_validation("enum "sv)) + enum_.name);
+return ([&]() -> ByteString { auto __jakt_enum_value = enum_.is_boxed;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation("boxed "sv);}else {return ByteString::from_utf8_without_validation(""sv);} 
+}() + ByteString::from_utf8_without_validation("enum "sv)) + enum_.name;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -2411,22 +2015,14 @@ case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
 {
 Jakt::types::CheckedStruct const struct_ = program->get_struct(id);
-return JaktInternal::ExplicitValue<ByteString>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = struct_.record_type;
+return [&]() -> ByteString { auto&& __jakt_match_variant = struct_.record_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 1 /* Class */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("class "sv));
-case 0 /* Struct */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("struct "sv));
-default:{
+case 1 /* Class */:return ByteString::from_utf8_without_validation("class "sv);case 0 /* Struct */:return ByteString::from_utf8_without_validation("struct "sv);default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("unreachable: should've been struct"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}) + struct_.name);
+ 
+}() + struct_.name;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -2463,7 +2059,7 @@ if (!args.is_empty()){
 self = (self + rhs);
 }
 }
-(output,TRY((Jakt::ide::get_type_signature(program,args.operator[](static_cast<i64>(0LL))))));
+(output,TRY((Jakt::ide::get_type_signature(program,args[static_cast<i64>(0LL)]))));
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(1ULL)),static_cast<size_t>(args.size())};
 for (;;){
@@ -2482,14 +2078,14 @@ self = (self + rhs);
 self = (self + rhs);
 }
 }
-(output,TRY((Jakt::ide::get_type_signature(program,args.operator[](i)))));
+(output,TRY((Jakt::ide::get_type_signature(program,args[i]))));
 }
 
 }
 }
 
 }
-return JaktInternal::ExplicitValue<ByteString>(output + ByteString::from_utf8_without_validation(">"sv));
+return output + ByteString::from_utf8_without_validation(">"sv);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -2519,7 +2115,7 @@ if (!args.is_empty()){
 self = (self + rhs);
 }
 }
-(output,TRY((Jakt::ide::get_type_signature(program,args.operator[](static_cast<i64>(0LL))))));
+(output,TRY((Jakt::ide::get_type_signature(program,args[static_cast<i64>(0LL)]))));
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(1ULL)),static_cast<size_t>(args.size())};
 for (;;){
@@ -2538,14 +2134,14 @@ self = (self + rhs);
 self = (self + rhs);
 }
 }
-(output,TRY((Jakt::ide::get_type_signature(program,args.operator[](i)))));
+(output,TRY((Jakt::ide::get_type_signature(program,args[i]))));
 }
 
 }
 }
 
 }
-return JaktInternal::ExplicitValue<ByteString>(output + ByteString::from_utf8_without_validation(">"sv));
+return output + ByteString::from_utf8_without_validation(">"sv);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -2557,31 +2153,31 @@ if (id.equals(array_struct_id)){
 if (args.is_empty()){
 return ByteString::from_utf8_without_validation("[]"sv);
 }
-return __jakt_format(StringView::from_string_literal("[{}]"sv),TRY((Jakt::ide::get_type_signature(program,args.operator[](static_cast<i64>(0LL))))));
+return __jakt_format(StringView::from_string_literal("[{}]"sv),TRY((Jakt::ide::get_type_signature(program,args[static_cast<i64>(0LL)]))));
 }
 if (id.equals(dictionary_struct_id)){
 if (args.size() < static_cast<size_t>(2ULL)){
 return ByteString::from_utf8_without_validation("[:]"sv);
 }
-return __jakt_format(StringView::from_string_literal("[{}: {}]"sv),TRY((Jakt::ide::get_type_signature(program,args.operator[](static_cast<i64>(0LL))))),TRY((Jakt::ide::get_type_signature(program,args.operator[](static_cast<i64>(1LL))))));
+return __jakt_format(StringView::from_string_literal("[{}: {}]"sv),TRY((Jakt::ide::get_type_signature(program,args[static_cast<i64>(0LL)]))),TRY((Jakt::ide::get_type_signature(program,args[static_cast<i64>(1LL)]))));
 }
 if (id.equals(optional_struct_id)){
 if (args.is_empty()){
 return ByteString::from_utf8_without_validation(""sv);
 }
-return __jakt_format(StringView::from_string_literal("{}?"sv),TRY((Jakt::ide::get_type_signature(program,args.operator[](static_cast<i64>(0LL))))));
+return __jakt_format(StringView::from_string_literal("{}?"sv),TRY((Jakt::ide::get_type_signature(program,args[static_cast<i64>(0LL)]))));
 }
 if (id.equals(range_struct_id)){
 if (args.is_empty()){
 return ByteString::from_utf8_without_validation(""sv);
 }
-return __jakt_format(StringView::from_string_literal("{}..{}"sv),TRY((Jakt::ide::get_type_signature(program,args.operator[](static_cast<i64>(0LL))))),TRY((program->type_name(args.operator[](static_cast<i64>(0LL)),false))));
+return __jakt_format(StringView::from_string_literal("{}..{}"sv),TRY((Jakt::ide::get_type_signature(program,args[static_cast<i64>(0LL)]))),TRY((program->type_name(args[static_cast<i64>(0LL)],false))));
 }
 if (id.equals(set_struct_id)){
 if (args.is_empty()){
 return ByteString::from_utf8_without_validation(""sv);
 }
-return __jakt_format(StringView::from_string_literal("{{{}}}"sv),TRY((Jakt::ide::get_type_signature(program,args.operator[](static_cast<i64>(0LL))))));
+return __jakt_format(StringView::from_string_literal("{{{}}}"sv),TRY((Jakt::ide::get_type_signature(program,args[static_cast<i64>(0LL)]))));
 }
 if (id.equals(tuple_struct_id)){
 ByteString output = ByteString::from_utf8_without_validation("("sv);
@@ -2590,7 +2186,7 @@ if (!args.is_empty()){
 self = (self + rhs);
 }
 }
-(output,TRY((Jakt::ide::get_type_signature(program,args.operator[](static_cast<i64>(0LL))))));
+(output,TRY((Jakt::ide::get_type_signature(program,args[static_cast<i64>(0LL)]))));
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(1ULL)),static_cast<size_t>(args.size())};
 for (;;){
@@ -2609,7 +2205,7 @@ self = (self + rhs);
 self = (self + rhs);
 }
 }
-(output,TRY((Jakt::ide::get_type_signature(program,args.operator[](i)))));
+(output,TRY((Jakt::ide::get_type_signature(program,args[i]))));
 }
 
 }
@@ -2622,26 +2218,17 @@ if (id.equals(weak_ptr_struct_id)){
 if (args.is_empty()){
 return ByteString::from_utf8_without_validation(""sv);
 }
-return __jakt_format(StringView::from_string_literal("weak {}"sv),TRY((Jakt::ide::get_type_signature(program,args.operator[](static_cast<i64>(0LL))))));
+return __jakt_format(StringView::from_string_literal("weak {}"sv),TRY((Jakt::ide::get_type_signature(program,args[static_cast<i64>(0LL)]))));
 }
 Jakt::types::CheckedStruct const record = program->get_struct(id);
-ByteString output = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = record.record_type;
+ByteString output = [&]() -> ByteString { auto&& __jakt_match_variant = record.record_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 1 /* Class */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("class "sv));
-case 0 /* Struct */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("struct "sv));
-case 2 /* ValueEnum */:case 3 /* SumEnum */:{
+case 1 /* Class */:return ByteString::from_utf8_without_validation("class "sv);case 0 /* Struct */:return ByteString::from_utf8_without_validation("struct "sv);case 2 /* ValueEnum */:case 3 /* SumEnum */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("unreachable: can't be an enum"sv));
 }
-case 4 /* Garbage */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 4 /* Garbage */:return ByteString::from_utf8_without_validation(""sv);default: VERIFY_NOT_REACHED();}/*switch end*/
+ 
+}();
 [](ByteString& self, ByteString rhs) -> void {{
 self = (self + rhs);
 }
@@ -2657,7 +2244,7 @@ if (!args.is_empty()){
 self = (self + rhs);
 }
 }
-(output,TRY((Jakt::ide::get_type_signature(program,args.operator[](static_cast<i64>(0LL))))));
+(output,TRY((Jakt::ide::get_type_signature(program,args[static_cast<i64>(0LL)]))));
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(1ULL)),static_cast<size_t>(args.size())};
 for (;;){
@@ -2676,32 +2263,25 @@ self = (self + rhs);
 self = (self + rhs);
 }
 }
-(output,TRY((Jakt::ide::get_type_signature(program,args.operator[](i)))));
+(output,TRY((Jakt::ide::get_type_signature(program,args[i]))));
 }
 
 }
 }
 
 }
-return JaktInternal::ExplicitValue<ByteString>(output + ByteString::from_utf8_without_validation(">"sv));
+return output + ByteString::from_utf8_without_validation(">"sv);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 27 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("&{}"sv),TRY((program->type_name(type_id,false)))));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("&{}"sv),TRY((program->type_name(type_id,false))));};/*case end*/
 case 28 /* MutableReference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MutableReference;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("&mut {}"sv),TRY((program->type_name(type_id,false)))));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("&mut {}"sv),TRY((program->type_name(type_id,false))));};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -2783,9 +2363,7 @@ self = (self + rhs);
 }
 }
 (output,ByteString::from_utf8_without_validation(" = "sv));
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = number_constant.value();
+{auto&& __jakt_match_variant = number_constant.value();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Signed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Signed;i64 const& value = __jakt_match_value.value;
@@ -2796,8 +2374,7 @@ self = (self + rhs);
 }
 (output,__jakt_format(StringView::from_string_literal("{}"sv),value));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_198;};/*case end*/
 case 1 /* Unsigned */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsigned;u64 const& value = __jakt_match_value.value;
 {
@@ -2807,8 +2384,7 @@ self = (self + rhs);
 }
 (output,__jakt_format(StringView::from_string_literal("{}"sv),value));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_198;};/*case end*/
 case 2 /* Floating */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Floating;f64 const& value = __jakt_match_value.value;
 {
@@ -2818,15 +2394,9 @@ self = (self + rhs);
 }
 (output,__jakt_format(StringView::from_string_literal("{}"sv),value));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_198;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}goto __jakt_label_198; __jakt_label_198:;;
 }
 return output;
 }
@@ -2834,7 +2404,7 @@ return output;
 
 ErrorOr<ByteString> get_enum_variant_signature_from_type_id_and_name(NonnullRefPtr<Jakt::types::CheckedProgram> const program,Jakt::ids::TypeId const type_id,ByteString const name) {
 {
-NonnullRefPtr<Jakt::types::Module> const mod = program->modules.operator[](type_id.module.id);
+NonnullRefPtr<Jakt::types::Module> const mod = program->modules[type_id.module.id];
 {
 JaktInternal::ArrayIterator<Jakt::types::CheckedEnum> _magic = mod->enums.iterator();
 for (;;){
@@ -2854,9 +2424,7 @@ break;
 }
 Jakt::types::CheckedEnumVariant variant = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = variant;
+{auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Untyped */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Untyped;ByteString const& v_name = __jakt_match_value.name;
@@ -2867,8 +2435,7 @@ JaktInternal::Optional<Jakt::types::NumberConstant> const none = JaktInternal::O
 return Jakt::ide::get_enum_variant_signature(program,name,type_id,params,none);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_199;};/*case end*/
 case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;ByteString const& v_name = __jakt_match_value.name;
 {
@@ -2878,45 +2445,33 @@ JaktInternal::Optional<Jakt::types::NumberConstant> const none = JaktInternal::O
 return Jakt::ide::get_enum_variant_signature(program,name,type_id,params,none);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_199;};/*case end*/
 case 2 /* WithValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.WithValue;ByteString const& v_name = __jakt_match_value.name;
 {
 if (v_name == name){
 JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::ids::TypeId>> const params = Jakt::ide::enum_variant_fields(program,variant);
-JaktInternal::Optional<Jakt::types::NumberConstant> const value = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::types::NumberConstant>, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = variant;
+JaktInternal::Optional<Jakt::types::NumberConstant> const value = [&]() -> JaktInternal::Optional<Jakt::types::NumberConstant> { auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* WithValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.WithValue;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 {
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::types::NumberConstant>>(expr->to_number_constant(program));
+return expr->to_number_constant(program);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
 JaktInternal::Optional<Jakt::types::NumberConstant> const none = JaktInternal::OptionalNone();
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::types::NumberConstant>>(none);
+return none;
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+ 
+}();
 return Jakt::ide::get_enum_variant_signature(program,name,type_id,params,value);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_199;};/*case end*/
 case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;ByteString const& v_name = __jakt_match_value.name;
 {
@@ -2926,19 +2481,9 @@ JaktInternal::Optional<Jakt::types::NumberConstant> const none = JaktInternal::O
 return Jakt::ide::get_enum_variant_signature(program,name,type_id,params,none);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_199;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+break;}goto __jakt_label_199; __jakt_label_199:;;
 }
 
 }
@@ -2979,27 +2524,15 @@ Jakt::types::CheckedEnumVariant variant = _magic_value.value();
 {
 if (variant.name() == name){
 JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::ids::TypeId>> const variants = Jakt::ide::enum_variant_fields(program,variant);
-JaktInternal::Optional<Jakt::types::NumberConstant> const number_constant = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::types::NumberConstant>, Jakt::ide::Usage>{
-auto&& __jakt_match_variant = variant;
+JaktInternal::Optional<Jakt::types::NumberConstant> const number_constant = [&]() -> JaktInternal::Optional<Jakt::types::NumberConstant> { auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* WithValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.WithValue;ByteString const& name = __jakt_match_value.name;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(expr->to_number_constant(program));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+return expr->to_number_constant(program);};/*case end*/
+default:return JaktInternal::OptionalNone();}/*switch end*/
+ 
+}();
 Jakt::utility::Span const span = variant.span();
 return Jakt::ide::Usage::EnumVariant(span,name,type_id,variants,number_constant);
 }
@@ -3020,9 +2553,7 @@ Jakt::utility::panic(ByteString::from_utf8_without_validation("unreachable: shou
 
 JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::ids::TypeId>> enum_variant_fields(NonnullRefPtr<Jakt::types::CheckedProgram> const program,Jakt::types::CheckedEnumVariant const checked_enum_variant) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::ids::TypeId>>, JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::ids::TypeId>>>{
-auto&& __jakt_match_variant = checked_enum_variant;
+{auto&& __jakt_match_variant = checked_enum_variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;JaktInternal::DynamicArray<Jakt::ids::VarId> const& fields = __jakt_match_value.fields;
@@ -3046,7 +2577,7 @@ output.push(o);
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::ids::TypeId>>>(output);
+return output;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -3054,18 +2585,12 @@ case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
 JaktInternal::Optional<ByteString> const string_none = JaktInternal::OptionalNone();
-return JaktInternal::ExplicitValue<JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::ids::TypeId>>>(DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::ids::TypeId>>::create_with({Tuple{string_none, type_id}}));
+return DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::ids::TypeId>>::create_with({Tuple{string_none, type_id}});
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::ids::TypeId>>::create_with({}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::ids::TypeId>>::create_with({});}/*switch end*/
+}
 }
 }
 
@@ -3073,7 +2598,7 @@ ErrorOr<ByteString> get_constructor_signature(NonnullRefPtr<Jakt::types::Checked
 {
 NonnullRefPtr<Jakt::types::CheckedFunction> const checked_function = program->get_function(function_id);
 Jakt::ids::TypeId const type_id = checked_function->return_type_id;
-NonnullRefPtr<Jakt::types::Module> const mod = program->modules.operator[](type_id.module.id);
+NonnullRefPtr<Jakt::types::Module> const mod = program->modules[type_id.module.id];
 {
 JaktInternal::ArrayIterator<Jakt::types::CheckedStruct> _magic = mod->structures.iterator();
 for (;;){

--- a/bootstrap/stage0/interpreter.cpp
+++ b/bootstrap/stage0/interpreter.cpp
@@ -10,24 +10,9 @@ namespace Jakt {
 namespace interpreter {
 ErrorOr<size_t> align_of_impl(Jakt::ids::TypeId const type_id,NonnullRefPtr<Jakt::interpreter::Interpreter> const interpreter) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<size_t>>{
-auto&& __jakt_match_variant = *interpreter->program->get_type(type_id);
+{auto&& __jakt_match_variant = *interpreter->program->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Void */:case 16 /* Unknown */:case 17 /* Never */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 1 /* Bool */:return JaktInternal::ExplicitValue(static_cast<size_t>(1ULL));
-case 6 /* I8 */:case 2 /* U8 */:return JaktInternal::ExplicitValue(static_cast<size_t>(1ULL));
-case 7 /* I16 */:case 3 /* U16 */:return JaktInternal::ExplicitValue(static_cast<size_t>(2ULL));
-case 8 /* I32 */:case 4 /* U32 */:return JaktInternal::ExplicitValue(static_cast<size_t>(4ULL));
-case 9 /* I64 */:case 5 /* U64 */:return JaktInternal::ExplicitValue(static_cast<size_t>(8ULL));
-case 10 /* F32 */:return JaktInternal::ExplicitValue(static_cast<size_t>(4ULL));
-case 11 /* F64 */:return JaktInternal::ExplicitValue(static_cast<size_t>(8ULL));
-case 12 /* Usize */:return JaktInternal::ExplicitValue(TRY((TRY((Jakt::jakt__platform::Target::active())).size_t_alignment())));
-case 13 /* JaktString */:return JaktInternal::ExplicitValue(TRY((TRY((Jakt::jakt__platform::Target::active())).pointer_alignment())));
-case 14 /* CChar */:return JaktInternal::ExplicitValue(static_cast<size_t>(1ULL));
-case 15 /* CInt */:return JaktInternal::ExplicitValue(TRY((TRY((Jakt::jakt__platform::Target::active())).int_alignment())));
-case 18 /* TypeVariable */:case 31 /* Const */:case 19 /* Dependent */:case 22 /* GenericTraitInstance */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 20 /* GenericInstance */: {
+case 0 /* Void */:case 16 /* Unknown */:case 17 /* Never */:return static_cast<size_t>(0ULL);case 1 /* Bool */:return static_cast<size_t>(1ULL);case 6 /* I8 */:case 2 /* U8 */:return static_cast<size_t>(1ULL);case 7 /* I16 */:case 3 /* U16 */:return static_cast<size_t>(2ULL);case 8 /* I32 */:case 4 /* U32 */:return static_cast<size_t>(4ULL);case 9 /* I64 */:case 5 /* U64 */:return static_cast<size_t>(8ULL);case 10 /* F32 */:return static_cast<size_t>(4ULL);case 11 /* F64 */:return static_cast<size_t>(8ULL);case 12 /* Usize */:return TRY((Jakt::jakt__platform::Target::active())).size_t_alignment();case 13 /* JaktString */:return TRY((Jakt::jakt__platform::Target::active())).pointer_alignment();case 14 /* CChar */:return static_cast<size_t>(1ULL);case 15 /* CInt */:return TRY((Jakt::jakt__platform::Target::active())).int_alignment();case 18 /* TypeVariable */:case 31 /* Const */:case 19 /* Dependent */:case 22 /* GenericTraitInstance */:return static_cast<size_t>(0ULL);case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& struct_id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
 {
@@ -47,7 +32,7 @@ ScopeGuard __jakt_var_6([&] {
 i += static_cast<i64>(1LL);
 });
 if (param.type_id.equals(type_id)){
-return args.operator[](i);
+return args[i];
 }
 }
 
@@ -77,14 +62,13 @@ align = field_alignment;
 }
 }
 
-return JaktInternal::ExplicitValue<size_t>(align);
+return align;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});
-{
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});{
 Jakt::types::CheckedStruct const struct_ = interpreter->program->get_struct(struct_id);
 Function<Jakt::ids::TypeId(Jakt::ids::TypeId)> const resolve_type_id = [&struct_, &args](Jakt::ids::TypeId type_id) -> Jakt::ids::TypeId {{
 i64 i = static_cast<i64>(0LL);
@@ -101,7 +85,7 @@ ScopeGuard __jakt_var_7([&] {
 i += static_cast<i64>(1LL);
 });
 if (param.type_id.equals(type_id)){
-return args.operator[](i);
+return args[i];
 }
 }
 
@@ -131,7 +115,7 @@ align = field_alignment;
 }
 }
 
-return JaktInternal::ExplicitValue<size_t>(align);
+return align;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -155,7 +139,7 @@ ScopeGuard __jakt_var_8([&] {
 i += static_cast<i64>(1LL);
 });
 if (param.type_id.equals(type_id)){
-return args.operator[](i);
+return args[i];
 }
 }
 
@@ -166,9 +150,7 @@ return type_id;
 }
 }
 ;
-return JaktInternal::ExplicitValue<size_t>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<size_t>> {
-auto __jakt_enum_value = (enum_.underlying_type_id.equals(Jakt::types::void_type_id()));
+{auto __jakt_enum_value = enum_.underlying_type_id.equals(Jakt::types::void_type_id());
 if (__jakt_enum_value) {{
 size_t align = static_cast<size_t>(0ULL);
 {
@@ -180,17 +162,12 @@ break;
 }
 Jakt::types::CheckedEnumVariant variant = _magic_value.value();
 {
-size_t const variant_align = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<size_t>>{
-auto&& __jakt_match_variant = variant;
+size_t const variant_align = TRY(([&]() -> ErrorOr<size_t> { auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Untyped */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 1 /* Typed */: {
+case 0 /* Untyped */:return static_cast<size_t>(0ULL);case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(TRY((Jakt::interpreter::align_of_impl(resolve_type_id(type_id),interpreter))));
-};/*case end*/
-case 2 /* WithValue */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 3 /* StructLike */: {
+return Jakt::interpreter::align_of_impl(resolve_type_id(type_id),interpreter);};/*case end*/
+case 2 /* WithValue */:return static_cast<size_t>(0ULL);case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;JaktInternal::DynamicArray<Jakt::ids::VarId> const& fields = __jakt_match_value.fields;
 {
 size_t align = static_cast<size_t>(0ULL);
@@ -212,21 +189,13 @@ align = field_alignment;
 }
 }
 
-return JaktInternal::ExplicitValue<size_t>(align);
+return align;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}()));
 if (variant_align > align){
 align = variant_align;
 }
@@ -235,36 +204,23 @@ align = variant_align;
 }
 }
 
-Jakt::types::BuiltinType const index_type = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BuiltinType,ErrorOr<size_t>> {
-auto __jakt_enum_value = (enum_.variants.size());
-if (__jakt_enum_value >= static_cast<size_t>(0ULL)&&__jakt_enum_value < static_cast<size_t>(256ULL)) {return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::U8());
-}else {return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::Usize());
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+Jakt::types::BuiltinType const index_type = [&]() -> Jakt::types::BuiltinType { auto __jakt_enum_value = enum_.variants.size();
+if (__jakt_enum_value >= static_cast<size_t>(0ULL)&&__jakt_enum_value < static_cast<size_t>(256ULL)) {return Jakt::types::BuiltinType::U8();}else {return Jakt::types::BuiltinType::Usize();} 
+}();
 size_t const index_align = TRY((Jakt::interpreter::align_of_impl(Jakt::types::builtin(index_type),interpreter)));
 if (index_align > align){
 align = index_align;
 }
-return JaktInternal::ExplicitValue<size_t>(align);
+return align;
 }
 VERIFY_NOT_REACHED();
-}else {return JaktInternal::ExplicitValue(TRY((Jakt::interpreter::align_of_impl(enum_.underlying_type_id,interpreter))));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}else {return Jakt::interpreter::align_of_impl(enum_.underlying_type_id,interpreter);}}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});
-{
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});{
 Jakt::types::CheckedEnum const enum_ = interpreter->program->get_enum(enum_id);
 Function<Jakt::ids::TypeId(Jakt::ids::TypeId)> const resolve_type_id = [&enum_, &args](Jakt::ids::TypeId type_id) -> Jakt::ids::TypeId {{
 i64 i = static_cast<i64>(0LL);
@@ -281,7 +237,7 @@ ScopeGuard __jakt_var_9([&] {
 i += static_cast<i64>(1LL);
 });
 if (param.type_id.equals(type_id)){
-return args.operator[](i);
+return args[i];
 }
 }
 
@@ -292,9 +248,7 @@ return type_id;
 }
 }
 ;
-return JaktInternal::ExplicitValue<size_t>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<size_t>> {
-auto __jakt_enum_value = (enum_.underlying_type_id.equals(Jakt::types::void_type_id()));
+{auto __jakt_enum_value = enum_.underlying_type_id.equals(Jakt::types::void_type_id());
 if (__jakt_enum_value) {{
 size_t align = static_cast<size_t>(0ULL);
 {
@@ -306,17 +260,12 @@ break;
 }
 Jakt::types::CheckedEnumVariant variant = _magic_value.value();
 {
-size_t const variant_align = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<size_t>>{
-auto&& __jakt_match_variant = variant;
+size_t const variant_align = TRY(([&]() -> ErrorOr<size_t> { auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Untyped */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 1 /* Typed */: {
+case 0 /* Untyped */:return static_cast<size_t>(0ULL);case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(TRY((Jakt::interpreter::align_of_impl(resolve_type_id(type_id),interpreter))));
-};/*case end*/
-case 2 /* WithValue */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 3 /* StructLike */: {
+return Jakt::interpreter::align_of_impl(resolve_type_id(type_id),interpreter);};/*case end*/
+case 2 /* WithValue */:return static_cast<size_t>(0ULL);case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;JaktInternal::DynamicArray<Jakt::ids::VarId> const& fields = __jakt_match_value.fields;
 {
 size_t align = static_cast<size_t>(0ULL);
@@ -338,21 +287,13 @@ align = field_alignment;
 }
 }
 
-return JaktInternal::ExplicitValue<size_t>(align);
+return align;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}()));
 if (variant_align > align){
 align = variant_align;
 }
@@ -361,68 +302,30 @@ align = variant_align;
 }
 }
 
-Jakt::types::BuiltinType const index_type = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BuiltinType,ErrorOr<size_t>> {
-auto __jakt_enum_value = (enum_.variants.size());
-if (__jakt_enum_value >= static_cast<size_t>(0ULL)&&__jakt_enum_value < static_cast<size_t>(256ULL)) {return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::U8());
-}else {return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::Usize());
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+Jakt::types::BuiltinType const index_type = [&]() -> Jakt::types::BuiltinType { auto __jakt_enum_value = enum_.variants.size();
+if (__jakt_enum_value >= static_cast<size_t>(0ULL)&&__jakt_enum_value < static_cast<size_t>(256ULL)) {return Jakt::types::BuiltinType::U8();}else {return Jakt::types::BuiltinType::Usize();} 
+}();
 size_t const index_align = TRY((Jakt::interpreter::align_of_impl(Jakt::types::builtin(index_type),interpreter)));
 if (index_align > align){
 align = index_align;
 }
-return JaktInternal::ExplicitValue<size_t>(align);
+return align;
 }
 VERIFY_NOT_REACHED();
-}else {return JaktInternal::ExplicitValue(TRY((Jakt::interpreter::align_of_impl(enum_.underlying_type_id,interpreter))));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}else {return Jakt::interpreter::align_of_impl(enum_.underlying_type_id,interpreter);}}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-case 25 /* RawPtr */:return JaktInternal::ExplicitValue(TRY((TRY((Jakt::jakt__platform::Target::active())).pointer_alignment())));
-case 26 /* Trait */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 27 /* Reference */:return JaktInternal::ExplicitValue(TRY((TRY((Jakt::jakt__platform::Target::active())).pointer_alignment())));
-case 28 /* MutableReference */:return JaktInternal::ExplicitValue(TRY((TRY((Jakt::jakt__platform::Target::active())).pointer_alignment())));
-case 29 /* Function */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 30 /* Self */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 25 /* RawPtr */:return TRY((Jakt::jakt__platform::Target::active())).pointer_alignment();case 26 /* Trait */:return static_cast<size_t>(0ULL);case 27 /* Reference */:return TRY((Jakt::jakt__platform::Target::active())).pointer_alignment();case 28 /* MutableReference */:return TRY((Jakt::jakt__platform::Target::active())).pointer_alignment();case 29 /* Function */:return static_cast<size_t>(0ULL);case 30 /* Self */:return static_cast<size_t>(0ULL);default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
 ErrorOr<size_t> size_of_impl(Jakt::ids::TypeId const type_id,NonnullRefPtr<Jakt::interpreter::Interpreter> const interpreter) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<size_t>>{
-auto&& __jakt_match_variant = *interpreter->program->get_type(type_id);
+{auto&& __jakt_match_variant = *interpreter->program->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Void */:case 16 /* Unknown */:case 17 /* Never */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 1 /* Bool */:return JaktInternal::ExplicitValue(static_cast<size_t>(1ULL));
-case 6 /* I8 */:case 2 /* U8 */:return JaktInternal::ExplicitValue(static_cast<size_t>(1ULL));
-case 7 /* I16 */:case 3 /* U16 */:return JaktInternal::ExplicitValue(static_cast<size_t>(2ULL));
-case 8 /* I32 */:case 4 /* U32 */:return JaktInternal::ExplicitValue(static_cast<size_t>(4ULL));
-case 9 /* I64 */:case 5 /* U64 */:return JaktInternal::ExplicitValue(static_cast<size_t>(8ULL));
-case 10 /* F32 */:return JaktInternal::ExplicitValue(static_cast<size_t>(4ULL));
-case 11 /* F64 */:return JaktInternal::ExplicitValue(static_cast<size_t>(8ULL));
-case 12 /* Usize */:return JaktInternal::ExplicitValue(TRY((TRY((Jakt::jakt__platform::Target::active())).size_t_size())));
-case 13 /* JaktString */:return JaktInternal::ExplicitValue(TRY((TRY((Jakt::jakt__platform::Target::active())).pointer_size())));
-case 14 /* CChar */:return JaktInternal::ExplicitValue(static_cast<size_t>(1ULL));
-case 15 /* CInt */:return JaktInternal::ExplicitValue(TRY((TRY((Jakt::jakt__platform::Target::active())).int_size())));
-case 18 /* TypeVariable */:case 31 /* Const */:case 19 /* Dependent */:case 22 /* GenericTraitInstance */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 20 /* GenericInstance */: {
+case 0 /* Void */:case 16 /* Unknown */:case 17 /* Never */:return static_cast<size_t>(0ULL);case 1 /* Bool */:return static_cast<size_t>(1ULL);case 6 /* I8 */:case 2 /* U8 */:return static_cast<size_t>(1ULL);case 7 /* I16 */:case 3 /* U16 */:return static_cast<size_t>(2ULL);case 8 /* I32 */:case 4 /* U32 */:return static_cast<size_t>(4ULL);case 9 /* I64 */:case 5 /* U64 */:return static_cast<size_t>(8ULL);case 10 /* F32 */:return static_cast<size_t>(4ULL);case 11 /* F64 */:return static_cast<size_t>(8ULL);case 12 /* Usize */:return TRY((Jakt::jakt__platform::Target::active())).size_t_size();case 13 /* JaktString */:return TRY((Jakt::jakt__platform::Target::active())).pointer_size();case 14 /* CChar */:return static_cast<size_t>(1ULL);case 15 /* CInt */:return TRY((Jakt::jakt__platform::Target::active())).int_size();case 18 /* TypeVariable */:case 31 /* Const */:case 19 /* Dependent */:case 22 /* GenericTraitInstance */:return static_cast<size_t>(0ULL);case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& struct_id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
 {
@@ -442,7 +345,7 @@ ScopeGuard __jakt_var_10([&] {
 i += static_cast<i64>(1LL);
 });
 if (param.type_id.equals(type_id)){
-return args.operator[](i);
+return args[i];
 }
 }
 
@@ -490,14 +393,13 @@ size += JaktInternal::checked_sub(align,total_slack);
 }
 }
 
-return JaktInternal::ExplicitValue<size_t>(size);
+return size;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});
-{
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});{
 Jakt::types::CheckedStruct const struct_ = interpreter->program->get_struct(struct_id);
 Function<Jakt::ids::TypeId(Jakt::ids::TypeId)> const resolve_type_id = [&struct_, &args](Jakt::ids::TypeId type_id) -> Jakt::ids::TypeId {{
 i64 i = static_cast<i64>(0LL);
@@ -514,7 +416,7 @@ ScopeGuard __jakt_var_11([&] {
 i += static_cast<i64>(1LL);
 });
 if (param.type_id.equals(type_id)){
-return args.operator[](i);
+return args[i];
 }
 }
 
@@ -562,7 +464,7 @@ size += JaktInternal::checked_sub(align,total_slack);
 }
 }
 
-return JaktInternal::ExplicitValue<size_t>(size);
+return size;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -586,7 +488,7 @@ ScopeGuard __jakt_var_12([&] {
 i += static_cast<i64>(1LL);
 });
 if (param.type_id.equals(type_id)){
-return args.operator[](i);
+return args[i];
 }
 }
 
@@ -597,9 +499,7 @@ return type_id;
 }
 }
 ;
-return JaktInternal::ExplicitValue<size_t>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<size_t>> {
-auto __jakt_enum_value = (enum_.underlying_type_id.equals(Jakt::types::void_type_id()));
+{auto __jakt_enum_value = enum_.underlying_type_id.equals(Jakt::types::void_type_id());
 if (__jakt_enum_value) {{
 size_t size = static_cast<size_t>(0ULL);
 size_t container_align = static_cast<size_t>(0ULL);
@@ -612,24 +512,20 @@ break;
 }
 Jakt::types::CheckedEnumVariant variant = _magic_value.value();
 {
-size_t const variant_size = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<size_t>>{
-auto&& __jakt_match_variant = variant;
+size_t const variant_size = TRY(([&]() -> ErrorOr<size_t> { auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Untyped */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 1 /* Typed */: {
+case 0 /* Untyped */:return static_cast<size_t>(0ULL);case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
 size_t const align = TRY((Jakt::interpreter::align_of_impl(resolve_type_id(type_id),interpreter)));
 if (align > container_align){
 container_align = align;
 }
-return JaktInternal::ExplicitValue<size_t>(TRY((Jakt::interpreter::size_of_impl(type_id,interpreter))));
+return Jakt::interpreter::size_of_impl(type_id,interpreter);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-case 2 /* WithValue */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 3 /* StructLike */: {
+case 2 /* WithValue */:return static_cast<size_t>(0ULL);case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;JaktInternal::DynamicArray<Jakt::ids::VarId> const& fields = __jakt_match_value.fields;
 {
 size_t size = static_cast<size_t>(0ULL);
@@ -672,21 +568,13 @@ size += JaktInternal::checked_sub(align,total_slack);
 if (align > container_align){
 container_align = align;
 }
-return JaktInternal::ExplicitValue<size_t>(size);
+return size;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}()));
 if (variant_size > size){
 size = variant_size;
 }
@@ -695,16 +583,9 @@ size = variant_size;
 }
 }
 
-Jakt::types::BuiltinType const index_type = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BuiltinType,ErrorOr<size_t>> {
-auto __jakt_enum_value = (enum_.variants.size());
-if (__jakt_enum_value >= static_cast<size_t>(0ULL)&&__jakt_enum_value < static_cast<size_t>(256ULL)) {return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::U8());
-}else {return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::Usize());
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+Jakt::types::BuiltinType const index_type = [&]() -> Jakt::types::BuiltinType { auto __jakt_enum_value = enum_.variants.size();
+if (__jakt_enum_value >= static_cast<size_t>(0ULL)&&__jakt_enum_value < static_cast<size_t>(256ULL)) {return Jakt::types::BuiltinType::U8();}else {return Jakt::types::BuiltinType::Usize();} 
+}();
 size_t const index_align = TRY((Jakt::interpreter::align_of_impl(Jakt::types::builtin(index_type),interpreter)));
 size_t const index_size = TRY((Jakt::interpreter::size_of_impl(Jakt::types::builtin(index_type),interpreter)));
 size_t const index_slack = JaktInternal::checked_mod(size,index_align);
@@ -718,22 +599,16 @@ if (slack != static_cast<size_t>(0ULL)){
 size += JaktInternal::checked_sub(container_align,slack);
 }
 }
-return JaktInternal::ExplicitValue<size_t>(size);
+return size;
 }
 VERIFY_NOT_REACHED();
-}else {return JaktInternal::ExplicitValue(TRY((Jakt::interpreter::align_of_impl(enum_.underlying_type_id,interpreter))));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}else {return Jakt::interpreter::align_of_impl(enum_.underlying_type_id,interpreter);}}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});
-{
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});{
 Jakt::types::CheckedEnum const enum_ = interpreter->program->get_enum(enum_id);
 Function<Jakt::ids::TypeId(Jakt::ids::TypeId)> const resolve_type_id = [&enum_, &args](Jakt::ids::TypeId type_id) -> Jakt::ids::TypeId {{
 i64 i = static_cast<i64>(0LL);
@@ -750,7 +625,7 @@ ScopeGuard __jakt_var_13([&] {
 i += static_cast<i64>(1LL);
 });
 if (param.type_id.equals(type_id)){
-return args.operator[](i);
+return args[i];
 }
 }
 
@@ -761,9 +636,7 @@ return type_id;
 }
 }
 ;
-return JaktInternal::ExplicitValue<size_t>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<size_t>> {
-auto __jakt_enum_value = (enum_.underlying_type_id.equals(Jakt::types::void_type_id()));
+{auto __jakt_enum_value = enum_.underlying_type_id.equals(Jakt::types::void_type_id());
 if (__jakt_enum_value) {{
 size_t size = static_cast<size_t>(0ULL);
 size_t container_align = static_cast<size_t>(0ULL);
@@ -776,24 +649,20 @@ break;
 }
 Jakt::types::CheckedEnumVariant variant = _magic_value.value();
 {
-size_t const variant_size = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<size_t>>{
-auto&& __jakt_match_variant = variant;
+size_t const variant_size = TRY(([&]() -> ErrorOr<size_t> { auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Untyped */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 1 /* Typed */: {
+case 0 /* Untyped */:return static_cast<size_t>(0ULL);case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
 size_t const align = TRY((Jakt::interpreter::align_of_impl(resolve_type_id(type_id),interpreter)));
 if (align > container_align){
 container_align = align;
 }
-return JaktInternal::ExplicitValue<size_t>(TRY((Jakt::interpreter::size_of_impl(type_id,interpreter))));
+return Jakt::interpreter::size_of_impl(type_id,interpreter);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-case 2 /* WithValue */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 3 /* StructLike */: {
+case 2 /* WithValue */:return static_cast<size_t>(0ULL);case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;JaktInternal::DynamicArray<Jakt::ids::VarId> const& fields = __jakt_match_value.fields;
 {
 size_t size = static_cast<size_t>(0ULL);
@@ -836,21 +705,13 @@ size += JaktInternal::checked_sub(align,total_slack);
 if (align > container_align){
 container_align = align;
 }
-return JaktInternal::ExplicitValue<size_t>(size);
+return size;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}()));
 if (variant_size > size){
 size = variant_size;
 }
@@ -859,16 +720,9 @@ size = variant_size;
 }
 }
 
-Jakt::types::BuiltinType const index_type = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BuiltinType,ErrorOr<size_t>> {
-auto __jakt_enum_value = (enum_.variants.size());
-if (__jakt_enum_value >= static_cast<size_t>(0ULL)&&__jakt_enum_value < static_cast<size_t>(256ULL)) {return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::U8());
-}else {return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::Usize());
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+Jakt::types::BuiltinType const index_type = [&]() -> Jakt::types::BuiltinType { auto __jakt_enum_value = enum_.variants.size();
+if (__jakt_enum_value >= static_cast<size_t>(0ULL)&&__jakt_enum_value < static_cast<size_t>(256ULL)) {return Jakt::types::BuiltinType::U8();}else {return Jakt::types::BuiltinType::Usize();} 
+}();
 size_t const index_align = TRY((Jakt::interpreter::align_of_impl(Jakt::types::builtin(index_type),interpreter)));
 size_t const index_size = TRY((Jakt::interpreter::size_of_impl(Jakt::types::builtin(index_type),interpreter)));
 size_t const index_slack = JaktInternal::checked_mod(size,index_align);
@@ -882,408 +736,175 @@ if (slack != static_cast<size_t>(0ULL)){
 size += JaktInternal::checked_sub(container_align,slack);
 }
 }
-return JaktInternal::ExplicitValue<size_t>(size);
+return size;
 }
 VERIFY_NOT_REACHED();
-}else {return JaktInternal::ExplicitValue(TRY((Jakt::interpreter::align_of_impl(enum_.underlying_type_id,interpreter))));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}else {return Jakt::interpreter::align_of_impl(enum_.underlying_type_id,interpreter);}}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-case 25 /* RawPtr */:return JaktInternal::ExplicitValue(TRY((TRY((Jakt::jakt__platform::Target::active())).pointer_size())));
-case 26 /* Trait */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 27 /* Reference */:return JaktInternal::ExplicitValue(TRY((TRY((Jakt::jakt__platform::Target::active())).pointer_size())));
-case 28 /* MutableReference */:return JaktInternal::ExplicitValue(TRY((TRY((Jakt::jakt__platform::Target::active())).pointer_size())));
-case 29 /* Function */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 30 /* Self */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 25 /* RawPtr */:return TRY((Jakt::jakt__platform::Target::active())).pointer_size();case 26 /* Trait */:return static_cast<size_t>(0ULL);case 27 /* Reference */:return TRY((Jakt::jakt__platform::Target::active())).pointer_size();case 28 /* MutableReference */:return TRY((Jakt::jakt__platform::Target::active())).pointer_size();case 29 /* Function */:return static_cast<size_t>(0ULL);case 30 /* Self */:return static_cast<size_t>(0ULL);default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
 ErrorOr<Jakt::types::Value> cast_value_to_type(Jakt::types::Value const this_value,Jakt::ids::TypeId const type_id,NonnullRefPtr<Jakt::interpreter::Interpreter> const interpreter,bool const saturating) {
 {
 NonnullRefPtr<typename Jakt::types::Type> const type = interpreter->program->get_type(type_id);
-bool const is_optional = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *type;
+bool const is_optional = TRY(([&]() -> ErrorOr<bool> { auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(id.equals(TRY((interpreter->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv))))));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *type;
+return id.equals(TRY((interpreter->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv)))));};/*case end*/
+default:return false;}/*switch end*/
+ 
+}()));
+{auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* U8 */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *this_value.impl;
+case 2 /* U8 */:{auto&& __jakt_match_variant = *this_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U8(infallible_integer_cast<u8>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::U8(infallible_integer_cast<u8>(value)),this_value.span);};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U8(infallible_integer_cast<u8>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::U8(infallible_integer_cast<u8>(value)),this_value.span);};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U8(infallible_integer_cast<u8>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::U8(infallible_integer_cast<u8>(value)),this_value.span);};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U8(infallible_integer_cast<u8>(value)),this_value.span));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value,ErrorOr<Jakt::types::Value>> {
-auto __jakt_enum_value = (is_optional);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(this_value);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 3 /* U16 */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *this_value.impl;
+return Jakt::types::Value(Jakt::types::ValueImpl::U8(infallible_integer_cast<u8>(value)),this_value.span);};/*case end*/
+default:{auto __jakt_enum_value = is_optional;
+if (__jakt_enum_value) {return Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span);}else if (!__jakt_enum_value) {return this_value;}VERIFY_NOT_REACHED();
+}}/*switch end*/
+}case 3 /* U16 */:{auto&& __jakt_match_variant = *this_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U16(infallible_integer_cast<u16>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::U16(infallible_integer_cast<u16>(value)),this_value.span);};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U16(infallible_integer_cast<u16>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::U16(infallible_integer_cast<u16>(value)),this_value.span);};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U16(infallible_integer_cast<u16>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::U16(infallible_integer_cast<u16>(value)),this_value.span);};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U16(infallible_integer_cast<u16>(value)),this_value.span));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value,ErrorOr<Jakt::types::Value>> {
-auto __jakt_enum_value = (is_optional);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(this_value);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 4 /* U32 */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *this_value.impl;
+return Jakt::types::Value(Jakt::types::ValueImpl::U16(infallible_integer_cast<u16>(value)),this_value.span);};/*case end*/
+default:{auto __jakt_enum_value = is_optional;
+if (__jakt_enum_value) {return Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span);}else if (!__jakt_enum_value) {return this_value;}VERIFY_NOT_REACHED();
+}}/*switch end*/
+}case 4 /* U32 */:{auto&& __jakt_match_variant = *this_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U32(infallible_integer_cast<u32>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::U32(infallible_integer_cast<u32>(value)),this_value.span);};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U32(infallible_integer_cast<u32>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::U32(infallible_integer_cast<u32>(value)),this_value.span);};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U32(infallible_integer_cast<u32>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::U32(infallible_integer_cast<u32>(value)),this_value.span);};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U32(infallible_integer_cast<u32>(value)),this_value.span));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value,ErrorOr<Jakt::types::Value>> {
-auto __jakt_enum_value = (is_optional);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(this_value);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 5 /* U64 */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *this_value.impl;
+return Jakt::types::Value(Jakt::types::ValueImpl::U32(infallible_integer_cast<u32>(value)),this_value.span);};/*case end*/
+default:{auto __jakt_enum_value = is_optional;
+if (__jakt_enum_value) {return Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span);}else if (!__jakt_enum_value) {return this_value;}VERIFY_NOT_REACHED();
+}}/*switch end*/
+}case 5 /* U64 */:{auto&& __jakt_match_variant = *this_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U64(infallible_integer_cast<u64>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::U64(infallible_integer_cast<u64>(value)),this_value.span);};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U64(infallible_integer_cast<u64>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::U64(infallible_integer_cast<u64>(value)),this_value.span);};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U64(infallible_integer_cast<u64>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::U64(infallible_integer_cast<u64>(value)),this_value.span);};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U64(infallible_integer_cast<u64>(value)),this_value.span));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value,ErrorOr<Jakt::types::Value>> {
-auto __jakt_enum_value = (is_optional);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(this_value);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 6 /* I8 */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *this_value.impl;
+return Jakt::types::Value(Jakt::types::ValueImpl::U64(infallible_integer_cast<u64>(value)),this_value.span);};/*case end*/
+default:{auto __jakt_enum_value = is_optional;
+if (__jakt_enum_value) {return Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span);}else if (!__jakt_enum_value) {return this_value;}VERIFY_NOT_REACHED();
+}}/*switch end*/
+}case 6 /* I8 */:{auto&& __jakt_match_variant = *this_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I8(infallible_integer_cast<i8>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::I8(infallible_integer_cast<i8>(value)),this_value.span);};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I8(infallible_integer_cast<i8>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::I8(infallible_integer_cast<i8>(value)),this_value.span);};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I8(infallible_integer_cast<i8>(value)),this_value.span));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value,ErrorOr<Jakt::types::Value>> {
-auto __jakt_enum_value = (is_optional);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(this_value);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 7 /* I16 */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *this_value.impl;
+return Jakt::types::Value(Jakt::types::ValueImpl::I8(infallible_integer_cast<i8>(value)),this_value.span);};/*case end*/
+default:{auto __jakt_enum_value = is_optional;
+if (__jakt_enum_value) {return Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span);}else if (!__jakt_enum_value) {return this_value;}VERIFY_NOT_REACHED();
+}}/*switch end*/
+}case 7 /* I16 */:{auto&& __jakt_match_variant = *this_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I16(infallible_integer_cast<i16>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::I16(infallible_integer_cast<i16>(value)),this_value.span);};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I16(infallible_integer_cast<i16>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::I16(infallible_integer_cast<i16>(value)),this_value.span);};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I16(infallible_integer_cast<i16>(value)),this_value.span));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value,ErrorOr<Jakt::types::Value>> {
-auto __jakt_enum_value = (is_optional);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(this_value);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 8 /* I32 */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *this_value.impl;
+return Jakt::types::Value(Jakt::types::ValueImpl::I16(infallible_integer_cast<i16>(value)),this_value.span);};/*case end*/
+default:{auto __jakt_enum_value = is_optional;
+if (__jakt_enum_value) {return Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span);}else if (!__jakt_enum_value) {return this_value;}VERIFY_NOT_REACHED();
+}}/*switch end*/
+}case 8 /* I32 */:{auto&& __jakt_match_variant = *this_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I32(infallible_integer_cast<i32>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::I32(infallible_integer_cast<i32>(value)),this_value.span);};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I32(infallible_integer_cast<i32>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::I32(infallible_integer_cast<i32>(value)),this_value.span);};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I32(infallible_integer_cast<i32>(value)),this_value.span));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value,ErrorOr<Jakt::types::Value>> {
-auto __jakt_enum_value = (is_optional);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(this_value);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 9 /* I64 */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *this_value.impl;
+return Jakt::types::Value(Jakt::types::ValueImpl::I32(infallible_integer_cast<i32>(value)),this_value.span);};/*case end*/
+default:{auto __jakt_enum_value = is_optional;
+if (__jakt_enum_value) {return Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span);}else if (!__jakt_enum_value) {return this_value;}VERIFY_NOT_REACHED();
+}}/*switch end*/
+}case 9 /* I64 */:{auto&& __jakt_match_variant = *this_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I64(infallible_integer_cast<i64>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::I64(infallible_integer_cast<i64>(value)),this_value.span);};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I64(infallible_integer_cast<i64>(value)),this_value.span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::I64(infallible_integer_cast<i64>(value)),this_value.span);};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I64(infallible_integer_cast<i64>(value)),this_value.span));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value,ErrorOr<Jakt::types::Value>> {
-auto __jakt_enum_value = (is_optional);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(this_value);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 12 /* Usize */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *this_value.impl;
+return Jakt::types::Value(Jakt::types::ValueImpl::I64(infallible_integer_cast<i64>(value)),this_value.span);};/*case end*/
+default:{auto __jakt_enum_value = is_optional;
+if (__jakt_enum_value) {return Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span);}else if (!__jakt_enum_value) {return this_value;}VERIFY_NOT_REACHED();
+}}/*switch end*/
+}case 12 /* Usize */:{auto&& __jakt_match_variant = *this_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(infallible_integer_cast<size_t>(value)),this_value.span));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value,ErrorOr<Jakt::types::Value>> {
-auto __jakt_enum_value = (is_optional);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(this_value);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value,ErrorOr<Jakt::types::Value>> {
-auto __jakt_enum_value = (is_optional);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *this_value.impl;
+return Jakt::types::Value(Jakt::types::ValueImpl::USize(infallible_integer_cast<size_t>(value)),this_value.span);};/*case end*/
+default:{auto __jakt_enum_value = is_optional;
+if (__jakt_enum_value) {return Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span);}else if (!__jakt_enum_value) {return this_value;}VERIFY_NOT_REACHED();
+}}/*switch end*/
+}default:{auto __jakt_enum_value = is_optional;
+if (__jakt_enum_value) {{auto&& __jakt_match_variant = *this_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 24 /* OptionalSome */:case 25 /* OptionalNone */:return JaktInternal::ExplicitValue(this_value);
-default:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else {return JaktInternal::ExplicitValue(this_value);
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 24 /* OptionalSome */:case 25 /* OptionalNone */:return this_value;default:return Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(this_value),this_value.span);}/*switch end*/
+}}else {return this_value;}}}/*switch end*/
+}
 }
 }
 
 ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>> value_to_checked_expression(Jakt::types::Value const this_value,NonnullRefPtr<Jakt::interpreter::Interpreter> interpreter) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedExpression>, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *this_value.impl;
+{auto&& __jakt_match_variant = *this_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Void */:{
 TRY((interpreter->error(ByteString::from_utf8_without_validation("Cannot convert void to expression"sv),this_value.span)));
@@ -1291,70 +912,53 @@ interpreter->compiler->panic(ByteString::from_utf8_without_validation("Invalid t
 }
 case 1 /* Bool */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Bool;bool const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::Boolean(JaktInternal::OptionalNone(),x,this_value.span));
-};/*case end*/
+return Jakt::types::CheckedExpression::Boolean(JaktInternal::OptionalNone(),x,this_value.span);};/*case end*/
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::U8(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::U8())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::U8(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::U8()));};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::U16(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::U16())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::U16(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::U16()));};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::U32(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::U32())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::U32(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::U32()));};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::U64(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::U64())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::U64(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::U64()));};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I8(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::I8())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I8(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::I8()));};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I16(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::I16())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I16(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::I16()));};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I32(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::I32())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I32(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::I32()));};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I64(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::I64())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I64(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::I64()));};/*case end*/
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::F32(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::F32())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::F32(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::F32()));};/*case end*/
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::F64(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::F64())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::F64(x),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::F64()));};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::USize(infallible_integer_cast<u64>(x)),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::Usize())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::USize(infallible_integer_cast<u64>(x)),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::Usize()));};/*case end*/
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),Jakt::types::CheckedStringLiteral(Jakt::types::StringLiteral::Static(Jakt::utility::escape_for_quotes(x)),interpreter->program->find_or_add_type_id(Jakt::types::Type::Struct(Jakt::parser::CheckedQualifiers(false),TRY((interpreter->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("String"sv))))),interpreter->program->prelude_module_id(),false),false),this_value.span));
-};/*case end*/
+return Jakt::types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),Jakt::types::CheckedStringLiteral(Jakt::types::StringLiteral::Static(Jakt::utility::escape_for_quotes(x)),interpreter->program->find_or_add_type_id(Jakt::types::Type::Struct(Jakt::parser::CheckedQualifiers(false),TRY((interpreter->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("String"sv))))),interpreter->program->prelude_module_id(),false),false),this_value.span);};/*case end*/
 case 14 /* StringView */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StringView;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),Jakt::types::CheckedStringLiteral(Jakt::types::StringLiteral::Static(Jakt::utility::escape_for_quotes(x)),interpreter->program->find_or_add_type_id(Jakt::types::Type::Struct(Jakt::parser::CheckedQualifiers(false),TRY((interpreter->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("StringView"sv))))),interpreter->program->prelude_module_id(),false),false),this_value.span));
-};/*case end*/
+return Jakt::types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),Jakt::types::CheckedStringLiteral(Jakt::types::StringLiteral::Static(Jakt::utility::escape_for_quotes(x)),interpreter->program->find_or_add_type_id(Jakt::types::Type::Struct(Jakt::parser::CheckedQualifiers(false),TRY((interpreter->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("StringView"sv))))),interpreter->program->prelude_module_id(),false),false),this_value.span);};/*case end*/
 case 15 /* CChar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CChar;char const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::CCharacterConstant(JaktInternal::OptionalNone(),__jakt_format(StringView::from_string_literal("{}"sv),x),this_value.span));
-};/*case end*/
+return Jakt::types::CheckedExpression::CCharacterConstant(JaktInternal::OptionalNone(),__jakt_format(StringView::from_string_literal("{}"sv),x),this_value.span);};/*case end*/
 case 16 /* CInt */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CInt;int const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I32(infallible_integer_cast<i32>(x)),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::CInt())));
-};/*case end*/
-case 25 /* OptionalNone */:return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::OptionalNone(JaktInternal::OptionalNone(),this_value.span,Jakt::types::unknown_type_id()));
-case 24 /* OptionalSome */: {
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I32(infallible_integer_cast<i32>(x)),this_value.span,Jakt::types::builtin(Jakt::types::BuiltinType::CInt()));};/*case end*/
+case 25 /* OptionalNone */:return Jakt::types::CheckedExpression::OptionalNone(JaktInternal::OptionalNone(),this_value.span,Jakt::types::unknown_type_id());case 24 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr = TRY((Jakt::interpreter::value_to_checked_expression(value,interpreter)));
@@ -1362,7 +966,7 @@ Jakt::ids::TypeId const inner_type_id = expr->type();
 Jakt::ids::StructId const optional_struct_id = TRY((interpreter->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv))));
 NonnullRefPtr<typename Jakt::types::Type> const type = Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),optional_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({inner_type_id}));
 Jakt::ids::TypeId const type_id = interpreter->find_or_add_type_id(type);
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::OptionalSome(JaktInternal::OptionalNone(),expr,this_value.span,type_id));
+return Jakt::types::CheckedExpression::OptionalSome(JaktInternal::OptionalNone(),expr,this_value.span,type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1386,7 +990,7 @@ vals.push(TRY((Jakt::interpreter::value_to_checked_expression(field,interpreter)
 }
 }
 
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::JaktTuple(JaktInternal::OptionalNone(),vals,this_value.span,type_id));
+return Jakt::types::CheckedExpression::JaktTuple(JaktInternal::OptionalNone(),vals,this_value.span,type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1435,7 +1039,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-namespace_.push(reversed_namespace.operator[](JaktInternal::checked_sub(i,static_cast<size_t>(1ULL))));
+namespace_.push(reversed_namespace[JaktInternal::checked_sub(i,static_cast<size_t>(1ULL))]);
 }
 
 }
@@ -1457,8 +1061,8 @@ break;
 }
 size_t i = _magic_value.value();
 {
-NonnullRefPtr<typename Jakt::types::CheckedExpression> const arg = materialised_fields.operator[](i);
-ByteString const label = callee->params.operator[](i).variable->name;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const arg = materialised_fields[i];
+ByteString const label = callee->params[i].variable->name;
 args.push(Tuple{label, arg});
 }
 
@@ -1466,7 +1070,7 @@ args.push(Tuple{label, arg});
 }
 
 Jakt::types::CheckedCall const call = Jakt::types::CheckedCall(namespace_,name,args,DynamicArray<Jakt::ids::TypeId>::create_with({}),constructor,struct_.type_id,callee->can_throw,JaktInternal::OptionalNone(),Jakt::parser::InlineState::Default());
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::Call(JaktInternal::OptionalNone(),call,this_value.span,struct_.type_id));
+return Jakt::types::CheckedExpression::Call(JaktInternal::OptionalNone(),call,this_value.span,struct_.type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1515,7 +1119,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-namespace_.push(reversed_namespace.operator[](JaktInternal::checked_sub(i,static_cast<size_t>(1ULL))));
+namespace_.push(reversed_namespace[JaktInternal::checked_sub(i,static_cast<size_t>(1ULL))]);
 }
 
 }
@@ -1537,8 +1141,8 @@ break;
 }
 size_t i = _magic_value.value();
 {
-NonnullRefPtr<typename Jakt::types::CheckedExpression> const arg = materialised_fields.operator[](i);
-ByteString const label = callee->params.operator[](i).variable->name;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const arg = materialised_fields[i];
+ByteString const label = callee->params[i].variable->name;
 args.push(Tuple{label, arg});
 }
 
@@ -1546,7 +1150,7 @@ args.push(Tuple{label, arg});
 }
 
 Jakt::types::CheckedCall const call = Jakt::types::CheckedCall(namespace_,name,args,DynamicArray<Jakt::ids::TypeId>::create_with({}),constructor,struct_.type_id,callee->can_throw,JaktInternal::OptionalNone(),Jakt::parser::InlineState::Default());
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::Call(JaktInternal::OptionalNone(),call,this_value.span,struct_.type_id));
+return Jakt::types::CheckedExpression::Call(JaktInternal::OptionalNone(),call,this_value.span,struct_.type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1591,7 +1195,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-namespace_.push(reversed_namespace.operator[](JaktInternal::checked_sub(i,static_cast<size_t>(1ULL))));
+namespace_.push(reversed_namespace[JaktInternal::checked_sub(i,static_cast<size_t>(1ULL))]);
 }
 
 }
@@ -1609,7 +1213,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-NonnullRefPtr<typename Jakt::types::CheckedExpression> const arg = materialised_fields.operator[](i);
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const arg = materialised_fields[i];
 args.push(Tuple{ByteString::from_utf8_without_validation(""sv), arg});
 }
 
@@ -1618,7 +1222,7 @@ args.push(Tuple{ByteString::from_utf8_without_validation(""sv), arg});
 
 NonnullRefPtr<Jakt::types::CheckedFunction> const callee = interpreter->program->get_function(constructor);
 Jakt::types::CheckedCall const call = Jakt::types::CheckedCall(namespace_,callee->name,args,DynamicArray<Jakt::ids::TypeId>::create_with({}),constructor,enum_.type_id,callee->can_throw,JaktInternal::OptionalNone(),Jakt::parser::InlineState::Default());
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::Call(JaktInternal::OptionalNone(),call,this_value.span,enum_.type_id));
+return Jakt::types::CheckedExpression::Call(JaktInternal::OptionalNone(),call,this_value.span,enum_.type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1642,25 +1246,18 @@ vals.push(TRY((Jakt::interpreter::value_to_checked_expression(value,interpreter)
 }
 }
 
-Jakt::ids::TypeId const inner_type_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *interpreter->program->get_type(type_id);
+Jakt::ids::TypeId const inner_type_id = [&]() -> Jakt::ids::TypeId { auto&& __jakt_match_variant = *interpreter->program->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(args.operator[](static_cast<i64>(0LL)));
-};/*case end*/
+return args[static_cast<i64>(0LL)];};/*case end*/
 default:{
 interpreter->compiler->panic(ByteString::from_utf8_without_validation("Expected generic instance of Array while materialising an array"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::JaktArray(JaktInternal::OptionalNone(),vals,JaktInternal::OptionalNone(),this_value.span,type_id,inner_type_id));
+ 
+}();
+return Jakt::types::CheckedExpression::JaktArray(JaktInternal::OptionalNone(),vals,JaktInternal::OptionalNone(),this_value.span,type_id,inner_type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1679,34 +1276,27 @@ break;
 }
 size_t i = _magic_value.value();
 {
-vals.push(Tuple{TRY((Jakt::interpreter::value_to_checked_expression(keys.operator[](i),interpreter))), TRY((Jakt::interpreter::value_to_checked_expression(values.operator[](i),interpreter)))});
+vals.push(Tuple{TRY((Jakt::interpreter::value_to_checked_expression(keys[i],interpreter))), TRY((Jakt::interpreter::value_to_checked_expression(values[i],interpreter)))});
 }
 
 }
 }
 
-JaktInternal::Tuple<Jakt::ids::TypeId,Jakt::ids::TypeId> const key_type_id_value_type_id_ = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<Jakt::ids::TypeId,Jakt::ids::TypeId>, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *interpreter->program->get_type(type_id);
+JaktInternal::Tuple<Jakt::ids::TypeId,Jakt::ids::TypeId> const key_type_id_value_type_id_ = [&]() -> JaktInternal::Tuple<Jakt::ids::TypeId,Jakt::ids::TypeId> { auto&& __jakt_match_variant = *interpreter->program->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(Tuple{args.operator[](static_cast<i64>(0LL)), args.operator[](static_cast<i64>(1LL))});
-};/*case end*/
+return Tuple{args[static_cast<i64>(0LL)], args[static_cast<i64>(1LL)]};};/*case end*/
 default:{
 interpreter->compiler->panic(ByteString::from_utf8_without_validation("Expected generic instance of Dictionary while materialising an array"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 Jakt::ids::TypeId const key_type_id = key_type_id_value_type_id_.template get<0>();
 Jakt::ids::TypeId const value_type_id = key_type_id_value_type_id_.template get<1>();
 
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::JaktDictionary(JaktInternal::OptionalNone(),vals,this_value.span,type_id,key_type_id,value_type_id));
+return Jakt::types::CheckedExpression::JaktDictionary(JaktInternal::OptionalNone(),vals,this_value.span,type_id,key_type_id,value_type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1724,31 +1314,24 @@ break;
 }
 size_t i = _magic_value.value();
 {
-vals.push(TRY((Jakt::interpreter::value_to_checked_expression(values.operator[](i),interpreter))));
+vals.push(TRY((Jakt::interpreter::value_to_checked_expression(values[i],interpreter))));
 }
 
 }
 }
 
-Jakt::ids::TypeId const value_type_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *interpreter->program->get_type(type_id);
+Jakt::ids::TypeId const value_type_id = [&]() -> Jakt::ids::TypeId { auto&& __jakt_match_variant = *interpreter->program->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(args.operator[](static_cast<i64>(0LL)));
-};/*case end*/
+return args[static_cast<i64>(0LL)];};/*case end*/
 default:{
 interpreter->compiler->panic(ByteString::from_utf8_without_validation("Expected generic instance of Set while materialising an array"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::JaktSet(JaktInternal::OptionalNone(),vals,this_value.span,type_id,value_type_id));
+ 
+}();
+return Jakt::types::CheckedExpression::JaktSet(JaktInternal::OptionalNone(),vals,this_value.span,type_id,value_type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1788,7 +1371,7 @@ Jakt::types::CheckedBlock const new_block = Jakt::types::CheckedBlock(statements
 NonnullRefPtr<Jakt::types::CheckedFunction> const checked_function = Jakt::types::CheckedFunction::__jakt_create(ByteString::from_utf8_without_validation("synthetic_lambda"sv),this_value.span,Jakt::types::CheckedVisibility::Public(),return_type_id,JaktInternal::OptionalNone(),checked_params,Jakt::types::FunctionGenerics::__jakt_create(inherited_scope_id,checked_params,DynamicArray<Jakt::types::FunctionGenericParameter>::create_with({}),DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>::create_with({})),new_block,can_throw,Jakt::parser::FunctionType::Expression(),Jakt::parser::FunctionLinkage::Internal(),inherited_scope_id,JaktInternal::OptionalNone(),true,JaktInternal::OptionalNone(),false,false,false,false,false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),Jakt::parser::InlineState::Default(),false);
 Function<ErrorOr<Jakt::ids::FunctionId>(NonnullRefPtr<Jakt::types::CheckedFunction>)> const& register_function = interpreter->typecheck_functions->register_function;
 Jakt::ids::FunctionId const pseudo_function_id = TRY((register_function(checked_function)));
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::Function(JaktInternal::OptionalNone(),DynamicArray<Jakt::types::CheckedCapture>::create_with({}),checked_params,can_throw,return_type_id,new_block,this_value.span,type_id,pseudo_function_id,scope_id));
+return Jakt::types::CheckedExpression::Function(JaktInternal::OptionalNone(),DynamicArray<Jakt::types::CheckedCapture>::create_with({}),checked_params,can_throw,return_type_id,new_block,this_value.span,type_id,pseudo_function_id,scope_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1797,12 +1380,7 @@ TRY((interpreter->error(__jakt_format(StringView::from_string_literal("Cannot ma
 interpreter->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -1894,12 +1472,12 @@ return Jakt::interpreter::InterpreterScope::__jakt_create(bindings,parent,Dictio
 ErrorOr<Jakt::types::Value> Jakt::interpreter::InterpreterScope::must_get(ByteString const name) const {
 {
 if (this->bindings.contains(name)){
-return this->bindings.operator[](name);
+return this->bindings[name];
 }
 JaktInternal::Optional<NonnullRefPtr<Jakt::interpreter::InterpreterScope>> scope = this->parent;
 while (scope.has_value()){
 if (scope.value()->bindings.contains(name)){
-return scope.value()->bindings.operator[](name);
+return scope.value()->bindings[name];
 }
 scope = scope.value()->parent;
 }
@@ -1958,12 +1536,12 @@ return bindings;
 Jakt::ids::TypeId Jakt::interpreter::InterpreterScope::map_type(Jakt::ids::TypeId const id) const {
 {
 if (this->type_bindings.contains(id)){
-return this->type_bindings.operator[](id);
+return this->type_bindings[id];
 }
 JaktInternal::Optional<NonnullRefPtr<Jakt::interpreter::InterpreterScope>> scope = this->parent;
 while (scope.has_value()){
 if (scope.value()->type_bindings.contains(id)){
-return scope.value()->type_bindings.operator[](id);
+return scope.value()->type_bindings[id];
 }
 scope = scope.value()->parent;
 }
@@ -2006,29 +1584,17 @@ ErrorOr<void> Jakt::interpreter::InterpreterScope::perform_defers(NonnullRefPtr<
 {
 while (!this->defers.is_empty()){
 JaktInternal::Optional<Jakt::interpreter::Deferred> const deferred = this->defers.pop();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<void>>{
-auto&& __jakt_match_variant = deferred.value();
+TRY(([&]() -> ErrorOr<Jakt::interpreter::StatementResult> { auto&& __jakt_match_variant = deferred.value();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((interpreter->execute_expression(expr,*this))));
-};/*case end*/
+return interpreter->execute_expression(expr,*this);};/*case end*/
 case 1 /* Statement */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Statement;NonnullRefPtr<typename Jakt::types::CheckedStatement> const& statement = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((interpreter->execute_statement(statement,*this,span))));
-};/*case end*/
+return interpreter->execute_statement(statement,*this,span);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}()));
 }
 }
 return {};
@@ -2135,32 +1701,26 @@ return this->perform_final_interpretation_pass(TRY((this->typecheck_block(block,
 
 ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedStatement>> Jakt::interpreter::Interpreter::perform_final_interpretation_pass(NonnullRefPtr<typename Jakt::types::CheckedStatement> const statement,NonnullRefPtr<Jakt::interpreter::InterpreterScope> const scope,JaktInternal::Optional<Jakt::ids::FunctionId> const function_id) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedStatement>, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedStatement>>>{
-auto&& __jakt_match_variant = *statement;
+{auto&& __jakt_match_variant = *statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedStatement::Expression(TRY((this->perform_final_interpretation_expr_pass(expr,scope,function_id))),span));
-};/*case end*/
+return Jakt::types::CheckedStatement::Expression(TRY((this->perform_final_interpretation_expr_pass(expr,scope,function_id))),span);};/*case end*/
 case 1 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;NonnullRefPtr<typename Jakt::types::CheckedStatement> const& statement = __jakt_match_value.statement;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedStatement::Defer(TRY((this->perform_final_interpretation_pass(statement,scope,function_id))),span));
-};/*case end*/
+return Jakt::types::CheckedStatement::Defer(TRY((this->perform_final_interpretation_pass(statement,scope,function_id))),span);};/*case end*/
 case 2 /* DestructuringAssignment */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DestructuringAssignment;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const& vars = __jakt_match_value.vars;
 NonnullRefPtr<typename Jakt::types::CheckedStatement> const& var_decl = __jakt_match_value.var_decl;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedStatement::DestructuringAssignment(vars,TRY((this->perform_final_interpretation_pass(var_decl,scope,function_id))),span));
-};/*case end*/
+return Jakt::types::CheckedStatement::DestructuringAssignment(vars,TRY((this->perform_final_interpretation_pass(var_decl,scope,function_id))),span);};/*case end*/
 case 3 /* VarDecl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.VarDecl;Jakt::ids::VarId const& var_id = __jakt_match_value.var_id;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const& init = __jakt_match_value.init;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedStatement::VarDecl(var_id,TRY((this->perform_final_interpretation_expr_pass(init,scope,function_id))),span));
-};/*case end*/
+return Jakt::types::CheckedStatement::VarDecl(var_id,TRY((this->perform_final_interpretation_expr_pass(init,scope,function_id))),span);};/*case end*/
 case 4 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& condition = __jakt_match_value.condition;
 Jakt::types::CheckedBlock const& then_block = __jakt_match_value.then_block;
@@ -2185,17 +1745,10 @@ then_statements.push(TRY((this->perform_final_interpretation_pass(statement,scop
 }
 
 Jakt::types::CheckedBlock const new_then_block = Jakt::types::CheckedBlock(then_statements,then_block.scope_id,then_block.control_flow,then_block.yielded_type,then_block.yielded_none);
-JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const new_else_statement = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedStatement>>,ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedStatement>>> {
-auto __jakt_enum_value = (else_statement.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedStatement>>>(TRY((this->perform_final_interpretation_pass(else_statement.value(),scope,function_id)))));
-}else {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedStatement>>(Jakt::types::CheckedStatement::If(new_condition,new_then_block,new_else_statement,span));
+JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const new_else_statement = TRY(([&]() -> ErrorOr<JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedStatement>>> { auto __jakt_enum_value = else_statement.has_value();
+if (__jakt_enum_value) {return static_cast<JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedStatement>>>(TRY((this->perform_final_interpretation_pass(else_statement.value(),scope,function_id))));}else {return JaktInternal::OptionalNone();} 
+}()));
+return Jakt::types::CheckedStatement::If(new_condition,new_then_block,new_else_statement,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -2220,7 +1773,7 @@ statements.push(TRY((this->perform_final_interpretation_pass(statement,scope,fun
 }
 
 Jakt::types::CheckedBlock const new_block = Jakt::types::CheckedBlock(statements,block.scope_id,block.control_flow,block.yielded_type,block.yielded_none);
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedStatement>>(Jakt::types::CheckedStatement::Block(new_block,span));
+return Jakt::types::CheckedStatement::Block(new_block,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -2245,7 +1798,7 @@ statements.push(TRY((this->perform_final_interpretation_pass(statement,scope,fun
 }
 
 Jakt::types::CheckedBlock const new_block = Jakt::types::CheckedBlock(statements,block.scope_id,block.control_flow,block.yielded_type,block.yielded_none);
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedStatement>>(Jakt::types::CheckedStatement::Loop(new_block,span));
+return Jakt::types::CheckedStatement::Loop(new_block,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -2272,53 +1825,28 @@ statements.push(TRY((this->perform_final_interpretation_pass(statement,scope,fun
 }
 
 Jakt::types::CheckedBlock const new_block = Jakt::types::CheckedBlock(statements,block.scope_id,block.control_flow,block.yielded_type,block.yielded_none);
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedStatement>>(Jakt::types::CheckedStatement::While(new_condition,new_block,span));
+return Jakt::types::CheckedStatement::While(new_condition,new_block,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 8 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& val = __jakt_match_value.val;
 JaktInternal::Optional<Jakt::utility::Span> const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedStatement>,ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedStatement>>> {
-auto __jakt_enum_value = (val.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::CheckedStatement::Return(TRY((this->perform_final_interpretation_expr_pass(val.value(),scope,function_id))),span));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(statement);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-case 9 /* Break */:case 10 /* Continue */:case 13 /* InlineCpp */:case 14 /* Garbage */:return JaktInternal::ExplicitValue(statement);
-case 11 /* Throw */: {
+{auto __jakt_enum_value = val.has_value();
+if (__jakt_enum_value) {return Jakt::types::CheckedStatement::Return(TRY((this->perform_final_interpretation_expr_pass(val.value(),scope,function_id))),span);}else if (!__jakt_enum_value) {return statement;}VERIFY_NOT_REACHED();
+}};/*case end*/
+case 9 /* Break */:case 10 /* Continue */:case 13 /* InlineCpp */:case 14 /* Garbage */:return statement;case 11 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedStatement::Throw(TRY((this->perform_final_interpretation_expr_pass(expr,scope,function_id))),span));
-};/*case end*/
+return Jakt::types::CheckedStatement::Throw(TRY((this->perform_final_interpretation_expr_pass(expr,scope,function_id))),span);};/*case end*/
 case 12 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& expr = __jakt_match_value.expr;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedStatement>,ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedStatement>>> {
-auto __jakt_enum_value = (expr.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::CheckedStatement::Yield(TRY((this->perform_final_interpretation_expr_pass(expr.value(),scope,function_id))),span));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(statement);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+{auto __jakt_enum_value = expr.has_value();
+if (__jakt_enum_value) {return Jakt::types::CheckedStatement::Yield(TRY((this->perform_final_interpretation_expr_pass(expr.value(),scope,function_id))),span);}else if (!__jakt_enum_value) {return statement;}VERIFY_NOT_REACHED();
+}};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -2336,16 +1864,14 @@ return function(block,parent_scope_id,Jakt::types::SafetyMode::Safe(),JaktIntern
 
 ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>> Jakt::interpreter::Interpreter::perform_final_interpretation_expr_pass(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr,NonnullRefPtr<Jakt::interpreter::InterpreterScope> const scope,JaktInternal::Optional<Jakt::ids::FunctionId> const function_id) {
 {
-NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp64 = expr;
-if (__jakt_tmp64->__jakt_init_index() == 6 /* UnaryOp */){
-Jakt::types::CheckedUnaryOperator const op = __jakt_tmp64->as.UnaryOp.op;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp63 = expr;
+if (__jakt_tmp63->__jakt_init_index() == 6 /* UnaryOp */){
+Jakt::types::CheckedUnaryOperator const op = __jakt_tmp63->as.UnaryOp.op;
 if (op.__jakt_init_index() == 11 /* TypeCast */){
 warnln(StringView::from_string_literal("{0:c}[31mFixup{0:c}[0m {1}"sv),static_cast<i64>(27LL),expr);
 }
 }
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedExpression>, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *expr;
+{auto&& __jakt_match_variant = *expr;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 18 /* ComptimeIndex */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ComptimeIndex;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
@@ -2382,7 +1908,7 @@ return JaktInternal::ExplicitValue(Jakt::types::NumericOrStringValue::UnsignedNu
 };/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::NumericOrStringValue::UnsignedNumericValue(infallible_integer_cast<u64>(val)));
+return JaktInternal::ExplicitValue(Jakt::types::NumericOrStringValue::UnsignedNumericValue(static_cast<u64>(val)));
 };/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& val = __jakt_match_value.value;
@@ -2390,15 +1916,15 @@ return JaktInternal::ExplicitValue(Jakt::types::NumericOrStringValue::UnsignedNu
 };/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::NumericOrStringValue::SignedNumericValue(static_cast<i64>(val)));
+return JaktInternal::ExplicitValue(Jakt::types::NumericOrStringValue::SignedNumericValue(infallible_integer_cast<i64>(val)));
 };/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::NumericOrStringValue::SignedNumericValue(static_cast<i64>(val)));
+return JaktInternal::ExplicitValue(Jakt::types::NumericOrStringValue::SignedNumericValue(infallible_integer_cast<i64>(val)));
 };/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::NumericOrStringValue::SignedNumericValue(static_cast<i64>(val)));
+return JaktInternal::ExplicitValue(Jakt::types::NumericOrStringValue::SignedNumericValue(infallible_integer_cast<i64>(val)));
 };/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& val = __jakt_match_value.value;
@@ -2427,9 +1953,7 @@ return Jakt::types::CheckedExpression::Garbage(JaktInternal::OptionalNone(),span
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = index_constant;
+{auto&& __jakt_match_variant = index_constant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* StringValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StringValue;ByteString const& field = __jakt_match_value.value;
@@ -2437,9 +1961,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.StringValue;ByteString const
 Jakt::ids::TypeId const checked_expr_type_id = scope->map_type(expr->type());
 NonnullRefPtr<typename Jakt::types::Type> const checked_expr_type = this->program->get_type(checked_expr_type_id);
 Jakt::ids::StructId const optional_struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv))));
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *checked_expr_type;
+{auto&& __jakt_match_variant = *checked_expr_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
@@ -2451,11 +1973,9 @@ if (!id.equals(optional_struct_id)){
 TRY((this->error(ByteString::from_utf8_without_validation("Optional chaining is only allowed on optional types"sv),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid operation"sv));
 }
-type_id = args.operator[](static_cast<i64>(0LL));
+type_id = args[static_cast<i64>(0LL)];
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *this->program->get_type(type_id);
+{auto&& __jakt_match_variant = *this->program->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& struct_id = __jakt_match_value.id;
@@ -2486,8 +2006,7 @@ return Jakt::types::CheckedExpression::IndexedStruct(JaktInternal::OptionalNone(
 TRY((this->error(__jakt_format(StringView::from_string_literal("unknown member of struct: {}.{}"sv),structure.name,field),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid operation"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_75;};/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
 {
@@ -2517,23 +2036,15 @@ return Jakt::types::CheckedExpression::IndexedStruct(JaktInternal::OptionalNone(
 TRY((this->error(__jakt_format(StringView::from_string_literal("unknown member of struct: {}.{}"sv),structure.name,field),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid operation"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_75;};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Member field access on value of non-struct type ‘{}’"sv),TRY((this->program->type_name(checked_expr_type_id,false)))),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid operation"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_75;}/*switch end*/
+}goto __jakt_label_75; __jakt_label_75:;;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_74;};/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
 {
@@ -2564,46 +2075,31 @@ return Jakt::types::CheckedExpression::IndexedStruct(JaktInternal::OptionalNone(
 TRY((this->error(__jakt_format(StringView::from_string_literal("unknown member of struct: {}.{}"sv),structure.name,field),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid operation"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_74;};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Member field access on value of non-struct type ‘{}’"sv),TRY((this->program->type_name(checked_expr_type_id,false)))),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid operation"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_74;}/*switch end*/
+}goto __jakt_label_74; __jakt_label_74:;;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_73;};/*case end*/
 case 2 /* UnsignedNumericValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnsignedNumericValue;u64 const& val = __jakt_match_value.value;
 {
 TRY((this->error(ByteString::from_utf8_without_validation("Unimplemented expression"sv),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_73;};/*case end*/
 case 1 /* SignedNumericValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SignedNumericValue;i64 const& val = __jakt_match_value.value;
 {
 TRY((this->error(ByteString::from_utf8_without_validation("Unimplemented expression"sv),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_73;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}goto __jakt_label_73; __jakt_label_73:;;
 }
 };/*case end*/
 case 6 /* UnaryOp */: {
@@ -2611,53 +2107,34 @@ auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;NonnullRefPtr<typena
 Jakt::types::CheckedUnaryOperator const& op = __jakt_match_value.op;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),TRY((this->perform_final_interpretation_expr_pass(expr,scope,function_id))),({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::CheckedUnaryOperator, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = op;
+return Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),TRY((this->perform_final_interpretation_expr_pass(expr,scope,function_id))),[&]() -> Jakt::types::CheckedUnaryOperator { auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* TypeCast */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeCast;Jakt::types::CheckedTypeCast const& cast = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedUnaryOperator::TypeCast(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::CheckedTypeCast, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = cast;
+return Jakt::types::CheckedUnaryOperator::TypeCast([&]() -> Jakt::types::CheckedTypeCast { auto&& __jakt_match_variant = cast;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Fallible */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Fallible;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedTypeCast::Fallible(scope->map_type(type_id)));
-};/*case end*/
+return Jakt::types::CheckedTypeCast::Fallible(scope->map_type(type_id));};/*case end*/
 case 1 /* Infallible */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Infallible;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedTypeCast::Infallible(scope->map_type(type_id)));
-};/*case end*/
+return Jakt::types::CheckedTypeCast::Infallible(scope->map_type(type_id));};/*case end*/
 case 2 /* Identity */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identity;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedTypeCast::Identity(scope->map_type(type_id)));
-};/*case end*/
+return Jakt::types::CheckedTypeCast::Identity(scope->map_type(type_id));};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-})));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(op);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span,scope->map_type(type_id)));
-};/*case end*/
+ 
+}());};/*case end*/
+default:return op;}/*switch end*/
+ 
+}(),span,scope->map_type(type_id));};/*case end*/
 case 7 /* BinaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.BinaryOp;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& lhs = __jakt_match_value.lhs;
 Jakt::types::CheckedBinaryOperator const& op = __jakt_match_value.op;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const& rhs = __jakt_match_value.rhs;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::BinaryOp(JaktInternal::OptionalNone(),TRY((this->perform_final_interpretation_expr_pass(lhs,scope,function_id))),op,TRY((this->perform_final_interpretation_expr_pass(rhs,scope,function_id))),span,scope->map_type(type_id)));
-};/*case end*/
+return Jakt::types::CheckedExpression::BinaryOp(JaktInternal::OptionalNone(),TRY((this->perform_final_interpretation_expr_pass(lhs,scope,function_id))),op,TRY((this->perform_final_interpretation_expr_pass(rhs,scope,function_id))),span,scope->map_type(type_id));};/*case end*/
 case 21 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::types::CheckedCall const& call = __jakt_match_value.call;
 Jakt::utility::Span const& span = __jakt_match_value.span;
@@ -2679,7 +2156,7 @@ new_args.push(Tuple{arg.template get<0>(), TRY((this->perform_final_interpretati
 }
 }
 
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::Call(JaktInternal::OptionalNone(),Jakt::types::CheckedCall(call.namespace_,call.name,new_args,call.type_args,call.function_id,call.return_type,call.callee_throws,JaktInternal::OptionalNone(),Jakt::parser::InlineState::Default()),span,type_id));
+return Jakt::types::CheckedExpression::Call(JaktInternal::OptionalNone(),Jakt::types::CheckedCall(call.namespace_,call.name,new_args,call.type_args,call.function_id,call.return_type,call.callee_throws,JaktInternal::OptionalNone(),Jakt::parser::InlineState::Default()),span,type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -2706,18 +2183,12 @@ new_args.push(Tuple{arg.template get<0>(), TRY((this->perform_final_interpretati
 }
 }
 
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::MethodCall(JaktInternal::OptionalNone(),TRY((this->perform_final_interpretation_expr_pass(expr,scope,function_id))),Jakt::types::CheckedCall(call.namespace_,call.name,new_args,call.type_args,call.function_id,call.return_type,call.callee_throws,JaktInternal::OptionalNone(),Jakt::parser::InlineState::Default()),span,is_optional,type_id));
+return Jakt::types::CheckedExpression::MethodCall(JaktInternal::OptionalNone(),TRY((this->perform_final_interpretation_expr_pass(expr,scope,function_id))),Jakt::types::CheckedCall(call.namespace_,call.name,new_args,call.type_args,call.function_id,call.return_type,call.callee_throws,JaktInternal::OptionalNone(),Jakt::parser::InlineState::Default()),span,is_optional,type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(expr);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return expr;}/*switch end*/
+}
 }
 }
 
@@ -2759,7 +2230,7 @@ break;
 }
 size_t id = _magic_value.value();
 {
-if (module->types.operator[](id)->equals(type)){
+if (module->types[id]->equals(type)){
 return Jakt::ids::TypeId(module->id,id);
 }
 }
@@ -2772,607 +2243,370 @@ return Jakt::ids::TypeId(module->id,id);
 }
 }
 
-this->program->modules.operator[](static_cast<i64>(0LL))->types.push(type);
-return Jakt::ids::TypeId(Jakt::ids::ModuleId(static_cast<size_t>(0ULL)),JaktInternal::checked_sub(this->program->modules.operator[](static_cast<i64>(0LL))->types.size(),static_cast<size_t>(1ULL)));
+this->program->modules[static_cast<i64>(0LL)]->types.push(type);
+return Jakt::ids::TypeId(Jakt::ids::ModuleId(static_cast<size_t>(0ULL)),JaktInternal::checked_sub(this->program->modules[static_cast<i64>(0LL)]->types.size(),static_cast<size_t>(1ULL)));
 }
 }
 
 ErrorOr<Jakt::interpreter::StatementResult> Jakt::interpreter::Interpreter::call_prelude_function(ByteString const prelude_function,JaktInternal::DynamicArray<Jakt::types::ResolvedNamespace> const namespace_,JaktInternal::Optional<Jakt::types::Value> const this_argument,JaktInternal::DynamicArray<Jakt::types::Value> const arguments,Jakt::utility::Span const call_span,JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> const type_bindings,JaktInternal::Optional<Jakt::ids::ScopeId> const runtime_scope_id) {
 {
 if (namespace_.size() != static_cast<size_t>(1ULL)){
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (prelude_function);
+{auto __jakt_enum_value = prelude_function;
 if (__jakt_enum_value == ByteString::from_utf8_without_validation("format"sv)) {{
-ByteString const format_string = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+ByteString const format_string = TRY(([&]() -> ErrorOr<ByteString> { auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
+return x;};/*case end*/
 default:{
-TRY((this->error(__jakt_format(StringView::from_string_literal("Expected string as first argument to format, got {}"sv),arguments.operator[](static_cast<i64>(0LL)).impl),call_span)));
+TRY((this->error(__jakt_format(StringView::from_string_literal("Expected string as first argument to format, got {}"sv),arguments[static_cast<i64>(0LL)].impl),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(TRY((Jakt::types::comptime_format_impl(format_string,arguments.operator[](JaktInternal::Range<i64>{static_cast<i64>(static_cast<i64>(1LL)),static_cast<i64>(9223372036854775807LL)}),this->program)))),call_span)));
+ 
+}()));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(TRY((Jakt::types::comptime_format_impl(format_string,arguments[JaktInternal::Range<i64>{static_cast<i64>(static_cast<i64>(1LL)),static_cast<i64>(9223372036854775807LL)}],this->program)))),call_span));
 }
 VERIFY_NOT_REACHED();
 }else if ((__jakt_enum_value == ByteString::from_utf8_without_validation("println"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("eprintln"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("print"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("eprint"sv))) {{
-ByteString const format_string = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+ByteString const format_string = TRY(([&]() -> ErrorOr<ByteString> { auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
+return x;};/*case end*/
 default:{
-TRY((this->error(__jakt_format(StringView::from_string_literal("println expects a string as its first argument, but got {}"sv),arguments.operator[](static_cast<i64>(0LL)).impl),call_span)));
+TRY((this->error(__jakt_format(StringView::from_string_literal("println expects a string as its first argument, but got {}"sv),arguments[static_cast<i64>(0LL)].impl),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-ByteString const formatted_string = TRY((Jakt::types::comptime_format_impl(format_string,arguments.operator[](JaktInternal::Range<i64>{static_cast<i64>(static_cast<i64>(1LL)),static_cast<i64>(9223372036854775807LL)}),this->program)));
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("println"sv)) {return ({outln(StringView::from_string_literal("{}"sv),formatted_string);}), JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("eprintln"sv)) {return ({warnln(StringView::from_string_literal("{}"sv),formatted_string);}), JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("print"sv)) {return ({out(StringView::from_string_literal("{}"sv),formatted_string);}), JaktInternal::ExplicitValue<void>();
-}else {return ({warn(StringView::from_string_literal("{}"sv),formatted_string);}), JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span)));
+ 
+}()));
+ByteString const formatted_string = TRY((Jakt::types::comptime_format_impl(format_string,arguments[JaktInternal::Range<i64>{static_cast<i64>(static_cast<i64>(1LL)),static_cast<i64>(9223372036854775807LL)}],this->program)));
+{auto __jakt_enum_value = prelude_function;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("println"sv)) {outln(StringView::from_string_literal("{}"sv),formatted_string);goto __jakt_label_76;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("eprintln"sv)) {warnln(StringView::from_string_literal("{}"sv),formatted_string);goto __jakt_label_76;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("print"sv)) {out(StringView::from_string_literal("{}"sv),formatted_string);goto __jakt_label_76;}else {warn(StringView::from_string_literal("{}"sv),formatted_string);goto __jakt_label_76;}}goto __jakt_label_76; __jakt_label_76:;;
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span));
 }
 VERIFY_NOT_REACHED();
 }else if (__jakt_enum_value == ByteString::from_utf8_without_validation("as_saturated"sv)) {{
-NonnullRefPtr<Jakt::types::CheckedFunction> const function = this->program->get_function(TRY((this->program->find_functions_with_name_in_scope(this->program->prelude_scope_id(),ByteString::from_utf8_without_validation("as_saturated"sv),false,JaktInternal::OptionalNone()))).value().operator[](static_cast<i64>(0LL)));
-JaktInternal::Optional<Jakt::ids::TypeId> const output_type_id = type_bindings.get(function->generics->params.operator[](static_cast<i64>(0LL)).type_id());
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(TRY((Jakt::interpreter::cast_value_to_type(arguments.operator[](static_cast<i64>(0LL)),output_type_id.value(),*this,true)))));
+NonnullRefPtr<Jakt::types::CheckedFunction> const function = this->program->get_function(TRY((this->program->find_functions_with_name_in_scope(this->program->prelude_scope_id(),ByteString::from_utf8_without_validation("as_saturated"sv),false,JaktInternal::OptionalNone()))).value()[static_cast<i64>(0LL)]);
+JaktInternal::Optional<Jakt::ids::TypeId> const output_type_id = type_bindings.get(function->generics->params[static_cast<i64>(0LL)].type_id());
+return Jakt::interpreter::StatementResult::JustValue(TRY((Jakt::interpreter::cast_value_to_type(arguments[static_cast<i64>(0LL)],output_type_id.value(),*this,true))));
 }
 VERIFY_NOT_REACHED();
 }else if (__jakt_enum_value == ByteString::from_utf8_without_validation("unchecked_mul"sv)) {{
-Jakt::types::Value const lhs_value = arguments.operator[](static_cast<i64>(0LL));
-Jakt::types::Value const rhs_value = arguments.operator[](static_cast<i64>(1LL));
+Jakt::types::Value const lhs_value = arguments[static_cast<i64>(0LL)];
+Jakt::types::Value const rhs_value = arguments[static_cast<i64>(1LL)];
 Jakt::utility::Span const span = call_span;
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U8(Jakt::unchecked_mul<u8>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U8(Jakt::unchecked_mul<u8>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U16(Jakt::unchecked_mul<u16>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U16(Jakt::unchecked_mul<u16>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U32(Jakt::unchecked_mul<u32>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U32(Jakt::unchecked_mul<u32>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U64(Jakt::unchecked_mul<u64>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U64(Jakt::unchecked_mul<u64>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I8(Jakt::unchecked_mul<i8>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I8(Jakt::unchecked_mul<i8>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I16(Jakt::unchecked_mul<i16>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I16(Jakt::unchecked_mul<i16>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I32(Jakt::unchecked_mul<i32>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I32(Jakt::unchecked_mul<i32>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I64(Jakt::unchecked_mul<i64>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I64(Jakt::unchecked_mul<i64>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::F32(Jakt::unchecked_mul<f32>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::F32(Jakt::unchecked_mul<f32>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::F64(Jakt::unchecked_mul<f64>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::F64(Jakt::unchecked_mul<f64>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::USize(Jakt::unchecked_mul<size_t>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::USize(Jakt::unchecked_mul<size_t>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
+ 
+}())),span));
 }
 VERIFY_NOT_REACHED();
 }else if (__jakt_enum_value == ByteString::from_utf8_without_validation("unchecked_add"sv)) {{
-Jakt::types::Value const lhs_value = arguments.operator[](static_cast<i64>(0LL));
-Jakt::types::Value const rhs_value = arguments.operator[](static_cast<i64>(1LL));
+Jakt::types::Value const lhs_value = arguments[static_cast<i64>(0LL)];
+Jakt::types::Value const rhs_value = arguments[static_cast<i64>(1LL)];
 Jakt::utility::Span const span = call_span;
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U8(Jakt::unchecked_add<u8>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U8(Jakt::unchecked_add<u8>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U16(Jakt::unchecked_add<u16>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U16(Jakt::unchecked_add<u16>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U32(Jakt::unchecked_add<u32>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U32(Jakt::unchecked_add<u32>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U64(Jakt::unchecked_add<u64>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U64(Jakt::unchecked_add<u64>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I8(Jakt::unchecked_add<i8>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I8(Jakt::unchecked_add<i8>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I16(Jakt::unchecked_add<i16>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I16(Jakt::unchecked_add<i16>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I32(Jakt::unchecked_add<i32>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I32(Jakt::unchecked_add<i32>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I64(Jakt::unchecked_add<i64>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I64(Jakt::unchecked_add<i64>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::F32(Jakt::unchecked_add<f32>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::F32(Jakt::unchecked_add<f32>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::F64(Jakt::unchecked_add<f64>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::F64(Jakt::unchecked_add<f64>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::USize(Jakt::unchecked_add<size_t>(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::USize(Jakt::unchecked_add<size_t>(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
+ 
+}())),span));
 }
 VERIFY_NOT_REACHED();
 }else if (__jakt_enum_value == ByteString::from_utf8_without_validation("abort"sv)) {{
@@ -3384,8 +2618,8 @@ TRY((this->error(ByteString::from_utf8_without_validation("Set constructor expec
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 Jakt::ids::StructId const set_struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Set"sv))));
-Jakt::ids::TypeId const type_id = this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),set_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({type_bindings.get(type_bindings.keys().operator[](static_cast<i64>(0LL))).value()})));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktSet(DynamicArray<Jakt::types::Value>::create_with({}),type_id),call_span)));
+Jakt::ids::TypeId const type_id = this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),set_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({type_bindings.get(type_bindings.keys()[static_cast<i64>(0LL)]).value()})));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktSet(DynamicArray<Jakt::types::Value>::create_with({}),type_id),call_span));
 }
 VERIFY_NOT_REACHED();
 }else if (__jakt_enum_value == ByteString::from_utf8_without_validation("Dictionary"sv)) {{
@@ -3394,117 +2628,78 @@ TRY((this->error(ByteString::from_utf8_without_validation("Dictionary constructo
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 Jakt::ids::StructId const dictionary_struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Dictionary"sv))));
-Jakt::ids::TypeId const type_id = this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),dictionary_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({type_bindings.get(type_bindings.keys().operator[](static_cast<i64>(0LL))).value(), type_bindings.get(type_bindings.keys().operator[](static_cast<i64>(1LL))).value()})));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktDictionary(DynamicArray<Jakt::types::Value>::create_with({}),DynamicArray<Jakt::types::Value>::create_with({}),type_id),call_span)));
+Jakt::ids::TypeId const type_id = this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),dictionary_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({type_bindings.get(type_bindings.keys()[static_cast<i64>(0LL)]).value(), type_bindings.get(type_bindings.keys()[static_cast<i64>(1LL)]).value()})));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktDictionary(DynamicArray<Jakt::types::Value>::create_with({}),DynamicArray<Jakt::types::Value>::create_with({}),type_id),call_span));
 }
 VERIFY_NOT_REACHED();
 }else if (__jakt_enum_value == ByteString::from_utf8_without_validation("from_string_literal"sv)) {{
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(arguments.operator[](static_cast<i64>(0LL))));
+return Jakt::interpreter::StatementResult::JustValue(arguments[static_cast<i64>(0LL)]);
 }
 VERIFY_NOT_REACHED();
 }else {{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function {}::{} is not implemented yet"sv),namespace_,prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}}
 }
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (namespace_.operator[](static_cast<i64>(0LL)).name);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("Error"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (prelude_function);
+{auto __jakt_enum_value = namespace_[static_cast<i64>(0LL)].name;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("Error"sv)) {{auto __jakt_enum_value = prelude_function;
 if (__jakt_enum_value == ByteString::from_utf8_without_validation("from_errno"sv)) {{
-Jakt::types::Value const err = arguments.operator[](static_cast<i64>(0LL));
+Jakt::types::Value const err = arguments[static_cast<i64>(0LL)];
 Jakt::ids::StructId const error_struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Error"sv))));
 Jakt::types::CheckedStruct const error_struct = this->program->get_struct(error_struct_id);
 NonnullRefPtr<Jakt::types::Scope> const scope = this->program->get_scope(error_struct.scope_id);
 JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::ids::FunctionId>> const constructors = scope->functions.get(ByteString::from_utf8_without_validation("from_errno"sv));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({err}),error_struct_id,constructors.value().operator[](static_cast<i64>(0LL))),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({err}),error_struct_id,constructors.value()[static_cast<i64>(0LL)]),call_span));
 }
 VERIFY_NOT_REACHED();
 }else if (__jakt_enum_value == ByteString::from_utf8_without_validation("from_string_literal"sv)) {{
-Jakt::types::Value const err = arguments.operator[](static_cast<i64>(0LL));
+Jakt::types::Value const err = arguments[static_cast<i64>(0LL)];
 Jakt::ids::StructId const error_struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Error"sv))));
 Jakt::types::CheckedStruct const error_struct = this->program->get_struct(error_struct_id);
 NonnullRefPtr<Jakt::types::Scope> const scope = this->program->get_scope(error_struct.scope_id);
 JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::ids::FunctionId>> const constructors = scope->functions.get(ByteString::from_utf8_without_validation("from_string_literal"sv));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({err}),error_struct_id,constructors.value().operator[](static_cast<i64>(0LL))),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({err}),error_struct_id,constructors.value()[static_cast<i64>(0LL)]),call_span));
 }
 VERIFY_NOT_REACHED();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("code"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("code"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *fields.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *fields[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& code = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::I32(code),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::I32(code),call_span));};/*case end*/
 default:{
-TRY((this->error(__jakt_format(StringView::from_string_literal("Error should have `i32` as its code, but got {}"sv),fields.operator[](static_cast<i64>(0LL)).impl),call_span)));
+TRY((this->error(__jakt_format(StringView::from_string_literal("Error should have `i32` as its code, but got {}"sv),fields[static_cast<i64>(0LL)].impl),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `Error::code` expects an Error as its this argument, but got {}"sv),this_argument.value().impl),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else {{
+}}else {{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `Error::{}` is not implemented"sv),prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("File"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (prelude_function);
+}}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("File"sv)) {{auto __jakt_enum_value = prelude_function;
 if (__jakt_enum_value == ByteString::from_utf8_without_validation("open_for_reading"sv)) {{
-ByteString const requested_path = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+ByteString const requested_path = TRY(([&]() -> ErrorOr<ByteString> { auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
+return x;};/*case end*/
 default:{
-TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `File::{}` expects a string as its first argument, but got {}"sv),prelude_function,arguments.operator[](static_cast<i64>(0LL)).impl),call_span)));
+TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `File::{}` expects a string as its first argument, but got {}"sv),prelude_function,arguments[static_cast<i64>(0LL)].impl),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::jakt__path::Path const path = this->program->compiler->get_file_path(call_span.file_id).value().parent().join(requested_path);
 Jakt::types::Value const path_value = Jakt::types::Value(Jakt::types::ValueImpl::JaktString(path.to_string()),call_span);
 this->compiler->files_used_in_build.add(path.to_string());
@@ -3515,29 +2710,22 @@ Jakt::ids::StructId const file_struct_id = TRY((this->program->find_struct_in_pr
 Jakt::types::CheckedStruct const file_struct = this->program->get_struct(file_struct_id);
 NonnullRefPtr<Jakt::types::Scope> const scope = this->program->get_scope(file_struct.scope_id);
 JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::ids::FunctionId>> const constructors = scope->functions.get(ByteString::from_utf8_without_validation("open_for_reading"sv));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({path_value}),file_struct_id,constructors.value().operator[](static_cast<i64>(0LL))),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({path_value}),file_struct_id,constructors.value()[static_cast<i64>(0LL)]),call_span));
 }
 VERIFY_NOT_REACHED();
 }else if (__jakt_enum_value == ByteString::from_utf8_without_validation("open_for_writing"sv)) {{
-ByteString const requested_path = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+ByteString const requested_path = TRY(([&]() -> ErrorOr<ByteString> { auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
+return x;};/*case end*/
 default:{
-TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `File::{}` expects a string as its first argument, but got {}"sv),prelude_function,arguments.operator[](static_cast<i64>(0LL)).impl),call_span)));
+TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `File::{}` expects a string as its first argument, but got {}"sv),prelude_function,arguments[static_cast<i64>(0LL)].impl),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::jakt__path::Path const path = this->program->compiler->get_file_path(call_span.file_id).value().parent().join(requested_path);
 Jakt::types::Value const path_value = Jakt::types::Value(Jakt::types::ValueImpl::JaktString(path.to_string()),call_span);
 this->compiler->files_used_in_build.add(path.to_string());
@@ -3548,53 +2736,36 @@ Jakt::ids::StructId const file_struct_id = TRY((this->program->find_struct_in_pr
 Jakt::types::CheckedStruct const file_struct = this->program->get_struct(file_struct_id);
 NonnullRefPtr<Jakt::types::Scope> const scope = this->program->get_scope(file_struct.scope_id);
 JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::ids::FunctionId>> const constructor = scope->functions.get(ByteString::from_utf8_without_validation("open_for_writing"sv));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({path_value}),file_struct_id,constructor.value().operator[](static_cast<i64>(0LL))),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({path_value}),file_struct_id,constructor.value()[static_cast<i64>(0LL)]),call_span));
 }
 VERIFY_NOT_REACHED();
 }else if (__jakt_enum_value == ByteString::from_utf8_without_validation("read_all"sv)) {{
-ByteString const path = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+ByteString const path = TRY(([&]() -> ErrorOr<ByteString> { auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *fields.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *fields[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
+return x;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("invalid type for File::read_all"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `File::read_all` expects a `File` as its this argument, but got {}"sv),this_argument.value().impl),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::ids::StructId const file_struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("File"sv))));
 Jakt::types::CheckedStruct const file_struct = this->program->get_struct(file_struct_id);
 NonnullRefPtr<Jakt::types::Scope> const scope = this->program->get_scope(file_struct.scope_id);
-Jakt::ids::FunctionId const open_for_reading = scope->functions.get(ByteString::from_utf8_without_validation("open_for_reading"sv)).value().operator[](static_cast<i64>(0LL));
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+Jakt::ids::FunctionId const open_for_reading = scope->functions.get(ByteString::from_utf8_without_validation("open_for_reading"sv)).value()[static_cast<i64>(0LL)];
+{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::Optional<Jakt::ids::FunctionId> const& constructor = __jakt_match_value.constructor;
@@ -3604,19 +2775,12 @@ TRY((this->error(ByteString::from_utf8_without_validation("Cannot read from a fi
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_77;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("expected struct as this argument"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_77;}/*switch end*/
+}goto __jakt_label_77; __jakt_label_77:;;
 NonnullRefPtr<File> file = TRY((File::open_for_reading(path)));
 JaktInternal::DynamicArray<Jakt::types::Value> result_values = DynamicArray<Jakt::types::Value>::create_with({});
 {
@@ -3635,53 +2799,36 @@ result_values.push(Jakt::types::Value(Jakt::types::ValueImpl::U8(byte),call_span
 }
 
 Jakt::ids::StructId const array_struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Array"sv))));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktArray(result_values,this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),array_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({Jakt::types::builtin(Jakt::types::BuiltinType::U8())})))),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktArray(result_values,this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),array_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({Jakt::types::builtin(Jakt::types::BuiltinType::U8())})))),call_span));
 }
 VERIFY_NOT_REACHED();
 }else if (__jakt_enum_value == ByteString::from_utf8_without_validation("read"sv)) {{
-ByteString const path = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+ByteString const path = TRY(([&]() -> ErrorOr<ByteString> { auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *fields.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *fields[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
+return x;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("invalid type for File::read"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `File::read` expects a `File` as its this argument, but got {}"sv),this_argument.value().impl),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::ids::StructId const file_struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("File"sv))));
 Jakt::types::CheckedStruct const file_struct = this->program->get_struct(file_struct_id);
 NonnullRefPtr<Jakt::types::Scope> const scope = this->program->get_scope(file_struct.scope_id);
-Jakt::ids::FunctionId const open_for_reading = scope->functions.get(ByteString::from_utf8_without_validation("open_for_reading"sv)).value().operator[](static_cast<i64>(0LL));
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+Jakt::ids::FunctionId const open_for_reading = scope->functions.get(ByteString::from_utf8_without_validation("open_for_reading"sv)).value()[static_cast<i64>(0LL)];
+{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::Optional<Jakt::ids::FunctionId> const& constructor = __jakt_match_value.constructor;
@@ -3691,39 +2838,25 @@ TRY((this->error(ByteString::from_utf8_without_validation("Cannot read from a fi
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_78;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("expected struct as this argument"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_78;}/*switch end*/
+}goto __jakt_label_78; __jakt_label_78:;;
 NonnullRefPtr<File> file = TRY((File::open_for_reading(path)));
-JaktInternal::DynamicArray<Jakt::types::Value> values_buffer = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::types::Value>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+JaktInternal::DynamicArray<Jakt::types::Value> values_buffer = TRY(([&]() -> ErrorOr<JaktInternal::DynamicArray<Jakt::types::Value>> { auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(values);
-};/*case end*/
+return values;};/*case end*/
 default:{
-TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `File::read` expects a `[u8]` as its argument, but got {}"sv),arguments.operator[](static_cast<i64>(0LL)).impl),call_span)));
+TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `File::read` expects a `[u8]` as its argument, but got {}"sv),arguments[static_cast<i64>(0LL)].impl),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 JaktInternal::DynamicArray<u8> byte_buffer = DynamicArray<u8>::filled(values_buffer.size(), static_cast<u8>(0));
 size_t const bytes_read = TRY((file->read(byte_buffer)));
 {
@@ -3735,84 +2868,60 @@ break;
 }
 size_t i = _magic_value.value();
 {
-values_buffer.operator[](i) = Jakt::types::Value(Jakt::types::ValueImpl::U8(byte_buffer.operator[](i)),call_span);
+values_buffer[i] = Jakt::types::Value(Jakt::types::ValueImpl::U8(byte_buffer[i]),call_span);
 }
 
 }
 }
 
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(bytes_read),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(bytes_read),call_span));
 }
 VERIFY_NOT_REACHED();
 }else if (__jakt_enum_value == ByteString::from_utf8_without_validation("exists"sv)) {{
-ByteString const requested_path = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+ByteString const requested_path = TRY(([&]() -> ErrorOr<ByteString> { auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
+return x;};/*case end*/
 default:{
-TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `File::{}` expects a string as its first argument, but got {}"sv),prelude_function,arguments.operator[](static_cast<i64>(0LL)).impl),call_span)));
+TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `File::{}` expects a string as its first argument, but got {}"sv),prelude_function,arguments[static_cast<i64>(0LL)].impl),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::jakt__path::Path const path = this->program->compiler->get_file_path(call_span.file_id).value().parent().join(requested_path);
 this->compiler->files_used_in_build.add(path.to_string());
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(path.exists()),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(path.exists()),call_span));
 }
 VERIFY_NOT_REACHED();
 }else if (__jakt_enum_value == ByteString::from_utf8_without_validation("write"sv)) {{
-ByteString const path = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+ByteString const path = TRY(([&]() -> ErrorOr<ByteString> { auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *fields.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *fields[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
+return x;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("invalid type for File::write"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `File::write` expects a `File` as its this argument, but got {}"sv),this_argument.value().impl),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::ids::StructId const file_struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("File"sv))));
 Jakt::types::CheckedStruct const file_struct = this->program->get_struct(file_struct_id);
 NonnullRefPtr<Jakt::types::Scope> const scope = this->program->get_scope(file_struct.scope_id);
-Jakt::ids::FunctionId const open_for_writing = scope->functions.get(ByteString::from_utf8_without_validation("open_for_writing"sv)).value().operator[](static_cast<i64>(0LL));
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+Jakt::ids::FunctionId const open_for_writing = scope->functions.get(ByteString::from_utf8_without_validation("open_for_writing"sv)).value()[static_cast<i64>(0LL)];
+{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::Optional<Jakt::ids::FunctionId> const& constructor = __jakt_match_value.constructor;
@@ -3822,39 +2931,25 @@ TRY((this->error(ByteString::from_utf8_without_validation("Cannot write to a fil
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_79;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("expected struct as this argument"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_79;}/*switch end*/
+}goto __jakt_label_79; __jakt_label_79:;;
 NonnullRefPtr<File> file = TRY((File::open_for_writing(path)));
-JaktInternal::DynamicArray<Jakt::types::Value> data_values = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::types::Value>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+JaktInternal::DynamicArray<Jakt::types::Value> data_values = TRY(([&]() -> ErrorOr<JaktInternal::DynamicArray<Jakt::types::Value>> { auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(values);
-};/*case end*/
+return values;};/*case end*/
 default:{
-TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `File::write` expects a `[u8]` as its argument, but got {}"sv),arguments.operator[](static_cast<i64>(0LL)).impl),call_span)));
+TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `File::write` expects a `[u8]` as its argument, but got {}"sv),arguments[static_cast<i64>(0LL)].impl),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 JaktInternal::DynamicArray<u8> data = DynamicArray<u8>::create_with({});
 {
 JaktInternal::ArrayIterator<Jakt::types::Value> _magic = data_values.iterator();
@@ -3865,280 +2960,166 @@ break;
 }
 Jakt::types::Value val = _magic_value.value();
 {
-data.push(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<u8, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *val.impl;
+data.push([&]() -> u8 { auto&& __jakt_match_variant = *val.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
+return x;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("expected byte"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-}));
+ 
+}());
 }
 
 }
 }
 
 size_t const bytes_written = TRY((file->write(data)));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(bytes_written),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(bytes_written),call_span));
 }
 VERIFY_NOT_REACHED();
 }else {{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `File::{}` is not implemented"sv),prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("StringBuilder"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (prelude_function);
+}}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("StringBuilder"sv)) {{auto __jakt_enum_value = prelude_function;
 if (__jakt_enum_value == ByteString::from_utf8_without_validation("create"sv)) {{
 Jakt::ids::StructId const string_builder_struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("StringBuilder"sv))));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::from_utf8_without_validation(""sv)),call_span)}),string_builder_struct_id,JaktInternal::OptionalNone()),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::from_utf8_without_validation(""sv)),call_span)}),string_builder_struct_id,JaktInternal::OptionalNone()),call_span));
 }
 VERIFY_NOT_REACHED();
 }else if ((__jakt_enum_value == ByteString::from_utf8_without_validation("append"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("append_code_point"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("append_escaped_for_json"sv))) {{
-JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::Value>,ByteString> fields_current_string_ = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::Value>,ByteString>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::Value>,ByteString> fields_current_string_ = TRY(([&]() -> ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::Value>,ByteString>> { auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::Value>,ByteString>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *fields.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *fields[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Tuple{fields, value});
-};/*case end*/
+return Tuple{fields, value};};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of prelude StringBuilder"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `StringBuilder::{}` expects a StringBuilder as its this argument"sv),prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid call"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 JaktInternal::DynamicArray<Jakt::types::Value> fields = fields_current_string_.template get<0>();
 ByteString current_string = fields_current_string_.template get<1>();
 
 ByteStringBuilder builder = ByteStringBuilder::create();
 builder.append(current_string);
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("append"sv)) {return ({({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+{auto __jakt_enum_value = prelude_function;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("append"sv)) {{auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& value = __jakt_match_value.value;
-return ({builder.append(value);}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+builder.append(value);goto __jakt_label_81;};/*case end*/
 case 14 /* StringView */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StringView;ByteString const& value = __jakt_match_value.value;
-return ({builder.append(value);}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+builder.append(value);goto __jakt_label_81;};/*case end*/
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& value = __jakt_match_value.value;
-return ({builder.append(value);}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+builder.append(value);goto __jakt_label_81;};/*case end*/
 default:{
-TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid use of StringBuilder::append({})"sv),arguments.operator[](static_cast<i64>(0LL)).impl),call_span)));
+TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid use of StringBuilder::append({})"sv),arguments[static_cast<i64>(0LL)].impl),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});}), JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("append_escaped_for_json"sv)) {return ({builder.append_escaped_for_json(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+goto __jakt_label_81;}/*switch end*/
+}goto __jakt_label_81; __jakt_label_81:;;goto __jakt_label_80;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("append_escaped_for_json"sv)) {builder.append_escaped_for_json(TRY(([&]() -> ErrorOr<ByteString> { auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
+return value;};/*case end*/
 default:{
 TRY((this->error(ByteString::from_utf8_without_validation("Invalid use of StringBuilder::append_escaped_for_json()"sv),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));}), JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("append_code_point"sv)) {return ({builder.append_code_point(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<u32, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+ 
+}())));goto __jakt_label_80;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("append_code_point"sv)) {builder.append_code_point(TRY(([&]() -> ErrorOr<u32> { auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
+return value;};/*case end*/
 default:{
 TRY((this->error(ByteString::from_utf8_without_validation("Invalid use of StringBuilder::append_code_point()"sv),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));}), JaktInternal::ExplicitValue<void>();
-}else {{
+ 
+}())));goto __jakt_label_80;}else {{
 Jakt::abort();
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-fields.operator[](static_cast<i64>(0LL)) = Jakt::types::Value(Jakt::types::ValueImpl::JaktString(builder.to_string()),call_span);
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span)));
+goto __jakt_label_80;}}goto __jakt_label_80; __jakt_label_80:;;
+fields[static_cast<i64>(0LL)] = Jakt::types::Value(Jakt::types::ValueImpl::JaktString(builder.to_string()),call_span);
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span));
 }
 VERIFY_NOT_REACHED();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("to_string"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("to_string"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(fields.operator[](static_cast<i64>(0LL))));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(fields[static_cast<i64>(0LL)]);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `StringBuilder::{}` expects a StringBuilder as its this argument"sv),prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("is_empty"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("is_empty"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *fields.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *fields[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(value.is_empty()),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(value.is_empty()),call_span));};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of prelude StringBuilder"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `StringBuilder::{}` expects a StringBuilder as its this argument"sv),prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("length"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("length"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *fields.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *fields[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(value.length()),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(value.length()),call_span));};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of prelude StringBuilder"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `StringBuilder::{}` expects a StringBuilder as its this argument"sv),prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("clear"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("clear"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
 {
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_fields = fields;
-mutable_fields.operator[](static_cast<i64>(0LL)).impl = Jakt::types::ValueImpl::JaktString(ByteString::from_utf8_without_validation(""sv));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span)));
+mutable_fields[static_cast<i64>(0LL)].impl = Jakt::types::ValueImpl::JaktString(ByteString::from_utf8_without_validation(""sv));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -4147,37 +3128,22 @@ TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else {{
+}}else {{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `StringBuilder::{}` is not implemented"sv),prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("Dictionary"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (prelude_function);
+}}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("Dictionary"sv)) {{auto __jakt_enum_value = prelude_function;
 if (__jakt_enum_value == ByteString::from_utf8_without_validation("Dictionary"sv)) {{
 if (type_bindings.size() != static_cast<size_t>(2ULL)){
 TRY((this->error(ByteString::from_utf8_without_validation("Dictionary constructor expects two generic argumenst"sv),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 Jakt::ids::StructId const dictionary_struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Dictionary"sv))));
-Jakt::ids::TypeId const type_id = this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),dictionary_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({type_bindings.get(type_bindings.keys().operator[](static_cast<i64>(0LL))).value(), type_bindings.get(type_bindings.keys().operator[](static_cast<i64>(1LL))).value()})));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktDictionary(DynamicArray<Jakt::types::Value>::create_with({}),DynamicArray<Jakt::types::Value>::create_with({}),type_id),call_span)));
+Jakt::ids::TypeId const type_id = this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),dictionary_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({type_bindings.get(type_bindings.keys()[static_cast<i64>(0LL)]).value(), type_bindings.get(type_bindings.keys()[static_cast<i64>(1LL)]).value()})));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktDictionary(DynamicArray<Jakt::types::Value>::create_with({}),DynamicArray<Jakt::types::Value>::create_with({}),type_id),call_span));
 }
 VERIFY_NOT_REACHED();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("get"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("get"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<Jakt::types::Value> const& keys = __jakt_match_value.keys;
@@ -4193,7 +3159,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (keys.operator[](i).impl->equals(arguments.operator[](static_cast<i64>(0LL)).impl)){
+if (keys[i].impl->equals(arguments[static_cast<i64>(0LL)].impl)){
 found_index = i;
 break;
 }
@@ -4202,16 +3168,9 @@ break;
 }
 }
 
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (found_index.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(values.operator[](found_index.value())),call_span));
-}else {return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalNone(),call_span));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-})));
+return Jakt::interpreter::StatementResult::JustValue([&]() -> Jakt::types::Value { auto __jakt_enum_value = found_index.has_value();
+if (__jakt_enum_value) {return Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(values[found_index.value()]),call_span);}else {return Jakt::types::Value(Jakt::types::ValueImpl::OptionalNone(),call_span);} 
+}());
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -4219,15 +3178,7 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Dictionary::get()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("set"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("set"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<Jakt::types::Value> const& keys = __jakt_match_value.keys;
@@ -4243,7 +3194,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (keys.operator[](i).impl->equals(arguments.operator[](static_cast<i64>(0LL)).impl)){
+if (keys[i].impl->equals(arguments[static_cast<i64>(0LL)].impl)){
 found_index = i;
 break;
 }
@@ -4255,14 +3206,14 @@ break;
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_keys = keys;
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_values = values;
 if (found_index.has_value()){
-mutable_values.operator[](found_index.value()) = arguments.operator[](static_cast<i64>(1LL));
+mutable_values[found_index.value()] = arguments[static_cast<i64>(1LL)];
 }
 else {
-mutable_keys.push(arguments.operator[](static_cast<i64>(0LL)));
-mutable_values.push(arguments.operator[](static_cast<i64>(1LL)));
+mutable_keys.push(arguments[static_cast<i64>(0LL)]);
+mutable_values.push(arguments[static_cast<i64>(1LL)]);
 }
 
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -4270,34 +3221,17 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Dictionary::set()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("is_empty"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("is_empty"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<Jakt::types::Value> const& keys = __jakt_match_value.keys;
 JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(keys.is_empty() && values.is_empty()),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(keys.is_empty() && values.is_empty()),call_span));};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Dictionary::is_empty()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("contains"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("contains"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<Jakt::types::Value> const& keys = __jakt_match_value.keys;
@@ -4312,7 +3246,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (keys.operator[](i).impl->equals(arguments.operator[](static_cast<i64>(0LL)).impl)){
+if (keys[i].impl->equals(arguments[static_cast<i64>(0LL)].impl)){
 found = true;
 break;
 }
@@ -4321,7 +3255,7 @@ break;
 }
 }
 
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(found),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(found),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -4329,15 +3263,7 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Dictionary::contains()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("remove"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("remove"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<Jakt::types::Value> const& keys = __jakt_match_value.keys;
@@ -4353,7 +3279,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (keys.operator[](i).impl->equals(arguments.operator[](static_cast<i64>(0LL)).impl)){
+if (keys[i].impl->equals(arguments[static_cast<i64>(0LL)].impl)){
 found_index = i;
 break;
 }
@@ -4377,8 +3303,8 @@ size_t i = _magic_value.value();
 if (i == found_index.value()){
 continue;
 }
-keys_without.push(keys.operator[](i));
-values_without.push(values.operator[](i));
+keys_without.push(keys[i]);
+values_without.push(values[i]);
 }
 
 }
@@ -4397,15 +3323,15 @@ break;
 }
 size_t i = _magic_value.value();
 {
-mutable_keys.push(keys_without.operator[](i));
-mutable_values.push(values_without.operator[](i));
+mutable_keys.push(keys_without[i]);
+mutable_values.push(values_without[i]);
 }
 
 }
 }
 
 }
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(found_index.has_value()),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(found_index.has_value()),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -4413,22 +3339,12 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Dictionary::remove()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("ensure_capacity"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("ensure_capacity"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<Jakt::types::Value> const& keys = __jakt_match_value.keys;
 JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& capacity = __jakt_match_value.value;
@@ -4437,53 +3353,30 @@ JaktInternal::DynamicArray<Jakt::types::Value> mutable_keys = keys;
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_values = values;
 mutable_keys.ensure_capacity(capacity);
 mutable_values.ensure_capacity(capacity);
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("Dictionary::ensure_capacity must be called with a usize"sv),arguments.operator[](static_cast<i64>(0LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("Dictionary::ensure_capacity must be called with a usize"sv),arguments[static_cast<i64>(0LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Dictionary::ensure_capacity()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("capacity"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("capacity"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<Jakt::types::Value> const& keys = __jakt_match_value.keys;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(keys.capacity()),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(keys.capacity()),call_span));};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Dictionary::capacity()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("clear"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("clear"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<Jakt::types::Value> const& keys = __jakt_match_value.keys;
@@ -4493,7 +3386,7 @@ JaktInternal::DynamicArray<Jakt::types::Value> mutable_keys = keys;
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_values = values;
 mutable_keys.shrink(static_cast<size_t>(0ULL));
 mutable_values.shrink(static_cast<size_t>(0ULL));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -4501,73 +3394,43 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Dictionary::clear()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("size"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("size"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<Jakt::types::Value> const& keys = __jakt_match_value.keys;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(keys.size()),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(keys.size()),call_span));};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Dictionary::size()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("keys"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("keys"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<Jakt::types::Value> const& keys = __jakt_match_value.keys;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const generics = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::ids::TypeId>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this->program->get_type(type_id);
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const generics = [&]() -> JaktInternal::DynamicArray<Jakt::ids::TypeId> { auto&& __jakt_match_variant = *this->program->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(args);
-};/*case end*/
+return args;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("expected generic instance"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (generics.size() == static_cast<size_t>(2ULL));
+ 
+}();
+{auto __jakt_enum_value = generics.size() == static_cast<size_t>(2ULL);
 if (__jakt_enum_value) {{
 Jakt::ids::StructId const array_struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Array"sv))));
-Jakt::ids::TypeId const type_id = this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),array_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({generics.operator[](static_cast<i64>(0LL))})));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktArray(keys,type_id),call_span)));
+Jakt::ids::TypeId const type_id = this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),array_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({generics[static_cast<i64>(0LL)]})));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktArray(keys,type_id),call_span));
 }
 VERIFY_NOT_REACHED();
 }else {{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("dictionary should have 2 generic args. one for keys, one for values"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -4575,70 +3438,39 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Dictionary::keys()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("iterator"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("iterator"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* JaktDictionary */:{
 Jakt::ids::StructId const struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("DictionaryIterator"sv))));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({this_argument.value(), Jakt::types::Value(Jakt::types::ValueImpl::USize(static_cast<size_t>(0ULL)),call_span)}),struct_id,JaktInternal::OptionalNone()),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({this_argument.value(), Jakt::types::Value(Jakt::types::ValueImpl::USize(static_cast<size_t>(0ULL)),call_span)}),struct_id,JaktInternal::OptionalNone()),call_span));
 }
 VERIFY_NOT_REACHED();
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Dictionary::iterator()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else {{
+}}else {{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `Dictionary::{}` is not implemented"sv),prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("Array"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("iterator"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("Array"sv)) {{auto __jakt_enum_value = prelude_function;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("iterator"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */:{
 Jakt::ids::StructId const struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("ArrayIterator"sv))));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({this_argument.value(), Jakt::types::Value(Jakt::types::ValueImpl::USize(static_cast<size_t>(0ULL)),call_span)}),struct_id,JaktInternal::OptionalNone()),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({this_argument.value(), Jakt::types::Value(Jakt::types::ValueImpl::USize(static_cast<size_t>(0ULL)),call_span)}),struct_id,JaktInternal::OptionalNone()),call_span));
 }
 VERIFY_NOT_REACHED();
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Array::iterator()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("size"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("size"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
 {
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(values.size()),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(values.size()),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -4646,22 +3478,14 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Array::size()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("push"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("push"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
 {
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_values = values;
-mutable_values.push(arguments.operator[](static_cast<i64>(0LL)));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span)));
+mutable_values.push(arguments[static_cast<i64>(0LL)]);
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -4669,23 +3493,13 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Array::push()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("push_values"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("push_values"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
 {
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_values = values;
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
@@ -4706,17 +3520,10 @@ mutable_values.push(value);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-default:return ({TRY((this->error(ByteString::from_utf8_without_validation("Only argument to push_values needs to be another Array"sv),call_span)));}), JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span)));
+goto __jakt_label_82;};/*case end*/
+default:TRY((this->error(ByteString::from_utf8_without_validation("Only argument to push_values needs to be another Array"sv),call_span)));goto __jakt_label_82;}/*switch end*/
+}goto __jakt_label_82; __jakt_label_82:;;
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -4724,32 +3531,16 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Array::push_values()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("pop"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("pop"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
 {
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_values = values;
 JaktInternal::Optional<Jakt::types::Value> const value = mutable_values.pop();
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (value.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(value.value()));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalNone(),call_span)));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+{auto __jakt_enum_value = value.has_value();
+if (__jakt_enum_value) {return Jakt::interpreter::StatementResult::JustValue(value.value());}else if (!__jakt_enum_value) {return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalNone(),call_span));}VERIFY_NOT_REACHED();
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -4757,32 +3548,16 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Array::push()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("first"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("first"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
 {
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_values = values;
 JaktInternal::Optional<Jakt::types::Value> const value = mutable_values.first();
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (value.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(value.value()));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalNone(),call_span)));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+{auto __jakt_enum_value = value.has_value();
+if (__jakt_enum_value) {return Jakt::interpreter::StatementResult::JustValue(value.value());}else if (!__jakt_enum_value) {return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalNone(),call_span));}VERIFY_NOT_REACHED();
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -4790,32 +3565,16 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Array::push()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("last"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("last"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
 {
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_values = values;
 JaktInternal::Optional<Jakt::types::Value> const value = mutable_values.last();
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (value.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(value.value()));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalNone(),call_span)));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+{auto __jakt_enum_value = value.has_value();
+if (__jakt_enum_value) {return Jakt::interpreter::StatementResult::JustValue(value.value());}else if (!__jakt_enum_value) {return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalNone(),call_span));}VERIFY_NOT_REACHED();
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -4823,15 +3582,7 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Array::push()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("contains"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("contains"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
@@ -4846,7 +3597,7 @@ break;
 }
 Jakt::types::Value value = _magic_value.value();
 {
-if (value.impl->equals(arguments.operator[](static_cast<i64>(0LL)).impl)){
+if (value.impl->equals(arguments[static_cast<i64>(0LL)].impl)){
 found = true;
 break;
 }
@@ -4855,7 +3606,7 @@ break;
 }
 }
 
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(found),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(found),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -4863,38 +3614,21 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Array::contains()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("is_empty"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("is_empty"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(values.is_empty()),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(values.is_empty()),call_span));};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Array::is_empty()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("capacity"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("capacity"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
 {
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(values.capacity()),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(values.capacity()),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -4902,204 +3636,120 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Array::capacity()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("ensure_capacity"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("ensure_capacity"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& capacity = __jakt_match_value.value;
 {
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_values = values;
 mutable_values.ensure_capacity(capacity);
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("Array::ensure_capacity must be called with a usize"sv),arguments.operator[](static_cast<i64>(0LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("Array::ensure_capacity must be called with a usize"sv),arguments[static_cast<i64>(0LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Array::ensure_capacity()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("add_capacity"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("add_capacity"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& capacity = __jakt_match_value.value;
 {
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_values = values;
 mutable_values.add_capacity(capacity);
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("Array::add_capacity must be called with a usize"sv),arguments.operator[](static_cast<i64>(0LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("Array::add_capacity must be called with a usize"sv),arguments[static_cast<i64>(0LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Array::add_capacity()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("shrink"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("shrink"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& size = __jakt_match_value.value;
 {
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_values = values;
 mutable_values.shrink(size);
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("Array::shrink must be called with a usize"sv),arguments.operator[](static_cast<i64>(0LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("Array::shrink must be called with a usize"sv),arguments[static_cast<i64>(0LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Array::shrink()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else {{
+}}else {{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `Array::{}` is not implemented"sv),prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("ArrayIterator"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("next"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("ArrayIterator"sv)) {{auto __jakt_enum_value = prelude_function;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("next"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
 {
-size_t const index = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *fields.operator[](static_cast<i64>(1LL)).impl;
+size_t const index = [&]() -> size_t { auto&& __jakt_match_variant = *fields[static_cast<i64>(1LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
+return value;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid ArrayIterator index configuration"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_fields = fields;
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *fields.operator[](static_cast<i64>(0LL)).impl;
+return Jakt::interpreter::StatementResult::JustValue([&]() -> Jakt::types::Value { auto&& __jakt_match_variant = *fields[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (values.size() > index);
+{auto __jakt_enum_value = values.size() > index;
 if (__jakt_enum_value) {{
-mutable_fields.operator[](static_cast<i64>(1LL)) = Jakt::types::Value(Jakt::types::ValueImpl::USize(JaktInternal::checked_add(index,static_cast<size_t>(1ULL))),call_span);
-return JaktInternal::ExplicitValue<Jakt::types::Value>(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(values.operator[](index)),call_span));
+mutable_fields[static_cast<i64>(1LL)] = Jakt::types::Value(Jakt::types::ValueImpl::USize(JaktInternal::checked_add(index,static_cast<size_t>(1ULL))),call_span);
+return Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(values[index]),call_span);
 }
 VERIFY_NOT_REACHED();
-}else {return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalNone(),call_span));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}else {return Jakt::types::Value(Jakt::types::ValueImpl::OptionalNone(),call_span);}}};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid ArrayIterator configuration"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-})));
+ 
+}());
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5107,159 +3757,107 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid ArrayIterator configuration"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else {{
+}}else {{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `ArrayIterator::{}` is not implemented"sv),prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("Range"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (prelude_function);
+}}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("Range"sv)) {{auto __jakt_enum_value = prelude_function;
 if (__jakt_enum_value == ByteString::from_utf8_without_validation("next"sv)) {{
-JaktInternal::DynamicArray<Jakt::types::Value> fields = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::types::Value>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+JaktInternal::DynamicArray<Jakt::types::Value> fields = [&]() -> JaktInternal::DynamicArray<Jakt::types::Value> { auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(fields);
-};/*case end*/
+return fields;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Range::next()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-u64 const start = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<u64, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *fields.operator[](static_cast<i64>(0LL)).impl;
+ 
+}();
+u64 const start = [&]() -> u64 { auto&& __jakt_match_variant = *fields[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return static_cast<u64>(x);};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid type for comptime range"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-u64 const end = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<u64, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *fields.operator[](static_cast<i64>(1LL)).impl;
+ 
+}();
+u64 const end = [&]() -> u64 { auto&& __jakt_match_variant = *fields[static_cast<i64>(1LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return static_cast<u64>(x);};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid type for comptime range"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 if (start == end){
 return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalNone(),call_span));
 }
 if (start > end){
-fields.operator[](static_cast<i64>(0LL)) = Jakt::types::Value(Jakt::types::ValueImpl::U64(JaktInternal::checked_sub(start,static_cast<u64>(1ULL))),call_span);
+fields[static_cast<i64>(0LL)] = Jakt::types::Value(Jakt::types::ValueImpl::U64(JaktInternal::checked_sub(start,static_cast<u64>(1ULL))),call_span);
 }
 else {
-fields.operator[](static_cast<i64>(0LL)) = Jakt::types::Value(Jakt::types::ValueImpl::U64(JaktInternal::checked_add(start,static_cast<u64>(1ULL))),call_span);
+fields[static_cast<i64>(0LL)] = Jakt::types::Value(Jakt::types::ValueImpl::U64(JaktInternal::checked_add(start,static_cast<u64>(1ULL))),call_span);
 }
 
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(Jakt::types::Value(Jakt::types::ValueImpl::U64(start),call_span)),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(Jakt::types::Value(Jakt::types::ValueImpl::U64(start),call_span)),call_span));
 }
 VERIFY_NOT_REACHED();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("inclusive"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("inclusive"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
@@ -5267,58 +3865,43 @@ Jakt::ids::StructId const& struct_id = __jakt_match_value.struct_id;
 JaktInternal::Optional<Jakt::ids::FunctionId> const& constructor = __jakt_match_value.constructor;
 {
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_fields = fields;
-u64 const end = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<u64, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *fields.operator[](static_cast<i64>(1LL)).impl;
+u64 const end = [&]() -> u64 { auto&& __jakt_match_variant = *fields[static_cast<i64>(1LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return static_cast<u64>(x);};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid type for comptime range"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-mutable_fields.operator[](static_cast<i64>(1LL)).impl = Jakt::types::ValueImpl::U64(JaktInternal::checked_add(end,static_cast<u64>(1ULL)));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(fields,struct_id,constructor),this_argument.value().span)));
+ 
+}();
+mutable_fields[static_cast<i64>(1LL)].impl = Jakt::types::ValueImpl::U64(JaktInternal::checked_add(end,static_cast<u64>(1ULL)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(fields,struct_id,constructor),this_argument.value().span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5326,172 +3909,109 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Range::inclusive()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("exclusive"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("exclusive"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 17 /* Struct */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(this_argument.value()));
-default:{
+case 17 /* Struct */:return Jakt::interpreter::StatementResult::JustValue(this_argument.value());default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Range::exclusive()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else {{
+}}else {{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `Range::{}` is not implemented"sv),prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("String"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("is_empty"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("String"sv)) {{auto __jakt_enum_value = prelude_function;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("is_empty"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(value.is_empty()),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(value.is_empty()),call_span));};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid String"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("length"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("length"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(value.length()),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(value.length()),call_span));};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid String"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("hash"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("hash"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::U32(value.hash()),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::U32(value.hash()),call_span));};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid String"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("substring"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("substring"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& start = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(1LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(1LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& length = __jakt_match_value.value;
 {
-ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+ByteString const result = value.substring(static_cast<size_t>(start),static_cast<size_t>(length));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& length = __jakt_match_value.value;
 {
-ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+ByteString const result = value.substring(static_cast<size_t>(start),infallible_integer_cast<size_t>(length));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& length = __jakt_match_value.value;
 {
-ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+ByteString const result = value.substring(static_cast<size_t>(start),infallible_integer_cast<size_t>(length));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& length = __jakt_match_value.value;
 {
-ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+ByteString const result = value.substring(static_cast<size_t>(start),infallible_integer_cast<size_t>(length));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& length = __jakt_match_value.value;
 {
-ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+ByteString const result = value.substring(static_cast<size_t>(start),infallible_integer_cast<size_t>(length));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv),arguments.operator[](static_cast<i64>(1LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv),arguments[static_cast<i64>(1LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& start = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(1LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(1LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& length = __jakt_match_value.value;
 {
-ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+ByteString const result = value.substring(infallible_integer_cast<size_t>(start),static_cast<size_t>(length));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5499,7 +4019,7 @@ case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& length = __jakt_match_value.value;
 {
 ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5507,7 +4027,7 @@ case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& length = __jakt_match_value.value;
 {
 ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5515,7 +4035,7 @@ case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& length = __jakt_match_value.value;
 {
 ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5523,33 +4043,25 @@ case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& length = __jakt_match_value.value;
 {
 ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv),arguments.operator[](static_cast<i64>(1LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv),arguments[static_cast<i64>(1LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& start = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(1LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(1LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& length = __jakt_match_value.value;
 {
-ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+ByteString const result = value.substring(infallible_integer_cast<size_t>(start),static_cast<size_t>(length));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5557,7 +4069,7 @@ case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& length = __jakt_match_value.value;
 {
 ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5565,7 +4077,7 @@ case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& length = __jakt_match_value.value;
 {
 ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5573,7 +4085,7 @@ case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& length = __jakt_match_value.value;
 {
 ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5581,33 +4093,25 @@ case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& length = __jakt_match_value.value;
 {
 ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv),arguments.operator[](static_cast<i64>(1LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv),arguments[static_cast<i64>(1LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& start = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(1LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(1LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& length = __jakt_match_value.value;
 {
-ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+ByteString const result = value.substring(infallible_integer_cast<size_t>(start),static_cast<size_t>(length));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5615,7 +4119,7 @@ case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& length = __jakt_match_value.value;
 {
 ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5623,7 +4127,7 @@ case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& length = __jakt_match_value.value;
 {
 ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5631,7 +4135,7 @@ case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& length = __jakt_match_value.value;
 {
 ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5639,33 +4143,25 @@ case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& length = __jakt_match_value.value;
 {
 ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv),arguments.operator[](static_cast<i64>(1LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv),arguments[static_cast<i64>(1LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& start = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(1LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(1LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& length = __jakt_match_value.value;
 {
-ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+ByteString const result = value.substring(infallible_integer_cast<size_t>(start),static_cast<size_t>(length));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5673,7 +4169,7 @@ case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& length = __jakt_match_value.value;
 {
 ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5681,7 +4177,7 @@ case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& length = __jakt_match_value.value;
 {
 ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5689,7 +4185,7 @@ case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& length = __jakt_match_value.value;
 {
 ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5697,94 +4193,59 @@ case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& length = __jakt_match_value.value;
 {
 ByteString const result = value.substring(infallible_integer_cast<size_t>(start),infallible_integer_cast<size_t>(length));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(result),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv),arguments.operator[](static_cast<i64>(1LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv),arguments[static_cast<i64>(1LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv),arguments.operator[](static_cast<i64>(0LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv),arguments[static_cast<i64>(0LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid String"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("number"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("number"sv)) {{auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& number = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::number(infallible_integer_cast<i64>(number))),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::number(static_cast<i64>(number))),call_span));};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& number = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::number(infallible_integer_cast<i64>(number))),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::number(infallible_integer_cast<i64>(number))),call_span));};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& number = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::number(infallible_integer_cast<i64>(number))),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::number(infallible_integer_cast<i64>(number))),call_span));};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& number = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::number(infallible_integer_cast<i64>(number))),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::number(infallible_integer_cast<i64>(number))),call_span));};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& number = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::number(infallible_integer_cast<i64>(number))),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::number(infallible_integer_cast<i64>(number))),call_span));};/*case end*/
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& number = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::number(infallible_integer_cast<i64>(number))),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::number(infallible_integer_cast<i64>(number))),call_span));};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& number = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::number(infallible_integer_cast<i64>(number))),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::number(infallible_integer_cast<i64>(number))),call_span));};/*case end*/
 case 12 /* USize */:case 5 /* U64 */:{
-TRY((this->error(ByteString::from_utf8_without_validation("String::number must not be called with a usize or u64"sv),arguments.operator[](static_cast<i64>(0LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("String::number must not be called with a usize or u64"sv),arguments[static_cast<i64>(0LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("String::number must be called with an integer"sv),arguments.operator[](static_cast<i64>(0LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("String::number must be called with an integer"sv),arguments[static_cast<i64>(0LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("to_number"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("to_number"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& value = __jakt_match_value.value;
@@ -5793,53 +4254,32 @@ if (type_bindings.size() < static_cast<size_t>(1ULL)){
 TRY((this->error(ByteString::from_utf8_without_validation("to_number expects one generic argument"sv),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-NonnullRefPtr<typename Jakt::types::Type> const target_type = this->program->get_type(type_bindings.get(type_bindings.keys().operator[](static_cast<i64>(0LL))).value());
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *target_type;
+NonnullRefPtr<typename Jakt::types::Type> const target_type = this->program->get_type(type_bindings.get(type_bindings.keys()[static_cast<i64>(0LL)]).value());
+{auto&& __jakt_match_variant = *target_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */:{
 JaktInternal::Optional<i32> const v = value.template to_number<i32>();
-NonnullRefPtr<typename Jakt::types::ValueImpl> const impl = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (v.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::OptionalSome(Jakt::types::Value(Jakt::types::ValueImpl::I32(v.value()),call_span)));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::OptionalNone());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(impl,call_span)));
+NonnullRefPtr<typename Jakt::types::ValueImpl> const impl = [&]() -> NonnullRefPtr<typename Jakt::types::ValueImpl> { auto __jakt_enum_value = v.has_value();
+if (__jakt_enum_value) {return Jakt::types::ValueImpl::OptionalSome(Jakt::types::Value(Jakt::types::ValueImpl::I32(v.value()),call_span));}else if (!__jakt_enum_value) {return Jakt::types::ValueImpl::OptionalNone();}VERIFY_NOT_REACHED();
+ 
+}();
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(impl,call_span));
 }
 VERIFY_NOT_REACHED();
 case 4 /* U32 */:{
 JaktInternal::Optional<u32> const v = value.template to_number<u32>();
-NonnullRefPtr<typename Jakt::types::ValueImpl> const impl = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (v.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::OptionalSome(Jakt::types::Value(Jakt::types::ValueImpl::U32(v.value()),call_span)));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::OptionalNone());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(impl,call_span)));
+NonnullRefPtr<typename Jakt::types::ValueImpl> const impl = [&]() -> NonnullRefPtr<typename Jakt::types::ValueImpl> { auto __jakt_enum_value = v.has_value();
+if (__jakt_enum_value) {return Jakt::types::ValueImpl::OptionalSome(Jakt::types::Value(Jakt::types::ValueImpl::U32(v.value()),call_span));}else if (!__jakt_enum_value) {return Jakt::types::ValueImpl::OptionalNone();}VERIFY_NOT_REACHED();
+ 
+}();
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(impl,call_span));
 }
 VERIFY_NOT_REACHED();
 default:{
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid or unsupported type for String::to_number"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -5847,181 +4287,99 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid String"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("is_whitespace"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("is_whitespace"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(value.is_whitespace()),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(value.is_whitespace()),call_span));};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid String"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("contains"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("contains"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& arg = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(value.contains(arg)),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(value.contains(arg)),call_span));};/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("String::contains must be called with a string"sv),arguments.operator[](static_cast<i64>(0LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("String::contains must be called with a string"sv),arguments[static_cast<i64>(0LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid String"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("replace"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("replace"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& replace = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(1LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(1LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& with = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(value.replace(replace,with)),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(value.replace(replace,with)),call_span));};/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("String::replace must be called with strings"sv),arguments.operator[](static_cast<i64>(1LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("String::replace must be called with strings"sv),arguments[static_cast<i64>(1LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("String::replace must be called with strings"sv),arguments.operator[](static_cast<i64>(0LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("String::replace must be called with strings"sv),arguments[static_cast<i64>(0LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid String"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("byte_at"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("byte_at"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& index = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::U8(value.byte_at(infallible_integer_cast<size_t>(index))),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::U8(value.byte_at(static_cast<size_t>(index))),call_span));};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& index = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::U8(value.byte_at(infallible_integer_cast<size_t>(index))),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::U8(value.byte_at(infallible_integer_cast<size_t>(index))),call_span));};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& index = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::U8(value.byte_at(infallible_integer_cast<size_t>(index))),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::U8(value.byte_at(infallible_integer_cast<size_t>(index))),call_span));};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& index = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::U8(value.byte_at(infallible_integer_cast<size_t>(index))),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::U8(value.byte_at(infallible_integer_cast<size_t>(index))),call_span));};/*case end*/
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& index = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::U8(value.byte_at(infallible_integer_cast<size_t>(index))),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::U8(value.byte_at(infallible_integer_cast<size_t>(index))),call_span));};/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("String::byte_at must be called with an unsigned integer"sv),arguments.operator[](static_cast<i64>(0LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("String::byte_at must be called with an unsigned integer"sv),arguments[static_cast<i64>(0LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid String"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("split"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("split"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 15 /* CChar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CChar;char const& c = __jakt_match_value.value;
@@ -6044,195 +4402,116 @@ result.push(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(value),call_sp
 }
 
 Jakt::ids::StructId const array_struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Array"sv))));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktArray(result,this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),array_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({TRY((this->string_type()))})))),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktArray(result,this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),array_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({TRY((this->string_type()))})))),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("String::split must be called with a c_char"sv),arguments.operator[](static_cast<i64>(0LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("String::split must be called with a c_char"sv),arguments[static_cast<i64>(0LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid String"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("starts_with"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("starts_with"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& arg = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(value.starts_with(arg)),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(value.starts_with(arg)),call_span));};/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("String::starts_with must be called with a string"sv),arguments.operator[](static_cast<i64>(0LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("String::starts_with must be called with a string"sv),arguments[static_cast<i64>(0LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid String"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("ends_with"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("ends_with"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& arg = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(value.ends_with(arg)),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(value.ends_with(arg)),call_span));};/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("String::ends_with must be called with a string"sv),arguments.operator[](static_cast<i64>(0LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("String::ends_with must be called with a string"sv),arguments[static_cast<i64>(0LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid String"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("repeated"sv)) {{
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("repeated"sv)) {{
 if (arguments.size() != static_cast<size_t>(2ULL)){
 TRY((this->error(ByteString::from_utf8_without_validation("String::repeated must be called with a c_char and a usize"sv),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-JaktInternal::Tuple<char,size_t> const character_count_ = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<char,size_t>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+JaktInternal::Tuple<char,size_t> const character_count_ = TRY(([&]() -> ErrorOr<JaktInternal::Tuple<char,size_t>> { auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 15 /* CChar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CChar;char const& arg = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<char,size_t>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(1LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(1LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& c = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Tuple{arg, c});
-};/*case end*/
+return Tuple{arg, c};};/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("String::repeated must be called with a usize"sv),arguments.operator[](static_cast<i64>(1LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("String::repeated must be called with a usize"sv),arguments[static_cast<i64>(1LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("String::repeated must be called with a c_char"sv),arguments.operator[](static_cast<i64>(0LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("String::repeated must be called with a c_char"sv),arguments[static_cast<i64>(0LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 char const character = character_count_.template get<0>();
 size_t const count = character_count_.template get<1>();
 
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::repeated(character,count)),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(ByteString::repeated(character,count)),call_span));
 }
 VERIFY_NOT_REACHED();
 }else {{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `String::{}` is not implemented"sv),prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("Set"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (prelude_function);
+}}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("Set"sv)) {{auto __jakt_enum_value = prelude_function;
 if (__jakt_enum_value == ByteString::from_utf8_without_validation("Set"sv)) {{
 if (type_bindings.size() != static_cast<size_t>(1ULL)){
 TRY((this->error(ByteString::from_utf8_without_validation("Set constructor expects one generic argument"sv),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 Jakt::ids::StructId const set_struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Set"sv))));
-Jakt::ids::TypeId const type_id = this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),set_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({type_bindings.get(type_bindings.keys().operator[](static_cast<i64>(0LL))).value()})));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktSet(DynamicArray<Jakt::types::Value>::create_with({}),type_id),call_span)));
+Jakt::ids::TypeId const type_id = this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),set_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({type_bindings.get(type_bindings.keys()[static_cast<i64>(0LL)]).value()})));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktSet(DynamicArray<Jakt::types::Value>::create_with({}),type_id),call_span));
 }
 VERIFY_NOT_REACHED();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("is_empty"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("is_empty"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 22 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(values.is_empty()),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(values.is_empty()),call_span));};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid Set"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("contains"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("contains"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 22 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
@@ -6247,7 +4526,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (values.operator[](i).impl->equals(arguments.operator[](static_cast<i64>(0LL)).impl)){
+if (values[i].impl->equals(arguments[static_cast<i64>(0LL)].impl)){
 found = true;
 break;
 }
@@ -6256,7 +4535,7 @@ break;
 }
 }
 
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(found),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(found),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -6264,22 +4543,14 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid Set"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("add"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("add"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 22 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
 {
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_values = values;
-mutable_values.push(arguments.operator[](static_cast<i64>(0LL)));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span)));
+mutable_values.push(arguments[static_cast<i64>(0LL)]);
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -6287,15 +4558,7 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid Set"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("remove"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("remove"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 22 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
@@ -6311,11 +4574,11 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (values.operator[](i).impl->equals(arguments.operator[](static_cast<i64>(0LL)).impl)){
+if (values[i].impl->equals(arguments[static_cast<i64>(0LL)].impl)){
 found = true;
 continue;
 }
-values_without.push(values.operator[](i));
+values_without.push(values[i]);
 }
 
 }
@@ -6332,13 +4595,13 @@ break;
 }
 size_t i = _magic_value.value();
 {
-mutable_values.push(values_without.operator[](i));
+mutable_values.push(values_without[i]);
 }
 
 }
 }
 
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(found),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(found),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -6346,22 +4609,14 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid Set"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("clear"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("clear"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 22 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
 {
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_values = values;
 mutable_values.shrink(static_cast<size_t>(0ULL));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -6369,177 +4624,99 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid Set"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("size"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("size"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 22 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(values.size()),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(values.size()),call_span));};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid Set"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("capacity"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("capacity"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 22 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(values.capacity()),call_span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(values.capacity()),call_span));};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid Set"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("ensure_capacity"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("ensure_capacity"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 22 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *arguments.operator[](static_cast<i64>(0LL)).impl;
+{auto&& __jakt_match_variant = *arguments[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& capacity = __jakt_match_value.value;
 {
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_values = values;
 mutable_values.ensure_capacity(capacity);
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
-TRY((this->error(ByteString::from_utf8_without_validation("Set::ensure_capacity must be called with a usize"sv),arguments.operator[](static_cast<i64>(0LL)).span)));
+TRY((this->error(ByteString::from_utf8_without_validation("Set::ensure_capacity must be called with a usize"sv),arguments[static_cast<i64>(0LL)].span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid Set"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("iterator"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("iterator"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 22 /* JaktSet */:{
 Jakt::ids::StructId const struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("SetIterator"sv))));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({this_argument.value(), Jakt::types::Value(Jakt::types::ValueImpl::USize(static_cast<size_t>(0ULL)),call_span)}),struct_id,JaktInternal::OptionalNone()),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({this_argument.value(), Jakt::types::Value(Jakt::types::ValueImpl::USize(static_cast<size_t>(0ULL)),call_span)}),struct_id,JaktInternal::OptionalNone()),call_span));
 }
 VERIFY_NOT_REACHED();
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid use of Set::iterator()"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else {{
+}}else {{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `Set::{}` is not implemented"sv),prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("SetIterator"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("next"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("SetIterator"sv)) {{auto __jakt_enum_value = prelude_function;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("next"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
 {
-size_t const index = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *fields.operator[](static_cast<i64>(1LL)).impl;
+size_t const index = [&]() -> size_t { auto&& __jakt_match_variant = *fields[static_cast<i64>(1LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
+return value;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid SetIterator index configuration"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_fields = fields;
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *fields.operator[](static_cast<i64>(0LL)).impl;
+return Jakt::interpreter::StatementResult::JustValue([&]() -> Jakt::types::Value { auto&& __jakt_match_variant = *fields[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 22 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (values.size() > index);
+{auto __jakt_enum_value = values.size() > index;
 if (__jakt_enum_value) {{
-mutable_fields.operator[](static_cast<i64>(1LL)) = Jakt::types::Value(Jakt::types::ValueImpl::USize(JaktInternal::checked_add(index,static_cast<size_t>(1ULL))),call_span);
-return JaktInternal::ExplicitValue<Jakt::types::Value>(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(values.operator[](index)),call_span));
+mutable_fields[static_cast<i64>(1LL)] = Jakt::types::Value(Jakt::types::ValueImpl::USize(JaktInternal::checked_add(index,static_cast<size_t>(1ULL))),call_span);
+return Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(values[index]),call_span);
 }
 VERIFY_NOT_REACHED();
-}else {return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalNone(),call_span));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}else {return Jakt::types::Value(Jakt::types::ValueImpl::OptionalNone(),call_span);}}};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid SetIterator configuration"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-})));
+ 
+}());
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -6547,104 +4724,61 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid SetIterator configuration"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else {{
+}}else {{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `ArrayIterator::{}` is not implemented"sv),prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("DictionaryIterator"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("next"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("DictionaryIterator"sv)) {{auto __jakt_enum_value = prelude_function;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("next"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
 {
-size_t const index = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *fields.operator[](static_cast<i64>(1LL)).impl;
+size_t const index = [&]() -> size_t { auto&& __jakt_match_variant = *fields[static_cast<i64>(1LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
+return value;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid DictionaryIterator index configuration"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 JaktInternal::DynamicArray<Jakt::types::Value> mutable_fields = fields;
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *fields.operator[](static_cast<i64>(0LL)).impl;
+return Jakt::interpreter::StatementResult::JustValue(TRY(([&]() -> ErrorOr<Jakt::types::Value> { auto&& __jakt_match_variant = *fields[static_cast<i64>(0LL)].impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<Jakt::types::Value> const& keys = __jakt_match_value.keys;
 JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = ((keys.size() > index) && (values.size() > index));
+{auto __jakt_enum_value = (keys.size() > index) && (values.size() > index);
 if (__jakt_enum_value) {{
-mutable_fields.operator[](static_cast<i64>(1LL)) = Jakt::types::Value(Jakt::types::ValueImpl::USize(JaktInternal::checked_add(index,static_cast<size_t>(1ULL))),call_span);
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const generics = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::ids::TypeId>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this->program->get_type(type_id);
+mutable_fields[static_cast<i64>(1LL)] = Jakt::types::Value(Jakt::types::ValueImpl::USize(JaktInternal::checked_add(index,static_cast<size_t>(1ULL))),call_span);
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const generics = [&]() -> JaktInternal::DynamicArray<Jakt::ids::TypeId> { auto&& __jakt_match_variant = *this->program->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(args);
-};/*case end*/
+return args;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("expected generic instance"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 Jakt::ids::StructId const tuple_struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Tuple"sv))));
 Jakt::ids::TypeId const tuple_type_id = this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),tuple_struct_id,generics));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(Jakt::types::Value(Jakt::types::ValueImpl::JaktTuple(DynamicArray<Jakt::types::Value>::create_with({keys.operator[](index), values.operator[](index)}),tuple_type_id),call_span)),call_span));
+return Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(Jakt::types::Value(Jakt::types::ValueImpl::JaktTuple(DynamicArray<Jakt::types::Value>::create_with({keys[index], values[index]}),tuple_type_id),call_span)),call_span);
 }
 VERIFY_NOT_REACHED();
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalNone(),call_span));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}else if (!__jakt_enum_value) {return Jakt::types::Value(Jakt::types::ValueImpl::OptionalNone(),call_span);}VERIFY_NOT_REACHED();
+}};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid DictionaryIterator configuration"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-})));
+ 
+}())));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -6652,80 +4786,44 @@ default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid DictionaryIterator configuration"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else {{
+}}else {{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `DictionaryIterator::{}` is not implemented"sv),prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("Optional"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("has_value"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("Optional"sv)) {{auto __jakt_enum_value = prelude_function;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("has_value"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 24 /* OptionalSome */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(true),call_span)));
-case 25 /* OptionalNone */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(false),call_span)));
-default:{
+case 24 /* OptionalSome */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(true),call_span));case 25 /* OptionalNone */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(false),call_span));default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid Optional configuration"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("value"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("value"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(value));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(value);};/*case end*/
 case 25 /* OptionalNone */:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Cannot unwrap optional none"sv),prelude_function),call_span)));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::Throw(TRY((this->error_value(ByteString::from_utf8_without_validation("Attempt to unwrap None"sv),call_span)))));
+return Jakt::interpreter::StatementResult::Throw(TRY((this->error_value(ByteString::from_utf8_without_validation("Attempt to unwrap None"sv),call_span))));
 }
 VERIFY_NOT_REACHED();
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid Optional configuration"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("map"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("map"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;Jakt::types::Value const& value = __jakt_match_value.value;
 {
-Jakt::types::Value const mapper_value = arguments.operator[](static_cast<i64>(0LL));
-NonnullRefPtr<typename Jakt::types::ValueImpl> __jakt_tmp65 = mapper_value.impl;
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (__jakt_tmp65->__jakt_init_index() == 27 /* Function */);
+Jakt::types::Value const mapper_value = arguments[static_cast<i64>(0LL)];
+NonnullRefPtr<typename Jakt::types::ValueImpl> __jakt_tmp64 = mapper_value.impl;
+{auto __jakt_enum_value = __jakt_tmp64->__jakt_init_index() == 27 /* Function */;
 if (__jakt_enum_value) {{
-Jakt::types::CheckedBlock const block = __jakt_tmp65->as.Function.block;
-JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<Jakt::ids::TypeId,JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>>>> const params = __jakt_tmp65->as.Function.params;
-Jakt::ids::TypeId const return_type_id = __jakt_tmp65->as.Function.return_type_id;
-JaktInternal::DynamicArray<Jakt::types::CheckedParameter> const checked_params = __jakt_tmp65->as.Function.checked_params;
+Jakt::types::CheckedBlock const block = __jakt_tmp64->as.Function.block;
+JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<Jakt::ids::TypeId,JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>>>> const params = __jakt_tmp64->as.Function.params;
+Jakt::ids::TypeId const return_type_id = __jakt_tmp64->as.Function.return_type_id;
+JaktInternal::DynamicArray<Jakt::types::CheckedParameter> const checked_params = __jakt_tmp64->as.Function.checked_params;
 NonnullRefPtr<Jakt::interpreter::InterpreterScope> scope = Jakt::interpreter::InterpreterScope::create(Dictionary<ByteString, Jakt::types::Value>::create_with_entries({}),JaktInternal::OptionalNone(),Dictionary<Jakt::ids::TypeId, Jakt::ids::TypeId>::create_with_entries({}),this->compiler,runtime_scope_id);
 bool first = true;
 {
@@ -6738,7 +4836,7 @@ break;
 Jakt::types::CheckedParameter declared_param = _magic_value.value();
 {
 ByteString const name = declared_param.variable->name;
-JaktInternal::Tuple<Jakt::ids::TypeId,JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>>> const param_type_id___ = params.operator[](name);
+JaktInternal::Tuple<Jakt::ids::TypeId,JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>>> const param_type_id___ = params[name];
 Jakt::ids::TypeId const param_type_id = param_type_id___.template get<0>();
 JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>> const _ = param_type_id___.template get<1>();
 
@@ -6756,84 +4854,48 @@ break;
 }
 
 Jakt::interpreter::StatementResult const result = TRY((this->execute_block(block,scope,call_span)));
-Jakt::interpreter::StatementResult __jakt_tmp66 = result;
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (__jakt_tmp66.__jakt_init_index() == 5 /* JustValue */);
+Jakt::interpreter::StatementResult __jakt_tmp65 = result;
+{auto __jakt_enum_value = __jakt_tmp65.__jakt_init_index() == 5 /* JustValue */;
 if (__jakt_enum_value) {{
-Jakt::types::Value const blk = __jakt_tmp66.as.JustValue.value;
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(blk));
+Jakt::types::Value const blk = __jakt_tmp65.as.JustValue.value;
+return Jakt::interpreter::StatementResult::JustValue(blk);
 }
 VERIFY_NOT_REACHED();
 }else {{
 return result;
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}}
 }
 VERIFY_NOT_REACHED();
 }else {{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid mapper type in Optional::map"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-case 25 /* OptionalNone */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(this_argument.value()));
-default:{
+case 25 /* OptionalNone */:return Jakt::interpreter::StatementResult::JustValue(this_argument.value());default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid Optional configuration"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("value_or"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("value_or"sv)) {{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(value));
-};/*case end*/
-case 25 /* OptionalNone */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(arguments.operator[](static_cast<i64>(0LL))));
-default:{
+return Jakt::interpreter::StatementResult::JustValue(value);};/*case end*/
+case 25 /* OptionalNone */:return Jakt::interpreter::StatementResult::JustValue(arguments[static_cast<i64>(0LL)]);default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid Optional configuration"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else {{
+}}else {{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `Optional::{}` is not implemented"sv),prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else {{
-TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `{}::{}` is not implemented"sv),namespace_.operator[](static_cast<i64>(0LL)).name,prelude_function),call_span)));
+}}}else {{
+TRY((this->error(__jakt_format(StringView::from_string_literal("Prelude function `{}::{}` is not implemented"sv),namespace_[static_cast<i64>(0LL)].name,prelude_function),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}}
 }
 }
 
@@ -6843,17 +4905,14 @@ if (function->params.size() != arguments.size()){
 TRY((this->error(__jakt_format(StringView::from_string_literal("Compiler interface function '{}' called with wrong number of arguments, expected {} but got {}"sv),function->name,function->params.size(),arguments.size()),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Mismatching arguments"sv));
 }
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (function->name);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("target_triple_string"sv)) {return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(TRY((this->compiler->target_triple.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY((TRY((Jakt::jakt__platform::Target::active())).name(false))); })))),call_span)));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("user_configuration_value"sv)) {{
+{auto __jakt_enum_value = function->name;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("target_triple_string"sv)) {return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(TRY((this->compiler->target_triple.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY((TRY((Jakt::jakt__platform::Target::active())).name(false))); })))),call_span));}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("user_configuration_value"sv)) {{
 NonnullRefPtr<typename Jakt::types::ValueImpl> impl = Jakt::types::ValueImpl::OptionalNone();
-JaktInternal::Optional<ByteString> const value = this->compiler->user_configuration.get(TRY((this->string_from_value(arguments.operator[](static_cast<i64>(0LL))))));
+JaktInternal::Optional<ByteString> const value = this->compiler->user_configuration.get(TRY((this->string_from_value(arguments[static_cast<i64>(0LL)]))));
 if (value.has_value()){
 impl = Jakt::types::ValueImpl::OptionalSome(TRY((this->string_value(value.value(),call_span))));
 }
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(impl,call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(impl,call_span));
 }
 VERIFY_NOT_REACHED();
 }else if (__jakt_enum_value == ByteString::from_utf8_without_validation("debug_this_scope"sv)) {{
@@ -6871,25 +4930,21 @@ warnln(StringView::from_string_literal("====== Scope {} ======"sv),scope->debug_
 warnln(StringView::from_string_literal(""sv));
 current_scope_id = scope->parent;
 }
-NonnullRefPtr<typename Jakt::types::ValueImpl> __jakt_tmp67 = arguments.operator[](static_cast<i64>(0LL)).impl;
-if (__jakt_tmp67->__jakt_init_index() == 1 /* Bool */){
-bool const value = __jakt_tmp67->as.Bool.value;
+NonnullRefPtr<typename Jakt::types::ValueImpl> __jakt_tmp66 = arguments[static_cast<i64>(0LL)].impl;
+if (__jakt_tmp66->__jakt_init_index() == 1 /* Bool */){
+bool const value = __jakt_tmp66->as.Bool.value;
 if (value){
 return Jakt::interpreter::StatementResult::Throw(TRY((this->error_value(ByteString::from_utf8_without_validation("Debugging breakpoint"sv),call_span))));
 }
 }
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::I32(scope_count),call_span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::I32(scope_count),call_span));
 }
 VERIFY_NOT_REACHED();
 }else {{
 warnln(StringView::from_string_literal("Compiler interface function '{}' is not implemented"sv),function->name);
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}}
 }
 }
 
@@ -6907,67 +4962,35 @@ this->leave_span();
 
 });
 bool is_prelude_function = false;
-JaktInternal::Optional<Jakt::ids::ScopeId> const runtime_scope_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ids::ScopeId>,ErrorOr<Jakt::interpreter::ExecutionResult>> {
-auto __jakt_enum_value = (invocation_scope.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ids::ScopeId>,ErrorOr<Jakt::interpreter::ExecutionResult>> {
-auto __jakt_enum_value = (invocation_scope.value()->runtime_scope_id.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(invocation_scope.value()->runtime_scope_id);
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+JaktInternal::Optional<Jakt::ids::ScopeId> const runtime_scope_id = [&]() -> JaktInternal::Optional<Jakt::ids::ScopeId> { auto __jakt_enum_value = invocation_scope.has_value();
+if (__jakt_enum_value) {{auto __jakt_enum_value = invocation_scope.value()->runtime_scope_id.has_value();
+if (__jakt_enum_value) {return invocation_scope.value()->runtime_scope_id;}else if (!__jakt_enum_value) {return JaktInternal::OptionalNone();}VERIFY_NOT_REACHED();
+}}else if (!__jakt_enum_value) {return JaktInternal::OptionalNone();}VERIFY_NOT_REACHED();
+ 
+}();
 if (function_to_run->linkage.__jakt_init_index() == 1 /* External */){
 NonnullRefPtr<Jakt::types::Scope> const function_scope = this->program->get_scope(function_to_run->function_scope_id);
-ByteString const parent_scope_name = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<Jakt::interpreter::ExecutionResult>> {
-auto __jakt_enum_value = (function_scope->parent.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(this->program->get_scope(function_scope->parent.value())->debug_name);
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const parent_scope_name = [&]() -> ByteString { auto __jakt_enum_value = function_scope->parent.has_value();
+if (__jakt_enum_value) {return this->program->get_scope(function_scope->parent.value())->debug_name;}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation(""sv);}VERIFY_NOT_REACHED();
+ 
+}();
 if (parent_scope_name == ByteString::from_utf8_without_validation("module(jakt__compiler)"sv)){
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::ExecutionResult, ErrorOr<Jakt::interpreter::ExecutionResult>>{
-auto&& __jakt_match_variant = TRY((this->call_compiler_interface_function(function_to_run,arguments,call_span,runtime_scope_id)));
+{auto&& __jakt_match_variant = TRY((this->call_compiler_interface_function(function_to_run,arguments,call_span,runtime_scope_id)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::ExecutionResult::Return(value));
-};/*case end*/
+return Jakt::interpreter::ExecutionResult::Return(value);};/*case end*/
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::ExecutionResult::Return(value));
-};/*case end*/
+return Jakt::interpreter::ExecutionResult::Return(value);};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::ExecutionResult::Throw(value));
-};/*case end*/
+return Jakt::interpreter::ExecutionResult::Throw(value);};/*case end*/
 case 3 /* Continue */:case 4 /* Break */:case 2 /* Yield */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid control flow"sv));
 }
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 if (!this->get_prelude_function(function_to_run->function_scope_id)){
 TRY((this->error(__jakt_format(StringView::from_string_literal("Cannot call external function '{}'"sv),function_to_run->name),call_span)));
@@ -6998,73 +5021,54 @@ this->compiler->panic(ByteString::from_utf8_without_validation("Mismatching argu
 if (is_prelude_function){
 if (this_argument.has_value() && ((!namespace_.has_value()) || namespace_.value().is_empty())){
 JaktInternal::DynamicArray<Jakt::types::ResolvedNamespace> effective_namespace = DynamicArray<Jakt::types::ResolvedNamespace>::create_with({});
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::ExecutionResult>>{
-auto&& __jakt_match_variant = *this_argument.value().impl;
+{auto&& __jakt_match_variant = *this_argument.value().impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */:{
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = DynamicArray<Jakt::ids::TypeId>::create_with({});
 effective_namespace.push(Jakt::types::ResolvedNamespace(ByteString::from_utf8_without_validation("String"sv),JaktInternal::OptionalNone(),generic_parameters));
 }
-return JaktInternal::ExplicitValue<void>();
-case 20 /* JaktArray */: {
+goto __jakt_label_83;case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::ids::TypeId>, ErrorOr<Jakt::interpreter::ExecutionResult>>{
-auto&& __jakt_match_variant = *this->program->get_type(type_id);
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = TRY(([&]() -> ErrorOr<JaktInternal::DynamicArray<Jakt::ids::TypeId>> { auto&& __jakt_match_variant = *this->program->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(args);
-};/*case end*/
+return args;};/*case end*/
 default:{
 TRY((this->error(ByteString::from_utf8_without_validation("Attempted to call a prelude function  on a non-generic array"sv),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 effective_namespace.push(Jakt::types::ResolvedNamespace(ByteString::from_utf8_without_validation("Array"sv),JaktInternal::OptionalNone(),generic_parameters));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_83;};/*case end*/
 case 21 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::ids::TypeId>, ErrorOr<Jakt::interpreter::ExecutionResult>>{
-auto&& __jakt_match_variant = *this->program->get_type(type_id);
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = TRY(([&]() -> ErrorOr<JaktInternal::DynamicArray<Jakt::ids::TypeId>> { auto&& __jakt_match_variant = *this->program->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(args);
-};/*case end*/
+return args;};/*case end*/
 default:{
 TRY((this->error(ByteString::from_utf8_without_validation("Attempted to call a prelude function  on a non-generic dictionary"sv),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 effective_namespace.push(Jakt::types::ResolvedNamespace(ByteString::from_utf8_without_validation("Dictionary"sv),JaktInternal::OptionalNone(),generic_parameters));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_83;};/*case end*/
 case 22 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp68 = this->program->get_type(type_id);
-if (__jakt_tmp68->__jakt_init_index() == 20 /* GenericInstance */){
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = __jakt_tmp68->as.GenericInstance.args;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp67 = this->program->get_type(type_id);
+if (__jakt_tmp67->__jakt_init_index() == 20 /* GenericInstance */){
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = __jakt_tmp67->as.GenericInstance.args;
 effective_namespace.push(Jakt::types::ResolvedNamespace(ByteString::from_utf8_without_validation("Set"sv),JaktInternal::OptionalNone(),generic_parameters));
 }
 else {
@@ -7073,85 +5077,62 @@ this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv)
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_83;};/*case end*/
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.struct_id;
 {
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = DynamicArray<Jakt::ids::TypeId>::create_with({});
 effective_namespace.push(Jakt::types::ResolvedNamespace(this->program->get_struct(struct_id).name,JaktInternal::OptionalNone(),generic_parameters));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_83;};/*case end*/
 case 18 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;Jakt::ids::StructId const& struct_id = __jakt_match_value.struct_id;
 {
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = DynamicArray<Jakt::ids::TypeId>::create_with({});
 effective_namespace.push(Jakt::types::ResolvedNamespace(this->program->get_struct(struct_id).name,JaktInternal::OptionalNone(),generic_parameters));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_83;};/*case end*/
 case 19 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.enum_id;
 {
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = DynamicArray<Jakt::ids::TypeId>::create_with({});
 effective_namespace.push(Jakt::types::ResolvedNamespace(this->program->get_enum(enum_id).name,JaktInternal::OptionalNone(),generic_parameters));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_83;};/*case end*/
 case 25 /* OptionalNone */:case 24 /* OptionalSome */:{
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = DynamicArray<Jakt::ids::TypeId>::create_with({});
 effective_namespace.push(Jakt::types::ResolvedNamespace(ByteString::from_utf8_without_validation("Optional"sv),JaktInternal::OptionalNone(),generic_parameters));
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_83;default:{
 TRY((this->error(ByteString::from_utf8_without_validation("Attempted to call an instance method on a non-struct/enum type"sv),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_83;}/*switch end*/
+}goto __jakt_label_83; __jakt_label_83:;;
 namespace_ = effective_namespace;
 }
 JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> type_bindings = Dictionary<Jakt::ids::TypeId, Jakt::ids::TypeId>::create_with_entries({});
 if (invocation_scope.has_value()){
 type_bindings = invocation_scope.value()->type_bindings;
 }
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::ExecutionResult, ErrorOr<Jakt::interpreter::ExecutionResult>>{
-auto&& __jakt_match_variant = TRY((this->call_prelude_function(function_to_run->name,namespace_.value(),this_argument,arguments,call_span,type_bindings,runtime_scope_id)));
+{auto&& __jakt_match_variant = TRY((this->call_prelude_function(function_to_run->name,namespace_.value(),this_argument,arguments,call_span,type_bindings,runtime_scope_id)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::ExecutionResult::Return(value));
-};/*case end*/
+return Jakt::interpreter::ExecutionResult::Return(value);};/*case end*/
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::ExecutionResult::Return(value));
-};/*case end*/
+return Jakt::interpreter::ExecutionResult::Return(value);};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::ExecutionResult::Throw(value));
-};/*case end*/
+return Jakt::interpreter::ExecutionResult::Throw(value);};/*case end*/
 case 3 /* Continue */:case 4 /* Break */:case 2 /* Yield */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid control flow"sv));
 }
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::ExecutionResult>>{
-auto&& __jakt_match_variant = function_to_run->type;
+}
+{auto&& __jakt_match_variant = function_to_run->type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Normal */:{
 NonnullRefPtr<Jakt::interpreter::InterpreterScope> scope = Jakt::interpreter::InterpreterScope::create(Dictionary<ByteString, Jakt::types::Value>::create_with_entries({}),invocation_scope,Dictionary<Jakt::ids::TypeId, Jakt::ids::TypeId>::create_with_entries({}),this->compiler,runtime_scope_id);
@@ -7173,8 +5154,8 @@ size_t i = _magic_value.value();
 if ((this_offset != static_cast<size_t>(0ULL)) && (i == static_cast<size_t>(0ULL))){
 continue;
 }
-ByteString const param_name = function_to_run->params.operator[](i).variable->name;
-Jakt::types::Value const param_value = arguments.operator[](JaktInternal::checked_sub(i,this_offset));
+ByteString const param_name = function_to_run->params[i].variable->name;
+Jakt::types::Value const param_value = arguments[JaktInternal::checked_sub(i,this_offset)];
 scope->bindings.set(param_name, param_value);
 }
 
@@ -7185,35 +5166,24 @@ if (this_argument.has_value()){
 scope->bindings.set(ByteString::from_utf8_without_validation("this"sv),this_argument.value());
 }
 Jakt::interpreter::StatementResult const blk = TRY((this->execute_block(function_to_run->block,scope,call_span)));
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::ExecutionResult, ErrorOr<Jakt::interpreter::ExecutionResult>>{
-auto&& __jakt_match_variant = blk;
+{auto&& __jakt_match_variant = blk;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::ExecutionResult::Return(TRY((Jakt::interpreter::cast_value_to_type(value,function_to_run->return_type_id,*this,false)))));
-};/*case end*/
+return Jakt::interpreter::ExecutionResult::Return(TRY((Jakt::interpreter::cast_value_to_type(value,function_to_run->return_type_id,*this,false))));};/*case end*/
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::ExecutionResult::Return(TRY((Jakt::interpreter::cast_value_to_type(value,function_to_run->return_type_id,*this,false)))));
-};/*case end*/
+return Jakt::interpreter::ExecutionResult::Return(TRY((Jakt::interpreter::cast_value_to_type(value,function_to_run->return_type_id,*this,false))));};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::ExecutionResult::Throw(value));
-};/*case end*/
+return Jakt::interpreter::ExecutionResult::Throw(value);};/*case end*/
 case 3 /* Continue */:case 4 /* Break */:case 2 /* Yield */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid control flow"sv));
 }
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
 }
-return JaktInternal::ExplicitValue<void>();
-case 7 /* Closure */:case 6 /* Expression */:{
+}
+goto __jakt_label_84;case 7 /* Closure */:case 6 /* Expression */:{
 NonnullRefPtr<Jakt::interpreter::InterpreterScope> scope = Jakt::interpreter::InterpreterScope::create(Dictionary<ByteString, Jakt::types::Value>::create_with_entries({}),invocation_scope,Dictionary<Jakt::ids::TypeId, Jakt::ids::TypeId>::create_with_entries({}),this->compiler,runtime_scope_id);
 ScopeGuard __jakt_var_16([&] {
 {
@@ -7233,8 +5203,8 @@ size_t i = _magic_value.value();
 if ((this_offset != static_cast<size_t>(0ULL)) && (i == static_cast<size_t>(0ULL))){
 continue;
 }
-ByteString const param_name = function_to_run->params.operator[](i).variable->name;
-Jakt::types::Value const param_value = arguments.operator[](JaktInternal::checked_sub(i,this_offset));
+ByteString const param_name = function_to_run->params[i].variable->name;
+Jakt::types::Value const param_value = arguments[JaktInternal::checked_sub(i,this_offset)];
 scope->bindings.set(param_name, param_value);
 }
 
@@ -7244,111 +5214,71 @@ scope->bindings.set(param_name, param_value);
 if (this_argument.has_value()){
 scope->bindings.set(ByteString::from_utf8_without_validation("this"sv),this_argument.value());
 }
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::ExecutionResult, ErrorOr<Jakt::interpreter::ExecutionResult>>{
-auto&& __jakt_match_variant = TRY((this->execute_block(function_to_run->block,scope,call_span)));
+{auto&& __jakt_match_variant = TRY((this->execute_block(function_to_run->block,scope,call_span)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::ExecutionResult::Return(TRY((Jakt::interpreter::cast_value_to_type(value,function_to_run->return_type_id,*this,false)))));
-};/*case end*/
+return Jakt::interpreter::ExecutionResult::Return(TRY((Jakt::interpreter::cast_value_to_type(value,function_to_run->return_type_id,*this,false))));};/*case end*/
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::ExecutionResult::Return(TRY((Jakt::interpreter::cast_value_to_type(value,function_to_run->return_type_id,*this,false)))));
-};/*case end*/
+return Jakt::interpreter::ExecutionResult::Return(TRY((Jakt::interpreter::cast_value_to_type(value,function_to_run->return_type_id,*this,false))));};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::ExecutionResult::Throw(value));
-};/*case end*/
+return Jakt::interpreter::ExecutionResult::Throw(value);};/*case end*/
 case 3 /* Continue */:case 4 /* Break */:case 2 /* Yield */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid control flow"sv));
 }
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* ImplicitConstructor */:{
+}
+goto __jakt_label_84;case 3 /* ImplicitConstructor */:{
 NonnullRefPtr<typename Jakt::types::Type> const result_type = this->program->get_type(function_to_run->return_type_id);
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::ExecutionResult>>{
-auto&& __jakt_match_variant = *result_type;
+{auto&& __jakt_match_variant = *result_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
 {
 Jakt::types::CheckedStruct const struct_ = this->program->get_struct(struct_id);
 Jakt::ids::FunctionId const constructor = function_to_run_id;
-NonnullRefPtr<typename Jakt::types::ValueImpl> const impl = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::ExecutionResult>>{
-auto&& __jakt_match_variant = struct_.record_type;
+NonnullRefPtr<typename Jakt::types::ValueImpl> const impl = TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = struct_.record_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Struct */:return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Struct(arguments,struct_id,constructor));
-case 1 /* Class */:return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Class(arguments,struct_id,constructor));
-default:{
+case 0 /* Struct */:return Jakt::types::ValueImpl::Struct(arguments,struct_id,constructor);case 1 /* Class */:return Jakt::types::ValueImpl::Class(arguments,struct_id,constructor);default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Cannot create instance of non-struct type {}"sv),struct_.name),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 return Jakt::interpreter::ExecutionResult::Return(Jakt::types::Value(impl,call_span));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_85;};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& struct_id = __jakt_match_value.id;
 {
 Jakt::types::CheckedStruct const struct_ = this->program->get_struct(struct_id);
 Jakt::ids::FunctionId const constructor = function_to_run_id;
-NonnullRefPtr<typename Jakt::types::ValueImpl> const impl = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::ExecutionResult>>{
-auto&& __jakt_match_variant = struct_.record_type;
+NonnullRefPtr<typename Jakt::types::ValueImpl> const impl = TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = struct_.record_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Struct */:return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Struct(arguments,struct_id,constructor));
-case 1 /* Class */:return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Class(arguments,struct_id,constructor));
-default:{
+case 0 /* Struct */:return Jakt::types::ValueImpl::Struct(arguments,struct_id,constructor);case 1 /* Class */:return Jakt::types::ValueImpl::Class(arguments,struct_id,constructor);default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Cannot create instance of non-struct type {}"sv),struct_.name),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 return Jakt::interpreter::ExecutionResult::Return(Jakt::types::Value(impl,call_span));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_85;};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Implicit constructor can only return a struct or a generic instance"sv)),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_85;}/*switch end*/
+}goto __jakt_label_85; __jakt_label_85:;;
 }
-return JaktInternal::ExplicitValue<void>();
-case 4 /* ImplicitEnumConstructor */:{
+goto __jakt_label_84;case 4 /* ImplicitEnumConstructor */:{
 NonnullRefPtr<typename Jakt::types::Type> const result_type = this->program->get_type(function_to_run->return_type_id);
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::ExecutionResult>>{
-auto&& __jakt_match_variant = *result_type;
+{auto&& __jakt_match_variant = *result_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
@@ -7358,8 +5288,7 @@ Jakt::ids::FunctionId const constructor = function_to_run_id;
 NonnullRefPtr<typename Jakt::types::ValueImpl> const impl = Jakt::types::ValueImpl::Enum(arguments,enum_id,constructor);
 return Jakt::interpreter::ExecutionResult::Return(Jakt::types::Value(impl,call_span));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_86;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& enum_id = __jakt_match_value.id;
 {
@@ -7368,32 +5297,18 @@ Jakt::ids::FunctionId const constructor = function_to_run_id;
 NonnullRefPtr<typename Jakt::types::ValueImpl> const impl = Jakt::types::ValueImpl::Enum(arguments,enum_id,constructor);
 return Jakt::interpreter::ExecutionResult::Return(Jakt::types::Value(impl,call_span));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_86;};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Implicit enum constructor can only return an enum or a generic instance of one"sv)),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_86;}/*switch end*/
+}goto __jakt_label_86; __jakt_label_86:;;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_84;default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_84;}/*switch end*/
+}goto __jakt_label_84; __jakt_label_84:;;
 TRY((this->error(__jakt_format(StringView::from_string_literal("Function type {} is not implemented"sv),function_to_run->type),call_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
@@ -7401,76 +5316,59 @@ this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemen
 
 ErrorOr<Jakt::interpreter::StatementResult> Jakt::interpreter::Interpreter::execute_statement(NonnullRefPtr<typename Jakt::types::CheckedStatement> const statement,NonnullRefPtr<Jakt::interpreter::InterpreterScope> scope,Jakt::utility::Span const call_span) {
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *statement;
+{auto&& __jakt_match_variant = *statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 {
 return this->execute_expression(expr,scope);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_87;};/*case end*/
 case 1 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;NonnullRefPtr<typename Jakt::types::CheckedStatement> const& statement = __jakt_match_value.statement;
 {
 scope->defer_statement(statement);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_87;};/*case end*/
 case 2 /* DestructuringAssignment */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DestructuringAssignment;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const& vars = __jakt_match_value.vars;
 NonnullRefPtr<typename Jakt::types::CheckedStatement> const& var_decl = __jakt_match_value.var_decl;
 {
-NonnullRefPtr<typename Jakt::types::CheckedStatement> __jakt_tmp69 = var_decl;
-if (__jakt_tmp69->__jakt_init_index() == 3 /* VarDecl */){
-Jakt::ids::VarId const var_id = __jakt_tmp69->as.VarDecl.var_id;
-NonnullRefPtr<typename Jakt::types::CheckedExpression> const init = __jakt_tmp69->as.VarDecl.init;
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = TRY((this->execute_expression(init,scope)));
+NonnullRefPtr<typename Jakt::types::CheckedStatement> __jakt_tmp68 = var_decl;
+if (__jakt_tmp68->__jakt_init_index() == 3 /* VarDecl */){
+Jakt::ids::VarId const var_id = __jakt_tmp68->as.VarDecl.var_id;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const init = __jakt_tmp68->as.VarDecl.init;
+{auto&& __jakt_match_variant = TRY((this->execute_expression(init,scope)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Return(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_88;};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Throw(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_88;};/*case end*/
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& var_value = __jakt_match_value.value;
 {
 scope->bindings.set(this->program->get_variable(var_id)->name, var_value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_88;};/*case end*/
 case 3 /* Continue */:{
 return Jakt::interpreter::StatementResult::Continue();
 }
-return JaktInternal::ExplicitValue<void>();
-case 4 /* Break */:{
+goto __jakt_label_88;case 4 /* Break */:{
 return Jakt::interpreter::StatementResult::Break();
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* Yield */:{
+goto __jakt_label_88;case 2 /* Yield */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid control flow"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_88;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_88; __jakt_label_88:;;
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename Jakt::types::CheckedStatement>> _magic = vars.iterator();
 for (;;){
@@ -7480,58 +5378,41 @@ break;
 }
 NonnullRefPtr<typename Jakt::types::CheckedStatement> var = _magic_value.value();
 {
-NonnullRefPtr<typename Jakt::types::CheckedStatement> __jakt_tmp70 = var;
-if (__jakt_tmp70->__jakt_init_index() == 3 /* VarDecl */){
-Jakt::ids::VarId const var_id = __jakt_tmp70->as.VarDecl.var_id;
-NonnullRefPtr<typename Jakt::types::CheckedExpression> const init = __jakt_tmp70->as.VarDecl.init;
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = TRY((this->execute_expression(init,scope)));
+NonnullRefPtr<typename Jakt::types::CheckedStatement> __jakt_tmp69 = var;
+if (__jakt_tmp69->__jakt_init_index() == 3 /* VarDecl */){
+Jakt::ids::VarId const var_id = __jakt_tmp69->as.VarDecl.var_id;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const init = __jakt_tmp69->as.VarDecl.init;
+{auto&& __jakt_match_variant = TRY((this->execute_expression(init,scope)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Return(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_89;};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Throw(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_89;};/*case end*/
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& var_value = __jakt_match_value.value;
 {
 scope->bindings.set(this->program->get_variable(var_id)->name, var_value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_89;};/*case end*/
 case 3 /* Continue */:{
 return Jakt::interpreter::StatementResult::Continue();
 }
-return JaktInternal::ExplicitValue<void>();
-case 4 /* Break */:{
+goto __jakt_label_89;case 4 /* Break */:{
 return Jakt::interpreter::StatementResult::Break();
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* Yield */:{
+goto __jakt_label_89;case 2 /* Yield */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid control flow"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_89;default: VERIFY_NOT_REACHED();}/*switch end*/
+break;}goto __jakt_label_89; __jakt_label_89:;;
 }
 else {
 Jakt::utility::panic(ByteString::from_utf8_without_validation("expected vardecl"sv));
@@ -7548,70 +5429,55 @@ Jakt::utility::panic(ByteString::from_utf8_without_validation("expected vardecl"
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_87;};/*case end*/
 case 3 /* VarDecl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.VarDecl;Jakt::ids::VarId const& var_id = __jakt_match_value.var_id;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const& init = __jakt_match_value.init;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = TRY((this->execute_expression(init,scope)));
+{auto&& __jakt_match_variant = TRY((this->execute_expression(init,scope)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Return(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_90;};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Throw(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_90;};/*case end*/
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& var_value = __jakt_match_value.value;
 {
 scope->bindings.set(this->program->get_variable(var_id)->name, var_value);
-NonnullRefPtr<typename Jakt::types::ValueImpl> __jakt_tmp72 = var_value.impl;
-if (__jakt_tmp72->__jakt_init_index() == 27 /* Function */){
-Jakt::types::CheckedBlock const block = __jakt_tmp72->as.Function.block;
-JaktInternal::Optional<Jakt::ids::FunctionId> const pseudo_function_id = __jakt_tmp72->as.Function.pseudo_function_id;
-JaktInternal::Optional<Jakt::ids::FunctionId> __jakt_tmp71 = pseudo_function_id;
-if (__jakt_tmp71.has_value()){
-Jakt::ids::FunctionId const id = __jakt_tmp71.value();
+NonnullRefPtr<typename Jakt::types::ValueImpl> __jakt_tmp71 = var_value.impl;
+if (__jakt_tmp71->__jakt_init_index() == 27 /* Function */){
+Jakt::types::CheckedBlock const block = __jakt_tmp71->as.Function.block;
+JaktInternal::Optional<Jakt::ids::FunctionId> const pseudo_function_id = __jakt_tmp71->as.Function.pseudo_function_id;
+JaktInternal::Optional<Jakt::ids::FunctionId> __jakt_tmp70 = pseudo_function_id;
+if (__jakt_tmp70.has_value()){
+Jakt::ids::FunctionId const id = __jakt_tmp70.value();
 this->program->get_function(id)->block = block;
 }
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_90;};/*case end*/
 case 3 /* Continue */:{
 return Jakt::interpreter::StatementResult::Continue();
 }
-return JaktInternal::ExplicitValue<void>();
-case 4 /* Break */:{
+goto __jakt_label_90;case 4 /* Break */:{
 return Jakt::interpreter::StatementResult::Break();
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* Yield */:{
+goto __jakt_label_90;case 2 /* Yield */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid control flow"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_90;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_90; __jakt_label_90:;;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_87;};/*case end*/
 case 4 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& condition = __jakt_match_value.condition;
 Jakt::types::CheckedBlock const& then_block = __jakt_match_value.then_block;
@@ -7624,25 +5490,18 @@ auto&& __jakt_match_variant = TRY((this->execute_expression(condition,scope)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *value.impl;
+return JaktInternal::ExplicitValue(TRY(([&]() -> ErrorOr<bool> { auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Bool */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Bool;bool const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
+return x;};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("if condition must be a boolean, but got {}"sv),value.impl),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+ 
+}())));
 };/*case end*/
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
@@ -7672,57 +5531,29 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-JaktInternal::Optional<Jakt::types::CheckedBlock> const block = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::types::CheckedBlock>,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (cond);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<Jakt::types::CheckedBlock>>(then_block));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::types::CheckedBlock>,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (else_statement.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<Jakt::types::CheckedBlock>>(Jakt::types::CheckedBlock(DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>>::create_with({else_statement.value()}),then_block.scope_id,Jakt::types::BlockControlFlow::MayReturn(),JaktInternal::OptionalNone(),false)));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+JaktInternal::Optional<Jakt::types::CheckedBlock> const block = [&]() -> JaktInternal::Optional<Jakt::types::CheckedBlock> { auto __jakt_enum_value = cond;
+if (__jakt_enum_value) {return static_cast<JaktInternal::Optional<Jakt::types::CheckedBlock>>(then_block);}else if (!__jakt_enum_value) {{auto __jakt_enum_value = else_statement.has_value();
+if (__jakt_enum_value) {return static_cast<JaktInternal::Optional<Jakt::types::CheckedBlock>>(Jakt::types::CheckedBlock(DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>>::create_with({else_statement.value()}),then_block.scope_id,Jakt::types::BlockControlFlow::MayReturn(),JaktInternal::OptionalNone(),false));}else if (!__jakt_enum_value) {return JaktInternal::OptionalNone();}VERIFY_NOT_REACHED();
+}}VERIFY_NOT_REACHED();
+ 
+}();
 if (block.has_value()){
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = TRY((this->execute_block(block.value(),scope,span)));
+{auto&& __jakt_match_variant = TRY((this->execute_block(block.value(),scope,span)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::Return(value));
-};/*case end*/
+return Jakt::interpreter::StatementResult::Return(value);};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::Throw(value));
-};/*case end*/
-case 5 /* JustValue */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),span)));
-case 3 /* Continue */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::Continue());
-case 4 /* Break */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::Break());
-case 2 /* Yield */:{
+return Jakt::interpreter::StatementResult::Throw(value);};/*case end*/
+case 5 /* JustValue */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),span));case 3 /* Continue */:return Jakt::interpreter::StatementResult::Continue();case 4 /* Break */:return Jakt::interpreter::StatementResult::Break();case 2 /* Yield */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid control flow"sv));
 }
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+}
+goto __jakt_label_87;};/*case end*/
 case 5 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
 Jakt::utility::Span const& span = __jakt_match_value.span;
@@ -7733,223 +5564,152 @@ MUST((new_scope->perform_defers(*this,span)));
 });
 return this->execute_block(block,new_scope,span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_87;};/*case end*/
 case 6 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 for (;;){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = TRY((this->execute_block(block,scope,span)));
+{auto&& __jakt_match_variant = TRY((this->execute_block(block,scope,span)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Return(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_91;};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Throw(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_91;};/*case end*/
 case 3 /* Continue */:{
-return JaktInternal::LoopContinue{};
+continue;
 }
-return JaktInternal::ExplicitValue<void>();
-case 4 /* Break */:{
-return JaktInternal::LoopBreak{};
+goto __jakt_label_91;case 4 /* Break */:{
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 5 /* JustValue */:{
+goto __jakt_label_91;case 5 /* JustValue */:{
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* Yield */:{
+goto __jakt_label_91;case 2 /* Yield */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid control flow"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_91;default: VERIFY_NOT_REACHED();}/*switch end*/
+break;}goto __jakt_label_91; __jakt_label_91:;;
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_87;};/*case end*/
 case 7 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& condition = __jakt_match_value.condition;
 Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 for (;;){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = TRY((this->execute_expression(condition,scope)));
+{auto&& __jakt_match_variant = TRY((this->execute_expression(condition,scope)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Return(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_92;};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Throw(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_92;};/*case end*/
 case 3 /* Continue */:{
 return Jakt::interpreter::StatementResult::Continue();
 }
-return JaktInternal::ExplicitValue<void>();
-case 4 /* Break */:{
+goto __jakt_label_92;case 4 /* Break */:{
 return Jakt::interpreter::StatementResult::Break();
 }
-return JaktInternal::ExplicitValue<void>();
-case 5 /* JustValue */: {
+goto __jakt_label_92;case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& x = __jakt_match_value.value;
 {
-NonnullRefPtr<typename Jakt::types::ValueImpl> __jakt_tmp73 = x.impl;
-if (__jakt_tmp73->__jakt_init_index() == 1 /* Bool */){
-bool const cond = __jakt_tmp73->as.Bool.value;
+NonnullRefPtr<typename Jakt::types::ValueImpl> __jakt_tmp72 = x.impl;
+if (__jakt_tmp72->__jakt_init_index() == 1 /* Bool */){
+bool const cond = __jakt_tmp72->as.Bool.value;
 if (!cond){
-return JaktInternal::LoopBreak{};
+break;
 }
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_92;};/*case end*/
 case 2 /* Yield */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid control flow"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = TRY((this->execute_block(block,scope,span)));
+goto __jakt_label_92;default: VERIFY_NOT_REACHED();}/*switch end*/
+break;}goto __jakt_label_92; __jakt_label_92:;;
+{auto&& __jakt_match_variant = TRY((this->execute_block(block,scope,span)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Return(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_93;};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Throw(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_93;};/*case end*/
 case 3 /* Continue */:{
-return JaktInternal::LoopContinue{};
+continue;
 }
-return JaktInternal::ExplicitValue<void>();
-case 4 /* Break */:{
-return JaktInternal::LoopBreak{};
+goto __jakt_label_93;case 4 /* Break */:{
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 5 /* JustValue */:{
+goto __jakt_label_93;case 5 /* JustValue */:{
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* Yield */:{
+goto __jakt_label_93;case 2 /* Yield */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid control flow"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_93;default: VERIFY_NOT_REACHED();}/*switch end*/
+break;}goto __jakt_label_93; __jakt_label_93:;;
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_87;};/*case end*/
 case 8 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& val = __jakt_match_value.val;
 {
 if (val.has_value()){
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = TRY((this->execute_expression(val.value(),scope)));
+{auto&& __jakt_match_variant = TRY((this->execute_expression(val.value(),scope)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::Return(value));
-};/*case end*/
+return Jakt::interpreter::StatementResult::Return(value);};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::Throw(value));
-};/*case end*/
+return Jakt::interpreter::StatementResult::Throw(value);};/*case end*/
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::Return(value));
-};/*case end*/
-case 3 /* Continue */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::Continue());
-case 4 /* Break */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::Break());
-case 2 /* Yield */:{
+return Jakt::interpreter::StatementResult::Return(value);};/*case end*/
+case 3 /* Continue */:return Jakt::interpreter::StatementResult::Continue();case 4 /* Break */:return Jakt::interpreter::StatementResult::Break();case 2 /* Yield */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid control flow"sv));
 }
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 return Jakt::interpreter::StatementResult::Return(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_87;};/*case end*/
 case 9 /* Break */:{
 return Jakt::interpreter::StatementResult::Break();
 }
-return JaktInternal::ExplicitValue<void>();
-case 10 /* Continue */:{
+goto __jakt_label_87;case 10 /* Continue */:{
 return Jakt::interpreter::StatementResult::Continue();
 }
-return JaktInternal::ExplicitValue<void>();
-case 12 /* Yield */: {
+goto __jakt_label_87;case 12 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& expr = __jakt_match_value.expr;
 {
 if (!expr.has_value()){
 return Jakt::interpreter::StatementResult::Yield(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span));
 }
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = TRY((this->execute_expression(expr.value(),scope)));
+{auto&& __jakt_match_variant = TRY((this->execute_expression(expr.value(),scope)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& value = __jakt_match_value.value;
@@ -7979,77 +5739,50 @@ case 2 /* Yield */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid control flow"sv));
 }
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+}
+goto __jakt_label_87;};/*case end*/
 case 11 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return ({({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = TRY((this->execute_expression(expr,scope)));
+{auto&& __jakt_match_variant = TRY((this->execute_expression(expr,scope)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Throw(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_94;};/*case end*/
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Throw(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_94;};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Throw(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_94;};/*case end*/
 case 3 /* Continue */:{
 return Jakt::interpreter::StatementResult::Continue();
 }
-return JaktInternal::ExplicitValue<void>();
-case 4 /* Break */:{
+goto __jakt_label_94;case 4 /* Break */:{
 return Jakt::interpreter::StatementResult::Break();
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* Yield */:{
+goto __jakt_label_94;case 2 /* Yield */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid control flow"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_94;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_94; __jakt_label_94:;;goto __jakt_label_87;};/*case end*/
 case 13 /* InlineCpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.InlineCpp;Jakt::utility::Span const& span = __jakt_match_value.span;
-return ({TRY((this->error(ByteString::from_utf8_without_validation("Cannot run inline cpp at compile time"sv),span)));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((this->error(ByteString::from_utf8_without_validation("Cannot run inline cpp at compile time"sv),span)));goto __jakt_label_87;};/*case end*/
 case 14 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((this->error(ByteString::from_utf8_without_validation("Cannot run invalid statements at compile time"sv),span)));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((this->error(ByteString::from_utf8_without_validation("Cannot run invalid statements at compile time"sv),span)));goto __jakt_label_87;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}goto __jakt_label_87; __jakt_label_87:;;
 return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),call_span));
 }
 }
@@ -8069,53 +5802,36 @@ this->enter_span(statement->span().value_or_lazy_evaluated([&] { return call_spa
 ScopeGuard __jakt_var_18([&] {
 this->leave_span();
 });
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = TRY((this->execute_statement(statement,scope,call_span)));
+{auto&& __jakt_match_variant = TRY((this->execute_statement(statement,scope,call_span)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Return(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_95;};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Throw(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_95;};/*case end*/
 case 3 /* Continue */:{
 return Jakt::interpreter::StatementResult::Continue();
 }
-return JaktInternal::ExplicitValue<void>();
-case 4 /* Break */:{
+goto __jakt_label_95;case 4 /* Break */:{
 return Jakt::interpreter::StatementResult::Break();
 }
-return JaktInternal::ExplicitValue<void>();
-case 5 /* JustValue */:{
+goto __jakt_label_95;case 5 /* JustValue */:{
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* Yield */: {
+goto __jakt_label_95;case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Yield(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_95;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+break;}goto __jakt_label_95; __jakt_label_95:;;
 }
 
 }
@@ -8143,1899 +5859,1122 @@ return {};
 
 ErrorOr<Jakt::interpreter::StatementResult> Jakt::interpreter::Interpreter::execute_binary_operator(Jakt::types::Value const lhs_value,Jakt::types::Value const rhs_value,Jakt::parser::BinaryOperator const op,Jakt::utility::Span const span,NonnullRefPtr<Jakt::interpreter::InterpreterScope> const scope) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = op;
+{auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Add */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+case 0 /* Add */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U8(JaktInternal::checked_add(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U8(JaktInternal::checked_add(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U16(JaktInternal::checked_add(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U16(JaktInternal::checked_add(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U32(JaktInternal::checked_add(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U32(JaktInternal::checked_add(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U64(JaktInternal::checked_add(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U64(JaktInternal::checked_add(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I8(JaktInternal::checked_add(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I8(JaktInternal::checked_add(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I16(JaktInternal::checked_add(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I16(JaktInternal::checked_add(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I32(JaktInternal::checked_add(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I32(JaktInternal::checked_add(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I64(JaktInternal::checked_add(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I64(JaktInternal::checked_add(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::F32(x + y));
-};/*case end*/
+return Jakt::types::ValueImpl::F32(x + y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::F64(x + y));
-};/*case end*/
+return Jakt::types::ValueImpl::F64(x + y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::USize(JaktInternal::checked_add(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::USize(JaktInternal::checked_add(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::JaktString(x + y));
-};/*case end*/
+return Jakt::types::ValueImpl::JaktString(x + y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 1 /* Subtract */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 1 /* Subtract */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U8(JaktInternal::checked_sub(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U8(JaktInternal::checked_sub(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U16(JaktInternal::checked_sub(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U16(JaktInternal::checked_sub(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U32(JaktInternal::checked_sub(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U32(JaktInternal::checked_sub(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U64(JaktInternal::checked_sub(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U64(JaktInternal::checked_sub(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I8(JaktInternal::checked_sub(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I8(JaktInternal::checked_sub(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I16(JaktInternal::checked_sub(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I16(JaktInternal::checked_sub(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I32(JaktInternal::checked_sub(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I32(JaktInternal::checked_sub(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I64(JaktInternal::checked_sub(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I64(JaktInternal::checked_sub(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::F32(x - y));
-};/*case end*/
+return Jakt::types::ValueImpl::F32(x - y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::F64(x - y));
-};/*case end*/
+return Jakt::types::ValueImpl::F64(x - y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::USize(JaktInternal::checked_sub(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::USize(JaktInternal::checked_sub(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 2 /* Multiply */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 2 /* Multiply */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U8(JaktInternal::checked_mul(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U8(JaktInternal::checked_mul(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U16(JaktInternal::checked_mul(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U16(JaktInternal::checked_mul(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U32(JaktInternal::checked_mul(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U32(JaktInternal::checked_mul(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U64(JaktInternal::checked_mul(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U64(JaktInternal::checked_mul(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I8(JaktInternal::checked_mul(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I8(JaktInternal::checked_mul(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I16(JaktInternal::checked_mul(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I16(JaktInternal::checked_mul(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I32(JaktInternal::checked_mul(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I32(JaktInternal::checked_mul(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I64(JaktInternal::checked_mul(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I64(JaktInternal::checked_mul(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::F32(x * y));
-};/*case end*/
+return Jakt::types::ValueImpl::F32(x * y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::F64(x * y));
-};/*case end*/
+return Jakt::types::ValueImpl::F64(x * y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::USize(JaktInternal::checked_mul(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::USize(JaktInternal::checked_mul(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 3 /* Divide */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 3 /* Divide */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U8(JaktInternal::checked_div(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U8(JaktInternal::checked_div(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U16(JaktInternal::checked_div(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U16(JaktInternal::checked_div(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U32(JaktInternal::checked_div(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U32(JaktInternal::checked_div(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U64(JaktInternal::checked_div(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U64(JaktInternal::checked_div(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I8(JaktInternal::checked_div(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I8(JaktInternal::checked_div(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I16(JaktInternal::checked_div(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I16(JaktInternal::checked_div(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I32(JaktInternal::checked_div(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I32(JaktInternal::checked_div(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I64(JaktInternal::checked_div(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I64(JaktInternal::checked_div(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::F32(x / y));
-};/*case end*/
+return Jakt::types::ValueImpl::F32(x / y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::F64(x / y));
-};/*case end*/
+return Jakt::types::ValueImpl::F64(x / y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::USize(JaktInternal::checked_div(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::USize(JaktInternal::checked_div(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 9 /* Equal */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 9 /* Equal */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x == y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x == y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x == y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x == y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x == y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x == y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x == y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x == y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x == y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x == y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x == y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x == y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x == y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x == y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x == y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x == y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x == y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x == y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x == y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x == y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x == y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x == y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 16 /* CInt */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CInt;int const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 16 /* CInt */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CInt;int const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x == y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x == y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 15 /* CChar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CChar;char const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 15 /* CChar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CChar;char const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x == y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x == y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x == y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x == y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 10 /* NotEqual */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 10 /* NotEqual */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x != y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x != y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x != y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x != y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x != y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x != y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x != y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x != y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x != y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x != y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x != y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x != y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x != y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x != y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x != y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x != y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x != y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x != y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x != y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x != y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x != y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x != y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 16 /* CInt */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CInt;int const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 16 /* CInt */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CInt;int const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x != y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x != y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 15 /* CChar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CChar;char const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 15 /* CChar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CChar;char const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x != y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x != y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool([](ByteString const& self, ByteString rhs) -> bool {{
+return Jakt::types::ValueImpl::Bool([](ByteString const& self, ByteString rhs) -> bool {{
 return !(self == rhs);
 }
 }
-(x,y)));
-};/*case end*/
+(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 5 /* LessThan */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 5 /* LessThan */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x < y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x < y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x < y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x < y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x < y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x < y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x < y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x < y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x < y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x < y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x < y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x < y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x < y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x < y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x < y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x < y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool([](f32 const& self, f32 rhs) -> bool {{
+return Jakt::types::ValueImpl::Bool([](f32 const& self, f32 rhs) -> bool {{
 return infallible_integer_cast<u8>([](f32 const& self, f32 rhs) -> Jakt::jakt__prelude__operators::Ordering {{
 return infallible_enum_cast<Jakt::jakt__prelude__operators::Ordering>(JaktInternal::compare(self,rhs));
 }
@@ -10043,29 +6982,20 @@ return infallible_enum_cast<Jakt::jakt__prelude__operators::Ordering>(JaktIntern
 (self,rhs)) == static_cast<u8>(0);
 }
 }
-(x,y)));
-};/*case end*/
+(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool([](f64 const& self, f64 rhs) -> bool {{
+return Jakt::types::ValueImpl::Bool([](f64 const& self, f64 rhs) -> bool {{
 return infallible_integer_cast<u8>([](f64 const& self, f64 rhs) -> Jakt::jakt__prelude__operators::Ordering {{
 return infallible_enum_cast<Jakt::jakt__prelude__operators::Ordering>(JaktInternal::compare(self,rhs));
 }
@@ -10073,264 +7003,158 @@ return infallible_enum_cast<Jakt::jakt__prelude__operators::Ordering>(JaktIntern
 (self,rhs)) == static_cast<u8>(0);
 }
 }
-(x,y)));
-};/*case end*/
+(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x < y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x < y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x < y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x < y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 6 /* LessThanOrEqual */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 6 /* LessThanOrEqual */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x <= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x <= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x <= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x <= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x <= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x <= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x <= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x <= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x <= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x <= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x <= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x <= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x <= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x <= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x <= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x <= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool([](f32 const& self, f32 rhs) -> bool {{
+return Jakt::types::ValueImpl::Bool([](f32 const& self, f32 rhs) -> bool {{
 return infallible_integer_cast<u8>([](f32 const& self, f32 rhs) -> Jakt::jakt__prelude__operators::Ordering {{
 return infallible_enum_cast<Jakt::jakt__prelude__operators::Ordering>(JaktInternal::compare(self,rhs));
 }
@@ -10338,29 +7162,20 @@ return infallible_enum_cast<Jakt::jakt__prelude__operators::Ordering>(JaktIntern
 (self,rhs)) != static_cast<u8>(2);
 }
 }
-(x,y)));
-};/*case end*/
+(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool([](f64 const& self, f64 rhs) -> bool {{
+return Jakt::types::ValueImpl::Bool([](f64 const& self, f64 rhs) -> bool {{
 return infallible_integer_cast<u8>([](f64 const& self, f64 rhs) -> Jakt::jakt__prelude__operators::Ordering {{
 return infallible_enum_cast<Jakt::jakt__prelude__operators::Ordering>(JaktInternal::compare(self,rhs));
 }
@@ -10368,264 +7183,158 @@ return infallible_enum_cast<Jakt::jakt__prelude__operators::Ordering>(JaktIntern
 (self,rhs)) != static_cast<u8>(2);
 }
 }
-(x,y)));
-};/*case end*/
+(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x <= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x <= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x <= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x <= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 7 /* GreaterThan */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 7 /* GreaterThan */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x > y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x > y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x > y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x > y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x > y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x > y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x > y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x > y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x > y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x > y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x > y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x > y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x > y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x > y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x > y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x > y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool([](f32 const& self, f32 rhs) -> bool {{
+return Jakt::types::ValueImpl::Bool([](f32 const& self, f32 rhs) -> bool {{
 return infallible_integer_cast<u8>([](f32 const& self, f32 rhs) -> Jakt::jakt__prelude__operators::Ordering {{
 return infallible_enum_cast<Jakt::jakt__prelude__operators::Ordering>(JaktInternal::compare(self,rhs));
 }
@@ -10633,29 +7342,20 @@ return infallible_enum_cast<Jakt::jakt__prelude__operators::Ordering>(JaktIntern
 (self,rhs)) == static_cast<u8>(2);
 }
 }
-(x,y)));
-};/*case end*/
+(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool([](f64 const& self, f64 rhs) -> bool {{
+return Jakt::types::ValueImpl::Bool([](f64 const& self, f64 rhs) -> bool {{
 return infallible_integer_cast<u8>([](f64 const& self, f64 rhs) -> Jakt::jakt__prelude__operators::Ordering {{
 return infallible_enum_cast<Jakt::jakt__prelude__operators::Ordering>(JaktInternal::compare(self,rhs));
 }
@@ -10663,264 +7363,158 @@ return infallible_enum_cast<Jakt::jakt__prelude__operators::Ordering>(JaktIntern
 (self,rhs)) == static_cast<u8>(2);
 }
 }
-(x,y)));
-};/*case end*/
+(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x > y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x > y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x > y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x > y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 8 /* GreaterThanOrEqual */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 8 /* GreaterThanOrEqual */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x >= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x >= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x >= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x >= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x >= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x >= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x >= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x >= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x >= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x >= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x >= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x >= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x >= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x >= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x >= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x >= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool([](f32 const& self, f32 rhs) -> bool {{
+return Jakt::types::ValueImpl::Bool([](f32 const& self, f32 rhs) -> bool {{
 return infallible_integer_cast<u8>([](f32 const& self, f32 rhs) -> Jakt::jakt__prelude__operators::Ordering {{
 return infallible_enum_cast<Jakt::jakt__prelude__operators::Ordering>(JaktInternal::compare(self,rhs));
 }
@@ -10928,29 +7522,20 @@ return infallible_enum_cast<Jakt::jakt__prelude__operators::Ordering>(JaktIntern
 (self,rhs)) != static_cast<u8>(0);
 }
 }
-(x,y)));
-};/*case end*/
+(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool([](f64 const& self, f64 rhs) -> bool {{
+return Jakt::types::ValueImpl::Bool([](f64 const& self, f64 rhs) -> bool {{
 return infallible_integer_cast<u8>([](f64 const& self, f64 rhs) -> Jakt::jakt__prelude__operators::Ordering {{
 return infallible_enum_cast<Jakt::jakt__prelude__operators::Ordering>(JaktInternal::compare(self,rhs));
 }
@@ -10958,1733 +7543,1020 @@ return infallible_enum_cast<Jakt::jakt__prelude__operators::Ordering>(JaktIntern
 (self,rhs)) != static_cast<u8>(0);
 }
 }
-(x,y)));
-};/*case end*/
+(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x >= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x >= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x >= y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x >= y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 11 /* BitwiseAnd */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 11 /* BitwiseAnd */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U8(static_cast<u8>(x & y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U8(static_cast<u8>(x & y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U16(static_cast<u16>(x & y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U16(static_cast<u16>(x & y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U32(x & y));
-};/*case end*/
+return Jakt::types::ValueImpl::U32(x & y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U64(x & y));
-};/*case end*/
+return Jakt::types::ValueImpl::U64(x & y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I8(static_cast<i8>(x & y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I8(static_cast<i8>(x & y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I16(static_cast<i16>(x & y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I16(static_cast<i16>(x & y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I32(x & y));
-};/*case end*/
+return Jakt::types::ValueImpl::I32(x & y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I64(x & y));
-};/*case end*/
+return Jakt::types::ValueImpl::I64(x & y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::USize(x & y));
-};/*case end*/
+return Jakt::types::ValueImpl::USize(x & y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 13 /* BitwiseOr */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 13 /* BitwiseOr */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U8(static_cast<u8>(x | y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U8(static_cast<u8>(x | y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U16(static_cast<u16>(x | y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U16(static_cast<u16>(x | y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U32(x | y));
-};/*case end*/
+return Jakt::types::ValueImpl::U32(x | y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U64(x | y));
-};/*case end*/
+return Jakt::types::ValueImpl::U64(x | y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I8(static_cast<i8>(x | y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I8(static_cast<i8>(x | y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I16(static_cast<i16>(x | y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I16(static_cast<i16>(x | y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I32(x | y));
-};/*case end*/
+return Jakt::types::ValueImpl::I32(x | y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I64(x | y));
-};/*case end*/
+return Jakt::types::ValueImpl::I64(x | y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::USize(x | y));
-};/*case end*/
+return Jakt::types::ValueImpl::USize(x | y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 12 /* BitwiseXor */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 12 /* BitwiseXor */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U8(static_cast<u8>(x ^ y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U8(static_cast<u8>(x ^ y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U16(static_cast<u16>(x ^ y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U16(static_cast<u16>(x ^ y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U32(x ^ y));
-};/*case end*/
+return Jakt::types::ValueImpl::U32(x ^ y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U64(x ^ y));
-};/*case end*/
+return Jakt::types::ValueImpl::U64(x ^ y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I8(static_cast<i8>(x ^ y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I8(static_cast<i8>(x ^ y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I16(static_cast<i16>(x ^ y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I16(static_cast<i16>(x ^ y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I32(x ^ y));
-};/*case end*/
+return Jakt::types::ValueImpl::I32(x ^ y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I64(x ^ y));
-};/*case end*/
+return Jakt::types::ValueImpl::I64(x ^ y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::USize(x ^ y));
-};/*case end*/
+return Jakt::types::ValueImpl::USize(x ^ y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 14 /* BitwiseLeftShift */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 14 /* BitwiseLeftShift */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U8(static_cast<u8>(x << y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U8(static_cast<u8>(x << y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U16(static_cast<u16>(x << y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U16(static_cast<u16>(x << y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U32(x << y));
-};/*case end*/
+return Jakt::types::ValueImpl::U32(x << y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U64(x << y));
-};/*case end*/
+return Jakt::types::ValueImpl::U64(x << y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I8(static_cast<i8>(x << y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I8(static_cast<i8>(x << y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I16(static_cast<i16>(x << y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I16(static_cast<i16>(x << y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I32(x << y));
-};/*case end*/
+return Jakt::types::ValueImpl::I32(x << y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I64(x << y));
-};/*case end*/
+return Jakt::types::ValueImpl::I64(x << y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::USize(x << y));
-};/*case end*/
+return Jakt::types::ValueImpl::USize(x << y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 15 /* BitwiseRightShift */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 15 /* BitwiseRightShift */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U8(static_cast<u8>(x >> y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U8(static_cast<u8>(x >> y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U16(static_cast<u16>(x >> y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U16(static_cast<u16>(x >> y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U32(x >> y));
-};/*case end*/
+return Jakt::types::ValueImpl::U32(x >> y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U64(x >> y));
-};/*case end*/
+return Jakt::types::ValueImpl::U64(x >> y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I8(static_cast<i8>(x >> y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I8(static_cast<i8>(x >> y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I16(static_cast<i16>(x >> y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I16(static_cast<i16>(x >> y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I32(x >> y));
-};/*case end*/
+return Jakt::types::ValueImpl::I32(x >> y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I64(x >> y));
-};/*case end*/
+return Jakt::types::ValueImpl::I64(x >> y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::USize(x >> y));
-};/*case end*/
+return Jakt::types::ValueImpl::USize(x >> y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 16 /* ArithmeticLeftShift */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 16 /* ArithmeticLeftShift */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U8(static_cast<u8>(x << y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U8(static_cast<u8>(x << y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U16(static_cast<u16>(x << y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U16(static_cast<u16>(x << y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U32(x << y));
-};/*case end*/
+return Jakt::types::ValueImpl::U32(x << y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U64(x << y));
-};/*case end*/
+return Jakt::types::ValueImpl::U64(x << y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I8(static_cast<i8>(x << y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I8(static_cast<i8>(x << y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I16(static_cast<i16>(x << y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I16(static_cast<i16>(x << y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I32(x << y));
-};/*case end*/
+return Jakt::types::ValueImpl::I32(x << y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I64(x << y));
-};/*case end*/
+return Jakt::types::ValueImpl::I64(x << y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::USize(x << y));
-};/*case end*/
+return Jakt::types::ValueImpl::USize(x << y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 17 /* ArithmeticRightShift */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 17 /* ArithmeticRightShift */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U8(JaktInternal::arithmetic_shift_right(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U8(JaktInternal::arithmetic_shift_right(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U16(JaktInternal::arithmetic_shift_right(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U16(JaktInternal::arithmetic_shift_right(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U32(JaktInternal::arithmetic_shift_right(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U32(JaktInternal::arithmetic_shift_right(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U64(JaktInternal::arithmetic_shift_right(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::U64(JaktInternal::arithmetic_shift_right(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I8(JaktInternal::arithmetic_shift_right(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I8(JaktInternal::arithmetic_shift_right(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I16(JaktInternal::arithmetic_shift_right(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I16(JaktInternal::arithmetic_shift_right(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I32(JaktInternal::arithmetic_shift_right(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I32(JaktInternal::arithmetic_shift_right(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I64(JaktInternal::arithmetic_shift_right(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::I64(JaktInternal::arithmetic_shift_right(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::USize(JaktInternal::arithmetic_shift_right(x,y)));
-};/*case end*/
+return Jakt::types::ValueImpl::USize(JaktInternal::arithmetic_shift_right(x,y));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 19 /* LogicalOr */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 19 /* LogicalOr */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Bool */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Bool;bool const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Bool */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Bool;bool const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x || y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x || y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 18 /* LogicalAnd */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *lhs_value.impl;
+ 
+}())),span));case 18 /* LogicalAnd */:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::ValueImpl>> { auto&& __jakt_match_variant = *lhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Bool */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Bool;bool const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *rhs_value.impl;
+{auto&& __jakt_match_variant = *rhs_value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Bool */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Bool;bool const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x && y));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x && y);};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid operands '{}' and '{}' to binary operation"sv),lhs_value.type_name(),rhs_value.type_name()),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),span)));
-case 21 /* Assign */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(rhs_value));
-case 22 /* BitwiseAndAssign */:return JaktInternal::ExplicitValue(TRY((this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::BitwiseAnd(),span,scope))));
-case 23 /* BitwiseOrAssign */:return JaktInternal::ExplicitValue(TRY((this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::BitwiseOr(),span,scope))));
-case 24 /* BitwiseXorAssign */:return JaktInternal::ExplicitValue(TRY((this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::BitwiseXor(),span,scope))));
-case 25 /* BitwiseLeftShiftAssign */:return JaktInternal::ExplicitValue(TRY((this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::BitwiseLeftShift(),span,scope))));
-case 26 /* BitwiseRightShiftAssign */:return JaktInternal::ExplicitValue(TRY((this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::BitwiseRightShift(),span,scope))));
-case 27 /* AddAssign */:return JaktInternal::ExplicitValue(TRY((this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::Add(),span,scope))));
-case 28 /* SubtractAssign */:return JaktInternal::ExplicitValue(TRY((this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::Subtract(),span,scope))));
-case 29 /* MultiplyAssign */:return JaktInternal::ExplicitValue(TRY((this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::Multiply(),span,scope))));
-case 30 /* ModuloAssign */:return JaktInternal::ExplicitValue(TRY((this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::Modulo(),span,scope))));
-case 31 /* DivideAssign */:return JaktInternal::ExplicitValue(TRY((this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::Divide(),span,scope))));
-default:{
+ 
+}())),span));case 21 /* Assign */:return Jakt::interpreter::StatementResult::JustValue(rhs_value);case 22 /* BitwiseAndAssign */:return this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::BitwiseAnd(),span,scope);case 23 /* BitwiseOrAssign */:return this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::BitwiseOr(),span,scope);case 24 /* BitwiseXorAssign */:return this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::BitwiseXor(),span,scope);case 25 /* BitwiseLeftShiftAssign */:return this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::BitwiseLeftShift(),span,scope);case 26 /* BitwiseRightShiftAssign */:return this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::BitwiseRightShift(),span,scope);case 27 /* AddAssign */:return this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::Add(),span,scope);case 28 /* SubtractAssign */:return this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::Subtract(),span,scope);case 29 /* MultiplyAssign */:return this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::Multiply(),span,scope);case 30 /* ModuloAssign */:return this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::Modulo(),span,scope);case 31 /* DivideAssign */:return this->execute_binary_operator(lhs_value,rhs_value,Jakt::parser::BinaryOperator::Divide(),span,scope);default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Unimplemented binary operator '{}'"sv),op),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 ErrorOr<void> Jakt::interpreter::Interpreter::update_binding(NonnullRefPtr<typename Jakt::types::CheckedExpression> const binding,NonnullRefPtr<Jakt::interpreter::InterpreterScope> scope,Jakt::types::Value const value,Jakt::utility::Span const span) {
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = *binding;
+{auto&& __jakt_match_variant = *binding;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* Var */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Var;NonnullRefPtr<Jakt::types::CheckedVariable> const& var = __jakt_match_value.var;
 {
 TRY((scope->set(var->name,value)));
-NonnullRefPtr<typename Jakt::types::ValueImpl> __jakt_tmp75 = value.impl;
-if (__jakt_tmp75->__jakt_init_index() == 27 /* Function */){
-Jakt::types::CheckedBlock const block = __jakt_tmp75->as.Function.block;
-JaktInternal::Optional<Jakt::ids::FunctionId> const pseudo_function_id = __jakt_tmp75->as.Function.pseudo_function_id;
-JaktInternal::Optional<Jakt::ids::FunctionId> __jakt_tmp74 = pseudo_function_id;
-if (__jakt_tmp74.has_value()){
-Jakt::ids::FunctionId const id = __jakt_tmp74.value();
+NonnullRefPtr<typename Jakt::types::ValueImpl> __jakt_tmp74 = value.impl;
+if (__jakt_tmp74->__jakt_init_index() == 27 /* Function */){
+Jakt::types::CheckedBlock const block = __jakt_tmp74->as.Function.block;
+JaktInternal::Optional<Jakt::ids::FunctionId> const pseudo_function_id = __jakt_tmp74->as.Function.pseudo_function_id;
+JaktInternal::Optional<Jakt::ids::FunctionId> __jakt_tmp73 = pseudo_function_id;
+if (__jakt_tmp73.has_value()){
+Jakt::ids::FunctionId const id = __jakt_tmp73.value();
 this->program->get_function(id)->block = block;
 }
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_96;};/*case end*/
 case 16 /* IndexedStruct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedStruct;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 ByteString const& name = __jakt_match_value.name;
 {
-JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::Value>,Jakt::ids::StructId> fields_struct_id_ = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::Value>,Jakt::ids::StructId>, ErrorOr<void>>{
-auto&& __jakt_match_variant = TRY((this->execute_expression(expr,scope)));
+JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::Value>,Jakt::ids::StructId> fields_struct_id_ = TRY(([&]() -> ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::Value>,Jakt::ids::StructId>> { auto&& __jakt_match_variant = TRY((this->execute_expression(expr,scope)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::Value>,Jakt::ids::StructId>, ErrorOr<void>>{
-auto&& __jakt_match_variant = *value.impl;
+{auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 18 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
 Jakt::ids::StructId const& struct_id = __jakt_match_value.struct_id;
-return JaktInternal::ExplicitValue(Tuple{fields, struct_id});
-};/*case end*/
+return Tuple{fields, struct_id};};/*case end*/
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
 Jakt::ids::StructId const& struct_id = __jakt_match_value.struct_id;
-return JaktInternal::ExplicitValue(Tuple{fields, struct_id});
-};/*case end*/
+return Tuple{fields, struct_id};};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid left-hand side in assignment"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Should not be happening here"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 JaktInternal::DynamicArray<Jakt::types::Value> fields = fields_struct_id_.template get<0>();
 Jakt::ids::StructId struct_id = fields_struct_id_.template get<1>();
 
@@ -12699,7 +8571,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (this->program->get_variable(field_decls.operator[](i)->variable_id)->name == name){
+if (this->program->get_variable(field_decls[i]->variable_id)->name == name){
 field_index = i;
 break;
 }
@@ -12708,50 +8580,34 @@ break;
 }
 }
 
-fields.operator[](field_index) = value;
+fields[field_index] = value;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_96;};/*case end*/
 case 17 /* IndexedCommonEnumMember */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedCommonEnumMember;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 ByteString const& index = __jakt_match_value.index;
 {
-JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::Value>,Jakt::ids::EnumId> fields_enum_id_ = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::Value>,Jakt::ids::EnumId>, ErrorOr<void>>{
-auto&& __jakt_match_variant = TRY((this->execute_expression(expr,scope)));
+JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::Value>,Jakt::ids::EnumId> fields_enum_id_ = TRY(([&]() -> ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::Value>,Jakt::ids::EnumId>> { auto&& __jakt_match_variant = TRY((this->execute_expression(expr,scope)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::Value>,Jakt::ids::EnumId>, ErrorOr<void>>{
-auto&& __jakt_match_variant = *value.impl;
+{auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 19 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
 Jakt::ids::EnumId const& enum_id = __jakt_match_value.enum_id;
-return JaktInternal::ExplicitValue(Tuple{fields, enum_id});
-};/*case end*/
+return Tuple{fields, enum_id};};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid left-hand side in assignment"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Should not be happening here"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 JaktInternal::DynamicArray<Jakt::types::Value> fields = fields_enum_id_.template get<0>();
 Jakt::ids::EnumId enum_id = fields_enum_id_.template get<1>();
 
@@ -12766,7 +8622,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (this->program->get_variable(field_decls.operator[](i)->variable_id)->name == index){
+if (this->program->get_variable(field_decls[i]->variable_id)->name == index){
 field_index = i;
 break;
 }
@@ -12775,74 +8631,44 @@ break;
 }
 }
 
-fields.operator[](field_index) = value;
+fields[field_index] = value;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_96;};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid left-hand side of assignment {}"sv),binding),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_96;}/*switch end*/
+}goto __jakt_label_96; __jakt_label_96:;;
 }
 return {};
 }
 
 ErrorOr<Jakt::interpreter::StatementResult> Jakt::interpreter::Interpreter::execute_expression(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr,NonnullRefPtr<Jakt::interpreter::InterpreterScope> scope) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (this->current_function_id.has_value());
-if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->execute_expression_without_cast(expr,scope))));
-}else {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = TRY((this->execute_expression_without_cast(expr,scope)));
+{auto __jakt_enum_value = this->current_function_id.has_value();
+if (!__jakt_enum_value) {return this->execute_expression_without_cast(expr,scope);}else {{auto&& __jakt_match_variant = TRY((this->execute_expression_without_cast(expr,scope)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::Return(TRY((Jakt::interpreter::cast_value_to_type(value,this->program->get_function(this->current_function_id.value())->return_type_id,*this,false)))));
-};/*case end*/
+return Jakt::interpreter::StatementResult::Return(TRY((Jakt::interpreter::cast_value_to_type(value,this->program->get_function(this->current_function_id.value())->return_type_id,*this,false))));};/*case end*/
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(TRY((Jakt::interpreter::cast_value_to_type(value,expr->type(),*this,false)))));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(TRY((Jakt::interpreter::cast_value_to_type(value,expr->type(),*this,false))));};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::Throw(value));
-};/*case end*/
+return Jakt::interpreter::StatementResult::Throw(value);};/*case end*/
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::Yield(value));
-};/*case end*/
-case 4 /* Break */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::Break());
-case 3 /* Continue */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::Continue());
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return Jakt::interpreter::StatementResult::Yield(value);};/*case end*/
+case 4 /* Break */:return Jakt::interpreter::StatementResult::Break();case 3 /* Continue */:return Jakt::interpreter::StatementResult::Continue();default: VERIFY_NOT_REACHED();}/*switch end*/
+}}}
 }
 }
 
 ErrorOr<Jakt::interpreter::StatementResult> Jakt::interpreter::Interpreter::execute_expression_without_cast(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr,NonnullRefPtr<Jakt::interpreter::InterpreterScope> scope) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *expr;
+{auto&& __jakt_match_variant = *expr;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* BinaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.BinaryOp;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& lhs = __jakt_match_value.lhs;
@@ -12957,8 +8783,8 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Bool */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Bool;bool const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (x);
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::interpreter::StatementResult>>{
+auto __jakt_enum_value = x;
 if (__jakt_enum_value == (op.op.__jakt_init_index() == 18 /* LogicalAnd */)) {return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((this->execute_expression(rhs,scope)));
@@ -12999,7 +8825,8 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
     _jakt_value.release_value();
 }).cast(lhs_value,span));
 }else {return JaktInternal::ExplicitValue(lhs_value);
-}}());
+}}()
+);
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
@@ -13066,42 +8893,24 @@ VERIFY_NOT_REACHED();
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = value;
+{auto&& __jakt_match_variant = value;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& value = __jakt_match_value.value;
-return ({({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = op.op;
+{auto&& __jakt_match_variant = op.op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* Assign */:case 22 /* BitwiseAndAssign */:case 23 /* BitwiseOrAssign */:case 24 /* BitwiseXorAssign */:case 25 /* BitwiseLeftShiftAssign */:case 26 /* BitwiseRightShiftAssign */:case 27 /* AddAssign */:case 28 /* SubtractAssign */:case 29 /* MultiplyAssign */:case 30 /* ModuloAssign */:case 31 /* DivideAssign */:case 32 /* NoneCoalescingAssign */:{
 TRY((this->update_binding(lhs,scope,value,span)));
 }
-return JaktInternal::ExplicitValue<void>();
+goto __jakt_label_98;default:{
+}
+goto __jakt_label_98;}/*switch end*/
+}goto __jakt_label_98; __jakt_label_98:;;goto __jakt_label_97;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-default:{
-}
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(value);
+goto __jakt_label_97;}/*switch end*/
+}goto __jakt_label_97; __jakt_label_97:;;
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13109,14 +8918,11 @@ case 6 /* UnaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 Jakt::types::CheckedUnaryOperator const& op = __jakt_match_value.op;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = op;
+{auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 16 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(TRY((Jakt::interpreter::size_of_impl(type_id,*this)))),span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(TRY((Jakt::interpreter::size_of_impl(type_id,*this)))),span));};/*case end*/
 default:{
 Jakt::types::Value const value = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::interpreter::StatementResult>>{
@@ -13157,38 +8963,25 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = op;
+{auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 9 /* LogicalNot */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *value.impl;
+case 9 /* LogicalNot */:{auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Bool */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Bool;bool const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(!value),span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(!value),span));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid type for unary operator"sv)),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 1 /* PostIncrement */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *value.impl;
+}case 1 /* PostIncrement */:return Jakt::interpreter::StatementResult::JustValue(TRY(([&]() -> ErrorOr<Jakt::types::Value> { auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::U8(JaktInternal::checked_add(x,static_cast<u8>(1))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13196,7 +8989,7 @@ case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::I8(JaktInternal::checked_add(x,static_cast<i8>(1))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13204,7 +8997,7 @@ case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::U16(JaktInternal::checked_add(x,static_cast<u16>(1))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13212,7 +9005,7 @@ case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::I16(JaktInternal::checked_add(x,static_cast<i16>(1))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13220,7 +9013,7 @@ case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::U32(JaktInternal::checked_add(x,static_cast<u32>(1))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13228,7 +9021,7 @@ case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::I32(JaktInternal::checked_add(x,static_cast<i32>(1))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13236,7 +9029,7 @@ case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::U64(JaktInternal::checked_add(x,static_cast<u64>(1ULL))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13244,7 +9037,7 @@ case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::I64(JaktInternal::checked_add(x,static_cast<i64>(1LL))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13252,7 +9045,7 @@ case 15 /* CChar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CChar;char const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::CChar(JaktInternal::checked_add(x,static_cast<char>(1))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13260,7 +9053,7 @@ case 16 /* CInt */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CInt;int const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::CInt(JaktInternal::checked_add(x,static_cast<int>(1))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13268,7 +9061,7 @@ case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::USize(JaktInternal::checked_add(x,static_cast<size_t>(1ULL))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13277,22 +9070,15 @@ TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid type for
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-})));
-case 0 /* PreIncrement */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *value.impl;
+ 
+}())));case 0 /* PreIncrement */:return Jakt::interpreter::StatementResult::JustValue(TRY(([&]() -> ErrorOr<Jakt::types::Value> { auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::U8(JaktInternal::checked_add(x,static_cast<u8>(1))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13301,7 +9087,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_matc
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::I8(JaktInternal::checked_add(x,static_cast<i8>(1))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13310,7 +9096,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_ma
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::U16(JaktInternal::checked_add(x,static_cast<u16>(1))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13319,7 +9105,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_ma
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::I16(JaktInternal::checked_add(x,static_cast<i16>(1))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13328,7 +9114,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_ma
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::U32(JaktInternal::checked_add(x,static_cast<u32>(1))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13337,7 +9123,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_ma
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::I32(JaktInternal::checked_add(x,static_cast<i32>(1))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13346,7 +9132,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_ma
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::U64(JaktInternal::checked_add(x,static_cast<u64>(1ULL))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13355,7 +9141,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_ma
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::I64(JaktInternal::checked_add(x,static_cast<i64>(1LL))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13364,7 +9150,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.CChar;char const& x = __jakt
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::CChar(JaktInternal::checked_add(x,static_cast<char>(1))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13373,7 +9159,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.CInt;int const& x = __jakt_m
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::CInt(JaktInternal::checked_add(x,static_cast<int>(1))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13382,7 +9168,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __ja
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::USize(JaktInternal::checked_add(x,static_cast<size_t>(1ULL))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13391,21 +9177,14 @@ TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid type for
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-})));
-case 3 /* PostDecrement */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *value.impl;
+ 
+}())));case 3 /* PostDecrement */:return Jakt::interpreter::StatementResult::JustValue(TRY(([&]() -> ErrorOr<Jakt::types::Value> { auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::U8(JaktInternal::checked_sub(x,static_cast<u8>(1))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13413,7 +9192,7 @@ case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::I8(JaktInternal::checked_sub(x,static_cast<i8>(1))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13421,7 +9200,7 @@ case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::U16(JaktInternal::checked_sub(x,static_cast<u16>(1))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13429,7 +9208,7 @@ case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::I16(JaktInternal::checked_sub(x,static_cast<i16>(1))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13437,7 +9216,7 @@ case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::U32(JaktInternal::checked_sub(x,static_cast<u32>(1))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13445,7 +9224,7 @@ case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::I32(JaktInternal::checked_sub(x,static_cast<i32>(1))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13453,7 +9232,7 @@ case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::U64(JaktInternal::checked_sub(x,static_cast<u64>(1ULL))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13461,7 +9240,7 @@ case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::I64(JaktInternal::checked_sub(x,static_cast<i64>(1LL))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13469,7 +9248,7 @@ case 15 /* CChar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CChar;char const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::CChar(JaktInternal::checked_sub(x,static_cast<char>(1))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13477,7 +9256,7 @@ case 16 /* CInt */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CInt;int const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::CInt(JaktInternal::checked_sub(x,static_cast<int>(1))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13485,7 +9264,7 @@ case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
 {
 TRY((this->update_binding(expr,scope,Jakt::types::Value(Jakt::types::ValueImpl::USize(JaktInternal::checked_sub(x,static_cast<size_t>(1ULL))),span),span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13494,22 +9273,15 @@ TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid type for
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-})));
-case 2 /* PreDecrement */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *value.impl;
+ 
+}())));case 2 /* PreDecrement */:return Jakt::interpreter::StatementResult::JustValue(TRY(([&]() -> ErrorOr<Jakt::types::Value> { auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::U8(JaktInternal::checked_sub(x,static_cast<u8>(1))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13518,7 +9290,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_matc
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::I8(JaktInternal::checked_sub(x,static_cast<i8>(1))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13527,7 +9299,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_ma
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::U16(JaktInternal::checked_sub(x,static_cast<u16>(1))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13536,7 +9308,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_ma
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::I16(JaktInternal::checked_sub(x,static_cast<i16>(1))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13545,7 +9317,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_ma
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::U32(JaktInternal::checked_sub(x,static_cast<u32>(1))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13554,7 +9326,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_ma
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::I32(JaktInternal::checked_sub(x,static_cast<i32>(1))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13563,7 +9335,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_ma
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::U64(JaktInternal::checked_sub(x,static_cast<u64>(1ULL))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13572,7 +9344,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_ma
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::I64(JaktInternal::checked_sub(x,static_cast<i64>(1LL))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13581,7 +9353,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.CChar;char const& x = __jakt
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::CChar(JaktInternal::checked_sub(x,static_cast<char>(1))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13590,7 +9362,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.CInt;int const& x = __jakt_m
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::CInt(JaktInternal::checked_sub(x,static_cast<int>(1))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13599,7 +9371,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __ja
 {
 Jakt::types::Value const value = Jakt::types::Value(Jakt::types::ValueImpl::USize(JaktInternal::checked_sub(x,static_cast<size_t>(1ULL))),span);
 TRY((this->update_binding(expr,scope,value,span)));
-return JaktInternal::ExplicitValue<Jakt::types::Value>(value);
+return value;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13608,47 +9380,30 @@ TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid type for
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-})));
-case 11 /* TypeCast */: {
+ 
+}())));case 11 /* TypeCast */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeCast;Jakt::types::CheckedTypeCast const& cast = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = cast;
+{auto&& __jakt_match_variant = cast;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* Identity */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identity;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(TRY((Jakt::interpreter::cast_value_to_type(value,type_id,*this,false)))));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(TRY((Jakt::interpreter::cast_value_to_type(value,type_id,*this,false))));};/*case end*/
 case 1 /* Infallible */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Infallible;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(TRY((Jakt::interpreter::cast_value_to_type(value,type_id,*this,false)))));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(TRY((Jakt::interpreter::cast_value_to_type(value,type_id,*this,false))));};/*case end*/
 case 0 /* Fallible */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Fallible;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
 {
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(TRY((Jakt::interpreter::cast_value_to_type(value,type_id,*this,false)))),span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(TRY((Jakt::interpreter::cast_value_to_type(value,type_id,*this,false)))),span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 13 /* IsEnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IsEnumVariant;Jakt::types::CheckedEnumVariant const& enum_variant = __jakt_match_value.enum_variant;
 JaktInternal::DynamicArray<Jakt::types::CheckedEnumVariantBinding> const& bindings = __jakt_match_value.bindings;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *value.impl;
+{auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 19 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
@@ -13662,7 +9417,7 @@ return !(self == rhs);
 (enum_variant.name(),constructor_name)){
 return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(false),span));
 }
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(true),span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(true),span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13671,42 +9426,25 @@ TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid value fo
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("Unimplemented unary operator '{}'"sv),op),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 9 /* Range */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Range;JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& from = __jakt_match_value.from;
 JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& to = __jakt_match_value.to;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 Jakt::types::Value const start = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (from.has_value());
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::interpreter::StatementResult>>{
+auto __jakt_enum_value = from.has_value();
 if (__jakt_enum_value) {return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((this->execute_expression(from.value(),scope)));
@@ -13751,14 +9489,15 @@ TRY((this->error(ByteString::from_utf8_without_validation("Partial ranges are no
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
 }VERIFY_NOT_REACHED();
-}());
+}()
+);
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
 Jakt::types::Value const end = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (to.has_value());
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::interpreter::StatementResult>>{
+auto __jakt_enum_value = to.has_value();
 if (__jakt_enum_value) {return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((this->execute_expression(to.value(),scope)));
@@ -13803,14 +9542,15 @@ TRY((this->error(ByteString::from_utf8_without_validation("Partial ranges are no
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
 }VERIFY_NOT_REACHED();
-}());
+}()
+);
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
 Jakt::ids::StructId const range_struct_id = TRY((this->program->find_struct_in_prelude(ByteString::from_utf8_without_validation("Range"sv))));
 JaktInternal::DynamicArray<Jakt::ids::FunctionId> const range_constructors = TRY((this->program->find_functions_with_name_in_scope(this->program->get_struct(range_struct_id).scope_id,ByteString::from_utf8_without_validation("Range"sv),false,JaktInternal::OptionalNone()))).value();
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({start, end}),range_struct_id,range_constructors.operator[](static_cast<i64>(0LL))),span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({start, end}),range_struct_id,range_constructors[static_cast<i64>(0LL)]),span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -13953,33 +9693,24 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::types::FunctionGenericParameter const param = function_to_run->generics->params.operator[](i);
-type_bindings.set(param.type_id(),call.type_args.operator[](i));
+Jakt::types::FunctionGenericParameter const param = function_to_run->generics->params[i];
+type_bindings.set(param.type_id(),call.type_args[i]);
 }
 
 }
 }
 
 JaktInternal::Dictionary<ByteString,Jakt::types::Value> const empty_bindings = Dictionary<ByteString, Jakt::types::Value>::create_with_entries({});
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = TRY((this->execute(call.function_id.value(),static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::ResolvedNamespace>>>(call.namespace_),this_argument,arguments,span,Jakt::interpreter::InterpreterScope::create(Dictionary<ByteString, Jakt::types::Value>::create_with_entries({}),JaktInternal::OptionalNone(),type_bindings,this->compiler,scope->runtime_scope_id),false)));
+{auto&& __jakt_match_variant = TRY((this->execute(call.function_id.value(),static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::ResolvedNamespace>>>(call.namespace_),this_argument,arguments,span,Jakt::interpreter::InterpreterScope::create(Dictionary<ByteString, Jakt::types::Value>::create_with_entries({}),JaktInternal::OptionalNone(),type_bindings,this->compiler,scope->runtime_scope_id),false)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(value));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(value);};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::Throw(value));
-};/*case end*/
+return Jakt::interpreter::StatementResult::Throw(value);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -14028,73 +9759,54 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
     _jakt_value.release_value();
 });
 JaktInternal::DynamicArray<Jakt::types::ResolvedNamespace> effective_namespace = DynamicArray<Jakt::types::ResolvedNamespace>::create_with({});
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this_argument.impl;
+{auto&& __jakt_match_variant = *this_argument.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */:{
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = DynamicArray<Jakt::ids::TypeId>::create_with({});
 effective_namespace.push(Jakt::types::ResolvedNamespace(ByteString::from_utf8_without_validation("String"sv),JaktInternal::OptionalNone(),generic_parameters));
 }
-return JaktInternal::ExplicitValue<void>();
-case 20 /* JaktArray */: {
+goto __jakt_label_99;case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::ids::TypeId>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this->program->get_type(type_id);
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = TRY(([&]() -> ErrorOr<JaktInternal::DynamicArray<Jakt::ids::TypeId>> { auto&& __jakt_match_variant = *this->program->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(args);
-};/*case end*/
+return args;};/*case end*/
 default:{
 TRY((this->error(ByteString::from_utf8_without_validation("Attempted to call a prelude function  on a non-generic array"sv),this_argument.span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 effective_namespace.push(Jakt::types::ResolvedNamespace(ByteString::from_utf8_without_validation("Array"sv),JaktInternal::OptionalNone(),generic_parameters));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_99;};/*case end*/
 case 21 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::ids::TypeId>, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this->program->get_type(type_id);
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = TRY(([&]() -> ErrorOr<JaktInternal::DynamicArray<Jakt::ids::TypeId>> { auto&& __jakt_match_variant = *this->program->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(args);
-};/*case end*/
+return args;};/*case end*/
 default:{
 TRY((this->error(ByteString::from_utf8_without_validation("Attempted to call a prelude function  on a non-generic dictionary"sv),this_argument.span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 effective_namespace.push(Jakt::types::ResolvedNamespace(ByteString::from_utf8_without_validation("Dictionary"sv),JaktInternal::OptionalNone(),generic_parameters));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_99;};/*case end*/
 case 22 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp76 = this->program->get_type(type_id);
-if (__jakt_tmp76->__jakt_init_index() == 20 /* GenericInstance */){
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = __jakt_tmp76->as.GenericInstance.args;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp75 = this->program->get_type(type_id);
+if (__jakt_tmp75->__jakt_init_index() == 20 /* GenericInstance */){
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = __jakt_tmp75->as.GenericInstance.args;
 effective_namespace.push(Jakt::types::ResolvedNamespace(ByteString::from_utf8_without_validation("Set"sv),JaktInternal::OptionalNone(),generic_parameters));
 }
 else {
@@ -14103,49 +9815,38 @@ this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv)
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_99;};/*case end*/
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.struct_id;
 {
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = DynamicArray<Jakt::ids::TypeId>::create_with({});
 effective_namespace.push(Jakt::types::ResolvedNamespace(this->program->get_struct(struct_id).name,JaktInternal::OptionalNone(),generic_parameters));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_99;};/*case end*/
 case 18 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;Jakt::ids::StructId const& struct_id = __jakt_match_value.struct_id;
 {
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = DynamicArray<Jakt::ids::TypeId>::create_with({});
 effective_namespace.push(Jakt::types::ResolvedNamespace(this->program->get_struct(struct_id).name,JaktInternal::OptionalNone(),generic_parameters));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_99;};/*case end*/
 case 19 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.enum_id;
 {
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = DynamicArray<Jakt::ids::TypeId>::create_with({});
 effective_namespace.push(Jakt::types::ResolvedNamespace(this->program->get_enum(enum_id).name,JaktInternal::OptionalNone(),generic_parameters));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_99;};/*case end*/
 case 25 /* OptionalNone */:case 24 /* OptionalSome */:{
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const generic_parameters = DynamicArray<Jakt::ids::TypeId>::create_with({});
 effective_namespace.push(Jakt::types::ResolvedNamespace(ByteString::from_utf8_without_validation("Optional"sv),JaktInternal::OptionalNone(),generic_parameters));
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_99;default:{
 TRY((this->error(ByteString::from_utf8_without_validation("Attempted to call an instance method on a non-struct/enum type"sv),this_argument.span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_99;}/*switch end*/
+}goto __jakt_label_99; __jakt_label_99:;;
 if (!call.function_id.has_value()){
 JaktInternal::DynamicArray<Jakt::types::Value> arguments = DynamicArray<Jakt::types::Value>::create_with({});
 {
@@ -14276,47 +9977,37 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::types::FunctionGenericParameter const param = function_to_run->generics->params.operator[](i);
-type_bindings.set(param.type_id(),call.type_args.operator[](i));
+Jakt::types::FunctionGenericParameter const param = function_to_run->generics->params[i];
+type_bindings.set(param.type_id(),call.type_args[i]);
 }
 
 }
 }
 
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = TRY((this->execute(call.function_id.value(),static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::ResolvedNamespace>>>(call.namespace_),this_argument,arguments,span,Jakt::interpreter::InterpreterScope::create(Dictionary<ByteString, Jakt::types::Value>::create_with_entries({}),JaktInternal::OptionalNone(),type_bindings,this->compiler,scope->runtime_scope_id),false)));
+{auto&& __jakt_match_variant = TRY((this->execute(call.function_id.value(),static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::ResolvedNamespace>>>(call.namespace_),this_argument,arguments,span,Jakt::interpreter::InterpreterScope::create(Dictionary<ByteString, Jakt::types::Value>::create_with_entries({}),JaktInternal::OptionalNone(),type_bindings,this->compiler,scope->runtime_scope_id),false)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(value));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(value);};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::Throw(value));
-};/*case end*/
+return Jakt::interpreter::StatementResult::Throw(value);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 25 /* OptionalNone */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalNone;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalNone(),span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalNone(),span));};/*case end*/
 case 26 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 Jakt::interpreter::StatementResult const result = TRY((this->execute_expression(expr,scope)));
-Jakt::interpreter::StatementResult __jakt_tmp77 = result;
-if (__jakt_tmp77.__jakt_init_index() == 5 /* JustValue */){
-Jakt::types::Value const value = __jakt_tmp77.as.JustValue.value;
+Jakt::interpreter::StatementResult __jakt_tmp76 = result;
+if (__jakt_tmp76.__jakt_init_index() == 5 /* JustValue */){
+Jakt::types::Value const value = __jakt_tmp76.as.JustValue.value;
 return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(value),span));
 }
 return result;
@@ -14368,42 +10059,31 @@ if (value.impl->__jakt_init_index() == 25 /* OptionalNone */){
 TRY((this->error(ByteString::from_utf8_without_validation("Attempted to unwrap an optional value that was None"sv),value.span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *value.impl;
+{auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(value));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(value);};/*case end*/
 default:{
 TRY((this->error(ByteString::from_utf8_without_validation("Invalid type for unwrap"sv),value.span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 28 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->execute_block(block,scope,span))));
-};/*case end*/
+return this->execute_block(block,scope,span);};/*case end*/
 case 3 /* ByteConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ByteConstant;ByteString const& val = __jakt_match_value.val;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::U8(val.byte_at(static_cast<size_t>(0ULL))),span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::U8(val.byte_at(static_cast<size_t>(0ULL))),span));};/*case end*/
 case 24 /* Var */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Var;NonnullRefPtr<Jakt::types::CheckedVariable> const& var = __jakt_match_value.var;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(TRY((scope->must_get(var->name)))));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(TRY((scope->must_get(var->name))));};/*case end*/
 case 13 /* IndexedExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedExpression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const& index_expr = __jakt_match_value.index;
@@ -14487,68 +10167,51 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *value.impl;
+{auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
 {
-u64 const numeric_index = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<u64, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *index.impl;
+u64 const numeric_index = [&]() -> u64 { auto&& __jakt_match_variant = *index.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return static_cast<u64>(x);};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(x));
-};/*case end*/
+return infallible_integer_cast<u64>(x);};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid type for repeat"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 if (numeric_index >= infallible_integer_cast<u64>(values.size())){
 TRY((this->error(__jakt_format(StringView::from_string_literal("Index {} out of bounds (max={})"sv),numeric_index,values.size()),span)));
 return Jakt::interpreter::StatementResult::Throw(TRY((this->error_value(ByteString::from_utf8_without_validation("Invalid type"sv),span))));
 }
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(values.operator[](numeric_index)));
+return Jakt::interpreter::StatementResult::JustValue(values[numeric_index]);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -14557,20 +10220,14 @@ TRY((this->error(ByteString::from_utf8_without_validation("Invalid or unsupporte
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 0 /* Boolean */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boolean;bool const& val = __jakt_match_value.val;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(val),span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Bool(val),span));};/*case end*/
 case 16 /* IndexedStruct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedStruct;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 ByteString const& name = __jakt_match_value.name;
@@ -14614,9 +10271,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *value.impl;
+{auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
@@ -14648,7 +10303,7 @@ if (!found_index.has_value()){
 TRY((this->error(ByteString::from_utf8_without_validation("Attempted to access a field that does not exist"sv),value.span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(fields.operator[](found_index.value())));
+return Jakt::interpreter::StatementResult::JustValue(fields[found_index.value()]);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -14682,7 +10337,7 @@ if (!found_index.has_value()){
 TRY((this->error(ByteString::from_utf8_without_validation("Attempted to access a field that does not exist"sv),value.span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(fields.operator[](found_index.value())));
+return Jakt::interpreter::StatementResult::JustValue(fields[found_index.value()]);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -14691,12 +10346,7 @@ TRY((this->error(ByteString::from_utf8_without_validation("Attempted to access a
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -14743,9 +10393,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *value.impl;
+{auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 19 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
@@ -14777,7 +10425,7 @@ if (!found_index.has_value()){
 TRY((this->error(ByteString::from_utf8_without_validation("Attempted to access a field that does not exist"sv),value.span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(fields.operator[](found_index.value())));
+return Jakt::interpreter::StatementResult::JustValue(fields[found_index.value()]);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -14786,12 +10434,7 @@ TRY((this->error(ByteString::from_utf8_without_validation("Attempted to access a
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -14908,80 +10551,57 @@ values.push(val);
 }
 }
 
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktDictionary(keys,values,type_id),span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktDictionary(keys,values,type_id),span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 1 /* NumericConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NumericConstant;Jakt::types::CheckedNumericConstant const& val = __jakt_match_value.val;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = val;
+return Jakt::interpreter::StatementResult::JustValue([&]() -> Jakt::types::Value { auto&& __jakt_match_variant = val;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I8(x),span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::I8(x),span);};/*case end*/
 case 1 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I16(x),span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::I16(x),span);};/*case end*/
 case 2 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I32(x),span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::I32(x),span);};/*case end*/
 case 3 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I64(x),span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::I64(x),span);};/*case end*/
 case 4 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U8(x),span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::U8(x),span);};/*case end*/
 case 5 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U16(x),span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::U16(x),span);};/*case end*/
 case 6 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U32(x),span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::U32(x),span);};/*case end*/
 case 7 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U64(x),span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::U64(x),span);};/*case end*/
 case 8 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(infallible_integer_cast<size_t>(x)),span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::USize(infallible_integer_cast<size_t>(x)),span);};/*case end*/
 case 9 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::F32(x),span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::F32(x),span);};/*case end*/
 case 10 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::F64(x),span));
-};/*case end*/
+return Jakt::types::Value(Jakt::types::ValueImpl::F64(x),span);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-})));
-};/*case end*/
+ 
+}());};/*case end*/
 case 2 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;Jakt::types::CheckedStringLiteral const& val = __jakt_match_value.val;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (val.type_id.equals(Jakt::types::builtin(Jakt::types::BuiltinType::JaktString())));
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(Jakt::utility::interpret_escapes(val.to_string())),span)));
-}else if (!__jakt_enum_value) {{
-Jakt::ids::FunctionId const function_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::FunctionId, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *this->program->get_type(val.type_id);
+{auto __jakt_enum_value = val.type_id.equals(Jakt::types::builtin(Jakt::types::BuiltinType::JaktString()));
+if (__jakt_enum_value) {return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(Jakt::utility::interpret_escapes(val.to_string())),span));}else if (!__jakt_enum_value) {{
+Jakt::ids::FunctionId const function_id = TRY(([&]() -> ErrorOr<Jakt::ids::FunctionId> { auto&& __jakt_match_variant = *this->program->get_type(val.type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
@@ -14991,7 +10611,7 @@ JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::ids::FunctionId>> const 
 if (!overloads.has_value()){
 Jakt::utility::panic(__jakt_format(StringView::from_string_literal("Failed to find a from_string_literal overload in {}"sv),TRY((this->program->type_name(val.type_id,false)))));
 }
-return JaktInternal::ExplicitValue<Jakt::ids::FunctionId>(overloads.value().first().value());
+return overloads.value().first().value();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -15003,7 +10623,7 @@ JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::ids::FunctionId>> const 
 if (!overloads.has_value()){
 Jakt::utility::panic(__jakt_format(StringView::from_string_literal("Failed to find a from_string_literal overload in {}"sv),TRY((this->program->type_name(val.type_id,false)))));
 }
-return JaktInternal::ExplicitValue<Jakt::ids::FunctionId>(overloads.value().first().value());
+return overloads.value().first().value();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -15015,7 +10635,7 @@ JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::ids::FunctionId>> const 
 if (!overloads.has_value()){
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Failed to find a from_string_literal overload"sv));
 }
-return JaktInternal::ExplicitValue<Jakt::ids::FunctionId>(overloads.value().first().value());
+return overloads.value().first().value();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -15027,7 +10647,7 @@ JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::ids::FunctionId>> const 
 if (!overloads.has_value()){
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Failed to find a from_string_literal overload"sv));
 }
-return JaktInternal::ExplicitValue<Jakt::ids::FunctionId>(overloads.value().first().value());
+return overloads.value().first().value();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -15036,46 +10656,27 @@ TRY((this->error(__jakt_format(StringView::from_string_literal("Invalid type {} 
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 JaktInternal::DynamicArray<Jakt::types::ResolvedNamespace> const ns = DynamicArray<Jakt::types::ResolvedNamespace>::create_with({});
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = TRY((this->execute(function_id,static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::ResolvedNamespace>>>(ns),JaktInternal::OptionalNone(),DynamicArray<Jakt::types::Value>::create_with({Jakt::types::Value(Jakt::types::ValueImpl::JaktString(Jakt::utility::interpret_escapes(val.to_string())),span)}),span,scope,false)));
+{auto&& __jakt_match_variant = TRY((this->execute(function_id,static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::ResolvedNamespace>>>(ns),JaktInternal::OptionalNone(),DynamicArray<Jakt::types::Value>::create_with({Jakt::types::Value(Jakt::types::ValueImpl::JaktString(Jakt::utility::interpret_escapes(val.to_string())),span)}),span,scope,false)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(value));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(value);};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::Throw(value));
-};/*case end*/
+return Jakt::interpreter::StatementResult::Throw(value);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}
 }
 VERIFY_NOT_REACHED();
 }VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* CCharacterConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CCharacterConstant;ByteString const& val = __jakt_match_value.val;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::CChar(infallible_integer_cast<char>(val.byte_at(static_cast<size_t>(0ULL)))),span)));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::CChar(infallible_integer_cast<char>(val.byte_at(static_cast<size_t>(0ULL)))),span));};/*case end*/
 case 4 /* CharacterConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CharacterConstant;ByteString const& val = __jakt_match_value.val;
 Jakt::utility::Span const& span = __jakt_match_value.span;
@@ -15086,7 +10687,7 @@ if (!code_point.has_value()){
 TRY((this->error(ByteString::from_utf8_without_validation("Invalid character constant"sv),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid character constant"sv));
 }
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::U32(code_point.value()),span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::U32(code_point.value()),span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -15095,9 +10696,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::Dyna
 JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& repeat = __jakt_match_value.repeat;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (repeat.has_value());
+{auto __jakt_enum_value = repeat.has_value();
 if (__jakt_enum_value) {{
 size_t const count = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<Jakt::interpreter::StatementResult>>{
@@ -15117,56 +10716,41 @@ return Jakt::interpreter::StatementResult::Throw(value);
 };/*case end*/
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *value.impl;
+return JaktInternal::ExplicitValue([&]() -> size_t { auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<size_t>(x));
-};/*case end*/
+return infallible_integer_cast<size_t>(x);};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<size_t>(x));
-};/*case end*/
+return infallible_integer_cast<size_t>(x);};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<size_t>(x));
-};/*case end*/
+return infallible_integer_cast<size_t>(x);};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<size_t>(x));
-};/*case end*/
+return infallible_integer_cast<size_t>(x);};/*case end*/
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<size_t>(x));
-};/*case end*/
+return infallible_integer_cast<size_t>(x);};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<size_t>(x));
-};/*case end*/
+return infallible_integer_cast<size_t>(x);};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<size_t>(x));
-};/*case end*/
+return infallible_integer_cast<size_t>(x);};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<size_t>(x));
-};/*case end*/
+return infallible_integer_cast<size_t>(x);};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<size_t>(x));
-};/*case end*/
+return static_cast<size_t>(x);};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid type for repeat"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+ 
+}());
 };/*case end*/
 case 3 /* Continue */:{
 return Jakt::interpreter::StatementResult::Continue();
@@ -15189,7 +10773,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 });
 Jakt::types::Value const value_to_repeat = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = TRY((this->execute_expression(vals.operator[](static_cast<i64>(0LL)),scope)));
+auto&& __jakt_match_variant = TRY((this->execute_expression(vals[static_cast<i64>(0LL)],scope)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
@@ -15226,7 +10810,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktArray(DynamicArray<Jakt::types::Value>::filled(count, value_to_repeat),TRY((this->program->substitute_typevars_in_type(type_id,scope->type_map_for_substitution(),type_id.module)))),span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktArray(DynamicArray<Jakt::types::Value>::filled(count, value_to_repeat),TRY((this->program->substitute_typevars_in_type(type_id,scope->type_map_for_substitution(),type_id.module)))),span));
 }
 VERIFY_NOT_REACHED();
 }else {{
@@ -15289,15 +10873,10 @@ values.push(val);
 }
 }
 
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktArray(values,TRY((this->program->substitute_typevars_in_type(type_id,scope->type_map_for_substitution(),type_id.module)))),span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktArray(values,TRY((this->program->substitute_typevars_in_type(type_id,scope->type_map_for_substitution(),type_id.module)))),span));
 }
 VERIFY_NOT_REACHED();
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}}};/*case end*/
 case 15 /* IndexedTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedTuple;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 size_t const& index = __jakt_match_value.index;
@@ -15338,23 +10917,17 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-NonnullRefPtr<typename Jakt::types::ValueImpl> __jakt_tmp78 = value.impl;
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult,ErrorOr<Jakt::interpreter::StatementResult>> {
-auto __jakt_enum_value = (__jakt_tmp78->__jakt_init_index() == 26 /* JaktTuple */);
+NonnullRefPtr<typename Jakt::types::ValueImpl> __jakt_tmp77 = value.impl;
+{auto __jakt_enum_value = __jakt_tmp77->__jakt_init_index() == 26 /* JaktTuple */;
 if (__jakt_enum_value) {{
-JaktInternal::DynamicArray<Jakt::types::Value> const fields = __jakt_tmp78->as.JaktTuple.fields;
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(fields.operator[](index)));
+JaktInternal::DynamicArray<Jakt::types::Value> const fields = __jakt_tmp77->as.JaktTuple.fields;
+return Jakt::interpreter::StatementResult::JustValue(fields[index]);
 }
 VERIFY_NOT_REACHED();
 }else {{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("expected tuple"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -15400,9 +10973,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *value.impl;
+{auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 19 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
@@ -15434,67 +11005,52 @@ break;
 }
 Jakt::types::CheckedMatchPattern pattern = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = pattern;
+{auto&& __jakt_match_variant = pattern;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* EnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;ByteString const& name = __jakt_match_value.name;
 JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> const& args = __jakt_match_value.args;
 size_t const& index = __jakt_match_value.index;
-Jakt::utility::Span const& marker_span = __jakt_match_value.marker_span;
+Jakt::utility::Span const& marker_span = __jakt_match_variant.common.init_common.marker_span;
 {
 if ([](ByteString const& self, ByteString rhs) -> bool {{
 return !(self == rhs);
 }
 }
 (name,constructor_name)){
-return JaktInternal::LoopContinue{};
+continue;
 }
 found_body = body;
 found_args = args;
 found_variant_index = index;
 span = marker_span;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_100;};/*case end*/
 case 2 /* ClassInstance */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.ClassInstance;Jakt::utility::Span const& marker_span = __jakt_match_value.marker_span;
+auto&& __jakt_match_value = __jakt_match_variant.as.ClassInstance;Jakt::utility::Span const& marker_span = __jakt_match_variant.common.init_common.marker_span;
 {
 TRY((this->error(ByteString::from_utf8_without_validation("Value matches are not allowed on enums"sv),marker_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_100;};/*case end*/
 case 1 /* Expression */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.Expression;Jakt::utility::Span const& marker_span = __jakt_match_value.marker_span;
+auto&& __jakt_match_value = __jakt_match_variant.as.Expression;Jakt::utility::Span const& marker_span = __jakt_match_variant.common.init_common.marker_span;
 {
 TRY((this->error(ByteString::from_utf8_without_validation("Value matches are not allowed on enums"sv),marker_span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_100;};/*case end*/
 case 3 /* CatchAll */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;Jakt::utility::Span const& marker_span = __jakt_match_value.marker_span;
+auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;Jakt::utility::Span const& marker_span = __jakt_match_variant.common.init_common.marker_span;
 {
 catch_all_case = body;
 span = marker_span;
-return JaktInternal::LoopContinue{};
+continue;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_100;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+break;}goto __jakt_label_100; __jakt_label_100:;;
 }
 
 }
@@ -15517,24 +11073,19 @@ ScopeGuard __jakt_var_19([&] {
 MUST((new_scope->perform_defers(*this,span.value())));
 });
 if (found_variant_index.has_value() && (!found_args.value().is_empty())){
-Jakt::types::CheckedEnumVariant const variant = this->program->get_enum(enum_id).variants.operator[](found_variant_index.value());
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = variant;
+Jakt::types::CheckedEnumVariant const variant = this->program->get_enum(enum_id).variants[found_variant_index.value()];
+{auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Untyped */:{
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* WithValue */:{
+goto __jakt_label_101;case 2 /* WithValue */:{
 }
-return JaktInternal::ExplicitValue<void>();
-case 1 /* Typed */:{
+goto __jakt_label_101;case 1 /* Typed */:{
 if (found_args.value().size() > static_cast<size_t>(0ULL)){
-new_scope->bindings.set(found_args.value().operator[](static_cast<i64>(0LL)).binding,fields.operator[](static_cast<i64>(0LL)));
+new_scope->bindings.set(found_args.value()[static_cast<i64>(0LL)].binding,fields[static_cast<i64>(0LL)]);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* StructLike */: {
+goto __jakt_label_101;case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;JaktInternal::DynamicArray<Jakt::ids::VarId> const& variant_fields = __jakt_match_value.fields;
 {
 i64 i = static_cast<i64>(0LL);
@@ -15559,7 +11110,7 @@ Jakt::parser::EnumVariantPatternArgument arg = _magic_value.value();
 {
 ByteString const matched_name = arg.name.value_or_lazy_evaluated([&] { return arg.binding; });
 if (matched_name == field->name){
-new_scope->bindings.set(arg.binding,fields.operator[](i));
+new_scope->bindings.set(arg.binding,fields[i]);
 break;
 }
 }
@@ -15574,40 +11125,23 @@ i += static_cast<i64>(1LL);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_101;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}goto __jakt_label_101; __jakt_label_101:;;
 }
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = found_body.value();
+{auto&& __jakt_match_variant = found_body.value();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.value;
 {
 Jakt::interpreter::StatementResult const result = TRY((this->execute_expression(expr,new_scope)));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = result;
+{auto&& __jakt_match_variant = result;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(value));
-};/*case end*/
-case 3 /* Continue */:case 4 /* Break */:case 5 /* JustValue */:case 0 /* Return */:case 1 /* Throw */:return JaktInternal::ExplicitValue(result);
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+return Jakt::interpreter::StatementResult::JustValue(value);};/*case end*/
+case 3 /* Continue */:case 4 /* Break */:case 5 /* JustValue */:case 0 /* Return */:case 1 /* Throw */:return result;default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -15615,32 +11149,18 @@ case 1 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& block = __jakt_match_value.value;
 {
 Jakt::interpreter::StatementResult const result = TRY((this->execute_block(block,new_scope,span.value())));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = result;
+{auto&& __jakt_match_variant = result;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(value));
-};/*case end*/
-case 3 /* Continue */:case 4 /* Break */:case 5 /* JustValue */:case 0 /* Return */:case 1 /* Throw */:return JaktInternal::ExplicitValue(result);
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+return Jakt::interpreter::StatementResult::JustValue(value);};/*case end*/
+case 3 /* Continue */:case 4 /* Break */:case 5 /* JustValue */:case 0 /* Return */:case 1 /* Throw */:return result;default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -15667,13 +11187,11 @@ break;
 }
 Jakt::types::CheckedMatchPattern pattern = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = pattern;
+{auto&& __jakt_match_variant = pattern;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expression = __jakt_match_value.expression;
-Jakt::utility::Span const& marker_span = __jakt_match_value.marker_span;
+Jakt::utility::Span const& marker_span = __jakt_match_variant.common.init_common.marker_span;
 {
 Jakt::types::Value const value_to_match_against = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<Jakt::interpreter::StatementResult>>{
@@ -15710,55 +11228,42 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
-if (value_to_match_against.impl->equals(value.impl)){
-found_body = static_cast<JaktInternal::Optional<Jakt::types::CheckedMatchBody>>(body);
-span = static_cast<JaktInternal::Optional<Jakt::utility::Span>>(marker_span);
-return JaktInternal::LoopBreak{};
-}
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 3 /* CatchAll */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;Jakt::utility::Span const& marker_span = __jakt_match_value.marker_span;
-{
-catch_all_case = body;
-span = marker_span;
-return JaktInternal::LoopContinue{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 2 /* ClassInstance */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.ClassInstance;Jakt::utility::Span const& marker_span = __jakt_match_value.marker_span;
-{
-TRY((this->error(ByteString::from_utf8_without_validation("Class instance matches are not implemented yet"sv),marker_span)));
-this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 0 /* EnumVariant */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;Jakt::utility::Span const& marker_span = __jakt_match_value.marker_span;
-{
-TRY((this->error(__jakt_format(StringView::from_string_literal("Value matches cannot have enum variant arms (matching on {})"sv),value.type_name()),marker_span)));
-this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
         break;
     if (_jakt_value.is_loop_continue())
         continue;
     _jakt_value.release_value();
 });
+if (value_to_match_against.impl->equals(value.impl)){
+found_body = static_cast<JaktInternal::Optional<Jakt::types::CheckedMatchBody>>(body);
+span = static_cast<JaktInternal::Optional<Jakt::utility::Span>>(marker_span);
+break;
+}
+}
+goto __jakt_label_102;};/*case end*/
+case 3 /* CatchAll */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;Jakt::utility::Span const& marker_span = __jakt_match_variant.common.init_common.marker_span;
+{
+catch_all_case = body;
+span = marker_span;
+continue;
+}
+goto __jakt_label_102;};/*case end*/
+case 2 /* ClassInstance */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.ClassInstance;Jakt::utility::Span const& marker_span = __jakt_match_variant.common.init_common.marker_span;
+{
+TRY((this->error(ByteString::from_utf8_without_validation("Class instance matches are not implemented yet"sv),marker_span)));
+this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
+}
+goto __jakt_label_102;};/*case end*/
+case 0 /* EnumVariant */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;Jakt::utility::Span const& marker_span = __jakt_match_variant.common.init_common.marker_span;
+{
+TRY((this->error(__jakt_format(StringView::from_string_literal("Value matches cannot have enum variant arms (matching on {})"sv),value.type_name()),marker_span)));
+this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
+}
+goto __jakt_label_102;};/*case end*/
+default: VERIFY_NOT_REACHED();}/*switch end*/
+break;}goto __jakt_label_102; __jakt_label_102:;;
 }
 
 }
@@ -15778,30 +11283,19 @@ NonnullRefPtr<Jakt::interpreter::InterpreterScope> new_scope = Jakt::interpreter
 ScopeGuard __jakt_var_20([&] {
 MUST((new_scope->perform_defers(*this,span.value())));
 });
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = found_body.value();
+{auto&& __jakt_match_variant = found_body.value();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.value;
 {
 Jakt::interpreter::StatementResult const result = TRY((this->execute_expression(expr,new_scope)));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = result;
+{auto&& __jakt_match_variant = result;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(value));
-};/*case end*/
-case 3 /* Continue */:case 4 /* Break */:case 5 /* JustValue */:case 0 /* Return */:case 1 /* Throw */:return JaktInternal::ExplicitValue(result);
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+return Jakt::interpreter::StatementResult::JustValue(value);};/*case end*/
+case 3 /* Continue */:case 4 /* Break */:case 5 /* JustValue */:case 0 /* Return */:case 1 /* Throw */:return result;default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -15809,41 +11303,22 @@ case 1 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& block = __jakt_match_value.value;
 {
 Jakt::interpreter::StatementResult const result = TRY((this->execute_block(block,new_scope,span.value())));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = result;
+{auto&& __jakt_match_variant = result;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(value));
-};/*case end*/
-case 3 /* Continue */:case 4 /* Break */:case 5 /* JustValue */:case 0 /* Return */:case 1 /* Throw */:return JaktInternal::ExplicitValue(result);
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+return Jakt::interpreter::StatementResult::JustValue(value);};/*case end*/
+case 3 /* Continue */:case 4 /* Break */:case 5 /* JustValue */:case 0 /* Return */:case 1 /* Throw */:return result;default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -15889,9 +11364,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *value.impl;
+{auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 19 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
@@ -15917,12 +11390,9 @@ break;
 }
 }
 
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::interpreter::StatementResult, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = found_variant.value();
+{auto&& __jakt_match_variant = found_variant.value();
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 1 /* Typed */:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(fields.operator[](static_cast<i64>(0LL))));
-case 3 /* StructLike */: {
+case 1 /* Typed */:return Jakt::interpreter::StatementResult::JustValue(fields[static_cast<i64>(0LL)]);case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;JaktInternal::DynamicArray<Jakt::ids::VarId> const& variant_fields = __jakt_match_value.fields;
 {
 i64 i = static_cast<i64>(0LL);
@@ -15946,18 +11416,12 @@ i += static_cast<i64>(1LL);
 }
 }
 
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(fields.operator[](i)));
+return Jakt::interpreter::StatementResult::JustValue(fields[i]);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),span)));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+default:return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),span));}/*switch end*/
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -15966,12 +11430,7 @@ TRY((this->error(__jakt_format(StringView::from_string_literal("Value matches ca
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16036,7 +11495,7 @@ fields.push(value);
 }
 }
 
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktTuple(fields,type_id),span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktTuple(fields,type_id),span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16104,7 +11563,7 @@ values.push(val);
 }
 }
 
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktSet(values,type_id),span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::JaktSet(values,type_id),span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16164,7 +11623,7 @@ checked_params.push(Jakt::types::CheckedParameter(param.requires_label,Jakt::typ
 }
 
 Jakt::types::CheckedBlock const fixed_block = TRY((this->perform_final_interpretation_pass(block,scope_id,Jakt::interpreter::InterpreterScope::create(resolved_captures,scope,Dictionary<Jakt::ids::TypeId, Jakt::ids::TypeId>::create_with_entries({}),this->compiler,scope_id),pseudo_function_id)));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Function(resolved_captures,resolved_params,TRY((this->program->substitute_typevars_in_type(return_type_id,type_map,return_type_id.module))),TRY((this->program->substitute_typevars_in_type(type_id,type_map,type_id.module))),fixed_block,can_throw,checked_params,scope_id,pseudo_function_id),span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Function(resolved_captures,resolved_params,TRY((this->program->substitute_typevars_in_type(return_type_id,type_map,return_type_id.module))),TRY((this->program->substitute_typevars_in_type(type_id,type_map,type_id.module))),fixed_block,can_throw,checked_params,scope_id,pseudo_function_id),span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16224,7 +11683,7 @@ checked_params.push(Jakt::types::CheckedParameter(param.requires_label,Jakt::typ
 }
 
 Jakt::types::CheckedBlock const fixed_block = TRY((this->perform_final_interpretation_pass(block,scope_id,Jakt::interpreter::InterpreterScope::create(resolved_captures,scope,Dictionary<Jakt::ids::TypeId, Jakt::ids::TypeId>::create_with_entries({}),this->compiler,scope_id),pseudo_function_id)));
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Function(resolved_captures,resolved_params,TRY((this->program->substitute_typevars_in_type(return_type_id,type_map,return_type_id.module))),TRY((this->program->substitute_typevars_in_type(type_id,type_map,type_id.module))),fixed_block,can_throw,checked_params,scope_id,pseudo_function_id),span)));
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Function(resolved_captures,resolved_params,TRY((this->program->substitute_typevars_in_type(return_type_id,type_map,return_type_id.module))),TRY((this->program->substitute_typevars_in_type(type_id,type_map,type_id.module))),fixed_block,can_throw,checked_params,scope_id,pseudo_function_id),span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16234,14 +11693,11 @@ Jakt::types::CheckedBlock const& catch_block = __jakt_match_value.catch_block;
 ByteString const& error_name = __jakt_match_value.error_name;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = TRY((this->execute_statement(stmt,scope,span)));
+{auto&& __jakt_match_variant = TRY((this->execute_statement(stmt,scope,span)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* JustValue */:{
 }
-return JaktInternal::ExplicitValue<void>();
-case 1 /* Throw */: {
+goto __jakt_label_103;case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 NonnullRefPtr<Jakt::interpreter::InterpreterScope> catch_scope = Jakt::interpreter::InterpreterScope::create(Dictionary<ByteString, Jakt::types::Value>::create_with_entries({}),scope,Dictionary<Jakt::ids::TypeId, Jakt::ids::TypeId>::create_with_entries({}),this->compiler,scope->runtime_scope_id);
@@ -16250,73 +11706,48 @@ MUST((catch_scope->perform_defers(*this,span)));
 });
 catch_scope->bindings.set(error_name,value);
 Jakt::interpreter::StatementResult const result = TRY((this->execute_block(catch_block,catch_scope,span)));
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::interpreter::StatementResult>>{
-auto&& __jakt_match_variant = result;
+{auto&& __jakt_match_variant = result;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Continue */:case 4 /* Break */:case 0 /* Return */:case 1 /* Throw */:{
 return result;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_104;default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_104;}/*switch end*/
+}goto __jakt_label_104; __jakt_label_104:;;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_103;};/*case end*/
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 return Jakt::interpreter::StatementResult::Return(value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_103;};/*case end*/
 case 4 /* Break */:{
 return Jakt::interpreter::StatementResult::Break();
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* Continue */:{
+goto __jakt_label_103;case 3 /* Continue */:{
 return Jakt::interpreter::StatementResult::Continue();
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* Yield */:{
+goto __jakt_label_103;case 2 /* Yield */:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Invalid control flow"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-return JaktInternal::ExplicitValue<Jakt::interpreter::StatementResult>(Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),span)));
+goto __jakt_label_103;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_103; __jakt_label_103:;;
+return Jakt::interpreter::StatementResult::JustValue(Jakt::types::Value(Jakt::types::ValueImpl::Void(),span));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 34 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;Jakt::ids::TypeId const& type_id = __jakt_match_value.type;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(Jakt::interpreter::StatementResult::JustValue(TRY((this->reflect_type(type_id,span,scope)))));
-};/*case end*/
+return Jakt::interpreter::StatementResult::JustValue(TRY((this->reflect_type(type_id,span,scope))));};/*case end*/
 default:{
 TRY((this->error(__jakt_format(StringView::from_string_literal("expression not implemented: {}"sv),expr),expr->span())));
 this->compiler->panic(ByteString::from_utf8_without_validation("Not yet implemented"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -16381,86 +11812,57 @@ return Jakt::types::Value(Jakt::types::ValueImpl::JaktString(string),span);
 
 ErrorOr<ByteString> Jakt::interpreter::Interpreter::string_from_value(Jakt::types::Value const value) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = *value.impl;
+{auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
+return x;};/*case end*/
 default:{
 TRY((this->error(ByteString::from_utf8_without_validation("Expected string value"sv),value.span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 ErrorOr<Jakt::types::Value> Jakt::interpreter::Interpreter::reflect_methods(Jakt::ids::ScopeId const scope_id,Jakt::utility::Span const span,NonnullRefPtr<Jakt::interpreter::InterpreterScope> const interpreter_scope) {
 {
-Jakt::ids::StructId const method_struct_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::StructId, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Method"sv))));
+Jakt::ids::StructId const method_struct_id = TRY(([&]() -> ErrorOr<Jakt::ids::StructId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Method"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected Method to be a struct"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-Jakt::ids::StructId const function_struct_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::StructId, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Function"sv))));
+ 
+}()));
+Jakt::ids::StructId const function_struct_id = TRY(([&]() -> ErrorOr<Jakt::ids::StructId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Function"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected Function to be a struct"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::ids::FunctionId const method_struct_constructor = TRY((this->program->find_function_in_scope(this->program->get_struct(method_struct_id).scope_id,ByteString::from_utf8_without_validation("Method"sv),JaktInternal::OptionalNone()))).value();
 Jakt::ids::FunctionId const function_struct_constructor = TRY((this->program->find_function_in_scope(this->program->get_struct(function_struct_id).scope_id,ByteString::from_utf8_without_validation("Function"sv),JaktInternal::OptionalNone()))).value();
-Jakt::ids::TypeId const type_type_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Type"sv))));
+Jakt::ids::TypeId const type_type_id = TRY(([&]() -> ErrorOr<Jakt::ids::TypeId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Type"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->program->get_enum(id).type_id);
-};/*case end*/
+return this->program->get_enum(id).type_id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected Type to be an enum"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 JaktInternal::DynamicArray<Jakt::types::Value> method_values = DynamicArray<Jakt::types::Value>::create_with({});
 NonnullRefPtr<Jakt::types::Scope> const scope = this->program->get_scope(scope_id);
 {
@@ -16504,63 +11906,42 @@ return Jakt::types::Value(Jakt::types::ValueImpl::JaktArray(method_values,TRY((t
 
 ErrorOr<JaktInternal::DynamicArray<Jakt::types::Value>> Jakt::interpreter::Interpreter::reflect_fields(JaktInternal::DynamicArray<Jakt::ids::VarId> const fields,Jakt::utility::Span const span,NonnullRefPtr<Jakt::interpreter::InterpreterScope> const scope) {
 {
-Jakt::ids::StructId const field_struct_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::StructId, ErrorOr<JaktInternal::DynamicArray<Jakt::types::Value>>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Field"sv))));
+Jakt::ids::StructId const field_struct_id = TRY(([&]() -> ErrorOr<Jakt::ids::StructId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Field"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected Field to be a struct"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::ids::FunctionId const field_struct_constructor = TRY((this->program->find_function_in_scope(this->program->get_struct(field_struct_id).scope_id,ByteString::from_utf8_without_validation("Field"sv),JaktInternal::OptionalNone()))).value();
-Jakt::ids::EnumId const visibility_enum_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::EnumId, ErrorOr<JaktInternal::DynamicArray<Jakt::types::Value>>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Visibility"sv))));
+Jakt::ids::EnumId const visibility_enum_id = TRY(([&]() -> ErrorOr<Jakt::ids::EnumId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Visibility"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected Visibility to be an enum"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::ids::FunctionId const visibility_public_constructor = TRY((this->program->find_function_in_scope(this->program->get_enum(visibility_enum_id).scope_id,ByteString::from_utf8_without_validation("Public"sv),JaktInternal::OptionalNone()))).value();
 Jakt::ids::FunctionId const visibility_private_constructor = TRY((this->program->find_function_in_scope(this->program->get_enum(visibility_enum_id).scope_id,ByteString::from_utf8_without_validation("Private"sv),JaktInternal::OptionalNone()))).value();
-Jakt::ids::StructId const variable_declaration_struct_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::StructId, ErrorOr<JaktInternal::DynamicArray<Jakt::types::Value>>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("VariableDeclaration"sv))));
+Jakt::ids::StructId const variable_declaration_struct_id = TRY(([&]() -> ErrorOr<Jakt::ids::StructId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("VariableDeclaration"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected VariableDeclaration to be a struct"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::ids::FunctionId const variable_declaration_struct_constructor = TRY((this->program->find_function_in_scope(this->program->get_struct(variable_declaration_struct_id).scope_id,ByteString::from_utf8_without_validation("VariableDeclaration"sv),JaktInternal::OptionalNone()))).value();
 JaktInternal::DynamicArray<Jakt::types::Value> record_type_fields = DynamicArray<Jakt::types::Value>::create_with({});
 {
@@ -16574,26 +11955,14 @@ Jakt::ids::VarId var_id = _magic_value.value();
 {
 NonnullRefPtr<Jakt::types::CheckedVariable> const field = this->program->get_variable(var_id);
 Jakt::types::Value const variable = Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({Jakt::types::Value(Jakt::types::ValueImpl::JaktString(field->name),span), TRY((this->reflect_type(field->type_id,span,scope))), Jakt::types::Value(Jakt::types::ValueImpl::Bool(field->is_mutable),span)}),variable_declaration_struct_id,variable_declaration_struct_constructor),span);
-Jakt::types::Value const field_value = Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({variable, Jakt::types::Value(Jakt::types::ValueImpl::Enum(DynamicArray<Jakt::types::Value>::create_with({}),visibility_enum_id,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::FunctionId, ErrorOr<JaktInternal::DynamicArray<Jakt::types::Value>>>{
-auto&& __jakt_match_variant = field->visibility;
+Jakt::types::Value const field_value = Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({variable, Jakt::types::Value(Jakt::types::ValueImpl::Enum(DynamicArray<Jakt::types::Value>::create_with({}),visibility_enum_id,[&]() -> Jakt::ids::FunctionId { auto&& __jakt_match_variant = field->visibility;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Public */:return JaktInternal::ExplicitValue(visibility_public_constructor);
-case 1 /* Private */:return JaktInternal::ExplicitValue(visibility_private_constructor);
-default:{
+case 0 /* Public */:return visibility_public_constructor;case 1 /* Private */:return visibility_private_constructor;default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Not implemented"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-})),span)}),field_struct_id,field_struct_constructor),span);
+ 
+}()),span)}),field_struct_id,field_struct_constructor),span);
 record_type_fields.push(field_value);
 }
 
@@ -16617,40 +11986,26 @@ break;
 }
 Jakt::types::CheckedEnumVariant entry = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::DynamicArray<Jakt::types::Value>>>{
-auto&& __jakt_match_variant = entry;
+{auto&& __jakt_match_variant = entry;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Untyped */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Untyped;ByteString const& name = __jakt_match_value.name;
 {
 result_elements.push(TRY((this->string_value(name,span))));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_105;};/*case end*/
 case 2 /* WithValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.WithValue;ByteString const& name = __jakt_match_value.name;
 {
 result_elements.push(TRY((this->string_value(name,span))));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_105;};/*case end*/
 default:{
 TRY((this->error(ByteString::from_utf8_without_validation("Expected untyped or with-value variant"sv),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_105;}/*switch end*/
+break;}goto __jakt_label_105; __jakt_label_105:;;
 }
 
 }
@@ -16662,45 +12017,31 @@ return DynamicArray<Jakt::types::Value>::create_with({TRY((this->array_value_of_
 
 ErrorOr<JaktInternal::DynamicArray<Jakt::types::Value>> Jakt::interpreter::Interpreter::reflect_sum_enum_variants(Jakt::types::CheckedEnum const subject_enum,Jakt::utility::Span const span,NonnullRefPtr<Jakt::interpreter::InterpreterScope> const scope) {
 {
-Jakt::ids::EnumId const sum_enum_variant_enum_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::EnumId, ErrorOr<JaktInternal::DynamicArray<Jakt::types::Value>>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("SumEnumVariant"sv))));
+Jakt::ids::EnumId const sum_enum_variant_enum_id = TRY(([&]() -> ErrorOr<Jakt::ids::EnumId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("SumEnumVariant"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected SumEnumVariant to be an enum"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::ids::FunctionId const typed_variant_constructor = TRY((this->program->find_function_in_scope(this->program->get_enum(sum_enum_variant_enum_id).scope_id,ByteString::from_utf8_without_validation("Typed"sv),JaktInternal::OptionalNone()))).value();
 Jakt::ids::FunctionId const struct_like_variant_constructor = TRY((this->program->find_function_in_scope(this->program->get_enum(sum_enum_variant_enum_id).scope_id,ByteString::from_utf8_without_validation("StructLike"sv),JaktInternal::OptionalNone()))).value();
 Jakt::ids::FunctionId const untyped_variant_constructor = TRY((this->program->find_function_in_scope(this->program->get_enum(sum_enum_variant_enum_id).scope_id,ByteString::from_utf8_without_validation("Untyped"sv),JaktInternal::OptionalNone()))).value();
-Jakt::ids::StructId const field_struct_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::StructId, ErrorOr<JaktInternal::DynamicArray<Jakt::types::Value>>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Field"sv))));
+Jakt::ids::StructId const field_struct_id = TRY(([&]() -> ErrorOr<Jakt::ids::StructId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Field"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected Field to be a struct"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 JaktInternal::DynamicArray<Jakt::types::Value> result = DynamicArray<Jakt::types::Value>::create_with({});
 {
 JaktInternal::ArrayIterator<Jakt::types::CheckedEnumVariant> _magic = subject_enum.variants.iterator();
@@ -16711,9 +12052,7 @@ break;
 }
 Jakt::types::CheckedEnumVariant variant = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::DynamicArray<Jakt::types::Value>>>{
-auto&& __jakt_match_variant = variant;
+{auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;ByteString const& name = __jakt_match_value.name;
@@ -16723,16 +12062,14 @@ Jakt::types::Value const type_value = TRY((this->reflect_type(type_id,span,scope
 Jakt::types::Value const variant_value = Jakt::types::Value(Jakt::types::ValueImpl::Enum(DynamicArray<Jakt::types::Value>::create_with({TRY((this->string_value(name,span))), type_value}),sum_enum_variant_enum_id,typed_variant_constructor),span);
 result.push(variant_value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_106;};/*case end*/
 case 0 /* Untyped */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Untyped;ByteString const& name = __jakt_match_value.name;
 {
 Jakt::types::Value const variant_value = Jakt::types::Value(Jakt::types::ValueImpl::Enum(DynamicArray<Jakt::types::Value>::create_with({TRY((this->string_value(name,span)))}),sum_enum_variant_enum_id,untyped_variant_constructor),span);
 result.push(variant_value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_106;};/*case end*/
 case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;ByteString const& name = __jakt_match_value.name;
 JaktInternal::DynamicArray<Jakt::ids::VarId> const& fields = __jakt_match_value.fields;
@@ -16741,22 +12078,11 @@ JaktInternal::DynamicArray<Jakt::types::Value> const reflected_fields = TRY((thi
 Jakt::types::Value const variant_value = Jakt::types::Value(Jakt::types::ValueImpl::Enum(DynamicArray<Jakt::types::Value>::create_with({TRY((this->string_value(name,span))), TRY((this->array_value_of_type(reflected_fields,TRY((this->array_type_of_struct(field_struct_id))),span)))}),sum_enum_variant_enum_id,struct_like_variant_constructor),span);
 result.push(variant_value);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_106;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_106;}/*switch end*/
+break;}goto __jakt_label_106; __jakt_label_106:;;
 }
 
 }
@@ -16777,31 +12103,22 @@ ScopeGuard __jakt_var_22([&] {
 this->seen_reflected_types.remove(mapped_type_id);
 });
 NonnullRefPtr<typename Jakt::types::Type> const type = this->program->get_type(mapped_type_id);
-Jakt::ids::EnumId const reflected_enum_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::EnumId, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Type"sv))));
+Jakt::ids::EnumId const reflected_enum_id = TRY(([&]() -> ErrorOr<Jakt::ids::EnumId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Type"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected Reflect::Type to be an enum"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::types::CheckedEnum const reflected_enum = this->program->get_enum(reflected_enum_id);
 Jakt::types::Value result = Jakt::types::Value(Jakt::types::ValueImpl::Enum(DynamicArray<Jakt::types::Value>::create_with({}),reflected_enum_id,Jakt::ids::FunctionId(type_id.module,static_cast<size_t>(0ULL))),span);
 this->reflected_type_cache.set(mapped_type_id,result);
 JaktInternal::DynamicArray<Jakt::types::Value> fields = DynamicArray<Jakt::types::Value>::create_with({});
-Jakt::ids::FunctionId const found_constructor = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::FunctionId, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *type;
+Jakt::ids::FunctionId const found_constructor = TRY(([&]() -> ErrorOr<Jakt::ids::FunctionId> { auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Void */:case 6 /* I8 */:case 7 /* I16 */:case 8 /* I32 */:case 9 /* I64 */:case 2 /* U8 */:case 3 /* U16 */:case 4 /* U32 */:case 5 /* U64 */:case 12 /* Usize */:case 10 /* F32 */:case 11 /* F64 */:case 13 /* JaktString */:case 14 /* CChar */:case 15 /* CInt */:case 1 /* Bool */:case 16 /* Unknown */:case 17 /* Never */:{
 JaktInternal::Optional<Jakt::ids::FunctionId> const constructor = TRY((this->program->find_function_in_scope(this->program->get_enum(reflected_enum_id).scope_id,type->constructor_name(),JaktInternal::OptionalNone())));
@@ -16809,7 +12126,7 @@ if (!constructor.has_value()){
 TRY((this->error(ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-return JaktInternal::ExplicitValue<Jakt::ids::FunctionId>(constructor.value());
+return constructor.value();
 }
 VERIFY_NOT_REACHED();
 case 26 /* Trait */:case 22 /* GenericTraitInstance */:{
@@ -16819,7 +12136,7 @@ TRY((this->error(ByteString::from_utf8_without_validation("Attempted to access a
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 fields = DynamicArray<Jakt::types::Value>::create_with({TRY((this->string_value(ByteString::from_utf8_without_validation("anon$trait_impl"sv),span)))});
-return JaktInternal::ExplicitValue<Jakt::ids::FunctionId>(constructor.value());
+return constructor.value();
 }
 VERIFY_NOT_REACHED();
 case 18 /* TypeVariable */: {
@@ -16831,7 +12148,7 @@ TRY((this->error(ByteString::from_utf8_without_validation("Attempted to access a
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 fields = DynamicArray<Jakt::types::Value>::create_with({TRY((this->string_value(name,span)))});
-return JaktInternal::ExplicitValue<Jakt::ids::FunctionId>(constructor.value());
+return constructor.value();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16840,7 +12157,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;Jakt::ids::TypeId con
 {
 Jakt::ids::FunctionId const constructor = TRY((this->program->find_function_in_scope(this->program->get_enum(reflected_enum_id).scope_id,type->constructor_name(),JaktInternal::OptionalNone()))).value();
 fields = DynamicArray<Jakt::types::Value>::create_with({TRY((this->reflect_type(type_id,span,scope)))});
-return JaktInternal::ExplicitValue<Jakt::ids::FunctionId>(constructor);
+return constructor;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16849,7 +12166,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Reference;Jakt::ids::TypeId 
 {
 Jakt::ids::FunctionId const constructor = TRY((this->program->find_function_in_scope(this->program->get_enum(reflected_enum_id).scope_id,type->constructor_name(),JaktInternal::OptionalNone()))).value();
 fields = DynamicArray<Jakt::types::Value>::create_with({TRY((this->reflect_type(type_id,span,scope)))});
-return JaktInternal::ExplicitValue<Jakt::ids::FunctionId>(constructor);
+return constructor;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16858,7 +12175,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.MutableReference;Jakt::ids::
 {
 Jakt::ids::FunctionId const constructor = TRY((this->program->find_function_in_scope(this->program->get_enum(reflected_enum_id).scope_id,type->constructor_name(),JaktInternal::OptionalNone()))).value();
 fields = DynamicArray<Jakt::types::Value>::create_with({TRY((this->reflect_type(type_id,span,scope)))});
-return JaktInternal::ExplicitValue<Jakt::ids::FunctionId>(constructor);
+return constructor;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16871,49 +12188,33 @@ if (!constructor.has_value()){
 TRY((this->error(ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-Jakt::ids::StructId const record_struct_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::StructId, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Record"sv))));
+Jakt::ids::StructId const record_struct_id = TRY(([&]() -> ErrorOr<Jakt::ids::StructId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Record"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected Record to be a struct"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::ids::FunctionId const record_struct_constructor = TRY((this->program->find_function_in_scope(this->program->get_struct(record_struct_id).scope_id,ByteString::from_utf8_without_validation("Record"sv),JaktInternal::OptionalNone()))).value();
-Jakt::ids::EnumId const record_type_enum_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::EnumId, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("RecordType"sv))));
+Jakt::ids::EnumId const record_type_enum_id = TRY(([&]() -> ErrorOr<Jakt::ids::EnumId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("RecordType"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected RecordType to be an enum"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::ids::FunctionId const record_type_struct_constructor = TRY((this->program->find_function_in_scope(this->program->get_enum(record_type_enum_id).scope_id,ByteString::from_utf8_without_validation("Struct"sv),JaktInternal::OptionalNone()))).value();
 Jakt::types::Value const methods = TRY((this->reflect_methods(subject_struct.scope_id,span,scope)));
 Jakt::ids::TypeId const tuple_type = TRY((this->tuple_type(DynamicArray<Jakt::ids::TypeId>::create_with({TRY((this->string_type())), reflected_enum.type_id}))));
-Jakt::types::Value const generic_parameters = TRY((this->array_value_of_type(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::types::Value>, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *type;
+Jakt::types::Value const generic_parameters = TRY((this->array_value_of_type(TRY(([&]() -> ErrorOr<JaktInternal::DynamicArray<Jakt::types::Value>> { auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -16929,43 +12230,21 @@ break;
 }
 Jakt::types::CheckedGenericParameter generic_parameter = _magic_value.value();
 {
-ByteString const name = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *this->program->get_type(generic_parameter.type_id);
+ByteString const name = [&]() -> ByteString { auto&& __jakt_match_variant = *this->program->get_type(generic_parameter.type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 18 /* TypeVariable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeVariable;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(name);
-};/*case end*/
+return name;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Unknown kind of generic parameter in struct definition"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
-Jakt::ids::TypeId const t = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId,ErrorOr<Jakt::types::Value>> {
-auto __jakt_enum_value = (i < args.size());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(args.operator[](i));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::Unknown()));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}();
+Jakt::ids::TypeId const t = [&]() -> Jakt::ids::TypeId { auto __jakt_enum_value = i < args.size();
+if (__jakt_enum_value) {return args[i];}else if (!__jakt_enum_value) {return Jakt::types::builtin(Jakt::types::BuiltinType::Unknown());}VERIFY_NOT_REACHED();
+ 
+}();
 result.push(TRY((this->tuple_value(DynamicArray<Jakt::types::Value>::create_with({TRY((this->string_value(name,span))), TRY((this->reflect_type(t,span,scope)))}),tuple_type,span))));
 i += static_cast<size_t>(1ULL);
 }
@@ -16973,18 +12252,13 @@ i += static_cast<size_t>(1ULL);
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::DynamicArray<Jakt::types::Value>>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(DynamicArray<Jakt::types::Value>::create_with({}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),tuple_type,span)));
+default:return DynamicArray<Jakt::types::Value>::create_with({});}/*switch end*/
+ 
+}())),tuple_type,span)));
 JaktInternal::DynamicArray<Jakt::ids::VarId> reflected_fields = DynamicArray<Jakt::ids::VarId>::create_with({});
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<Jakt::types::CheckedField>> _magic = subject_struct.fields.iterator();
@@ -17002,26 +12276,19 @@ reflected_fields.push(field->variable_id);
 }
 
 JaktInternal::DynamicArray<Jakt::types::Value> const record_type_fields = TRY((this->reflect_fields(reflected_fields,span,scope)));
-Jakt::ids::StructId const field_struct_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::StructId, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Field"sv))));
+Jakt::ids::StructId const field_struct_id = TRY(([&]() -> ErrorOr<Jakt::ids::StructId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Field"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected Field to be a struct"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 fields = DynamicArray<Jakt::types::Value>::create_with({Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({TRY((this->string_value(subject_struct.name,span))), methods, generic_parameters, Jakt::types::Value(Jakt::types::ValueImpl::Enum(DynamicArray<Jakt::types::Value>::create_with({Jakt::types::Value(Jakt::types::ValueImpl::JaktArray(record_type_fields,TRY((this->array_type_of_struct(field_struct_id)))),span)}),record_type_enum_id,record_type_struct_constructor),span)}),record_struct_id,record_struct_constructor),span)});
-return JaktInternal::ExplicitValue<Jakt::ids::FunctionId>(constructor.value());
+return constructor.value();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -17034,49 +12301,33 @@ if (!constructor.has_value()){
 TRY((this->error(ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-Jakt::ids::StructId const record_struct_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::StructId, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Record"sv))));
+Jakt::ids::StructId const record_struct_id = TRY(([&]() -> ErrorOr<Jakt::ids::StructId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Record"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected Record to be a struct"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::ids::FunctionId const record_struct_constructor = TRY((this->program->find_function_in_scope(this->program->get_struct(record_struct_id).scope_id,ByteString::from_utf8_without_validation("Record"sv),JaktInternal::OptionalNone()))).value();
-Jakt::ids::EnumId const record_type_enum_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::EnumId, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("RecordType"sv))));
+Jakt::ids::EnumId const record_type_enum_id = TRY(([&]() -> ErrorOr<Jakt::ids::EnumId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("RecordType"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected RecordType to be an enum"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::ids::FunctionId const record_type_struct_constructor = TRY((this->program->find_function_in_scope(this->program->get_enum(record_type_enum_id).scope_id,ByteString::from_utf8_without_validation("Struct"sv),JaktInternal::OptionalNone()))).value();
 Jakt::types::Value const methods = TRY((this->reflect_methods(subject_struct.scope_id,span,scope)));
 Jakt::ids::TypeId const tuple_type = TRY((this->tuple_type(DynamicArray<Jakt::ids::TypeId>::create_with({TRY((this->string_type())), reflected_enum.type_id}))));
-Jakt::types::Value const generic_parameters = TRY((this->array_value_of_type(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::types::Value>, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *type;
+Jakt::types::Value const generic_parameters = TRY((this->array_value_of_type(TRY(([&]() -> ErrorOr<JaktInternal::DynamicArray<Jakt::types::Value>> { auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -17092,43 +12343,21 @@ break;
 }
 Jakt::types::CheckedGenericParameter generic_parameter = _magic_value.value();
 {
-ByteString const name = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *this->program->get_type(generic_parameter.type_id);
+ByteString const name = [&]() -> ByteString { auto&& __jakt_match_variant = *this->program->get_type(generic_parameter.type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 18 /* TypeVariable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeVariable;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(name);
-};/*case end*/
+return name;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Unknown kind of generic parameter in struct definition"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
-Jakt::ids::TypeId const t = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId,ErrorOr<Jakt::types::Value>> {
-auto __jakt_enum_value = (i < args.size());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(args.operator[](i));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::Unknown()));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}();
+Jakt::ids::TypeId const t = [&]() -> Jakt::ids::TypeId { auto __jakt_enum_value = i < args.size();
+if (__jakt_enum_value) {return args[i];}else if (!__jakt_enum_value) {return Jakt::types::builtin(Jakt::types::BuiltinType::Unknown());}VERIFY_NOT_REACHED();
+ 
+}();
 result.push(TRY((this->tuple_value(DynamicArray<Jakt::types::Value>::create_with({TRY((this->string_value(name,span))), TRY((this->reflect_type(t,span,scope)))}),tuple_type,span))));
 i += static_cast<size_t>(1ULL);
 }
@@ -17136,18 +12365,13 @@ i += static_cast<size_t>(1ULL);
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::DynamicArray<Jakt::types::Value>>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(DynamicArray<Jakt::types::Value>::create_with({}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),tuple_type,span)));
+default:return DynamicArray<Jakt::types::Value>::create_with({});}/*switch end*/
+ 
+}())),tuple_type,span)));
 JaktInternal::DynamicArray<Jakt::ids::VarId> reflected_fields = DynamicArray<Jakt::ids::VarId>::create_with({});
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<Jakt::types::CheckedField>> _magic = subject_struct.fields.iterator();
@@ -17165,26 +12389,19 @@ reflected_fields.push(field->variable_id);
 }
 
 JaktInternal::DynamicArray<Jakt::types::Value> const record_type_fields = TRY((this->reflect_fields(reflected_fields,span,scope)));
-Jakt::ids::StructId const field_struct_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::StructId, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Field"sv))));
+Jakt::ids::StructId const field_struct_id = TRY(([&]() -> ErrorOr<Jakt::ids::StructId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Field"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected Field to be a struct"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 fields = DynamicArray<Jakt::types::Value>::create_with({Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({TRY((this->string_value(subject_struct.name,span))), methods, generic_parameters, Jakt::types::Value(Jakt::types::ValueImpl::Enum(DynamicArray<Jakt::types::Value>::create_with({Jakt::types::Value(Jakt::types::ValueImpl::JaktArray(record_type_fields,TRY((this->array_type_of_struct(field_struct_id)))),span)}),record_type_enum_id,record_type_struct_constructor),span)}),record_struct_id,record_struct_constructor),span)});
-return JaktInternal::ExplicitValue<Jakt::ids::FunctionId>(constructor.value());
+return constructor.value();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -17197,60 +12414,37 @@ if (!constructor.has_value()){
 TRY((this->error(ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-Jakt::ids::StructId const record_struct_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::StructId, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Record"sv))));
+Jakt::ids::StructId const record_struct_id = TRY(([&]() -> ErrorOr<Jakt::ids::StructId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Record"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected Record to be a struct"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::ids::FunctionId const record_struct_constructor = TRY((this->program->find_function_in_scope(this->program->get_struct(record_struct_id).scope_id,ByteString::from_utf8_without_validation("Record"sv),JaktInternal::OptionalNone()))).value();
-Jakt::ids::EnumId const record_type_enum_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::EnumId, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("RecordType"sv))));
+Jakt::ids::EnumId const record_type_enum_id = TRY(([&]() -> ErrorOr<Jakt::ids::EnumId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("RecordType"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected RecordType to be an enum"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 bool const is_value_enum = subject_enum.underlying_type_id.equals(Jakt::types::unknown_type_id());
-Jakt::ids::FunctionId const record_type_struct_constructor = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::FunctionId,ErrorOr<Jakt::types::Value>> {
-auto __jakt_enum_value = (is_value_enum);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->program->find_function_in_scope(this->program->get_enum(record_type_enum_id).scope_id,ByteString::from_utf8_without_validation("ValueEnum"sv),JaktInternal::OptionalNone()))).value());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->program->find_function_in_scope(this->program->get_enum(record_type_enum_id).scope_id,ByteString::from_utf8_without_validation("SumEnum"sv),JaktInternal::OptionalNone()))).value());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+Jakt::ids::FunctionId const record_type_struct_constructor = TRY(([&]() -> ErrorOr<Jakt::ids::FunctionId> { auto __jakt_enum_value = is_value_enum;
+if (__jakt_enum_value) {return TRY((this->program->find_function_in_scope(this->program->get_enum(record_type_enum_id).scope_id,ByteString::from_utf8_without_validation("ValueEnum"sv),JaktInternal::OptionalNone()))).value();}else if (!__jakt_enum_value) {return TRY((this->program->find_function_in_scope(this->program->get_enum(record_type_enum_id).scope_id,ByteString::from_utf8_without_validation("SumEnum"sv),JaktInternal::OptionalNone()))).value();}VERIFY_NOT_REACHED();
+ 
+}()));
 Jakt::types::Value const methods = TRY((this->reflect_methods(subject_enum.scope_id,span,scope)));
 Jakt::ids::TypeId const tuple_type = TRY((this->tuple_type(DynamicArray<Jakt::ids::TypeId>::create_with({TRY((this->string_type())), reflected_enum.type_id}))));
-Jakt::types::Value const generic_parameters = TRY((this->array_value_of_type(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::types::Value>, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *type;
+Jakt::types::Value const generic_parameters = TRY((this->array_value_of_type(TRY(([&]() -> ErrorOr<JaktInternal::DynamicArray<Jakt::types::Value>> { auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -17266,43 +12460,21 @@ break;
 }
 Jakt::types::CheckedGenericParameter generic_parameter = _magic_value.value();
 {
-ByteString const name = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *this->program->get_type(generic_parameter.type_id);
+ByteString const name = [&]() -> ByteString { auto&& __jakt_match_variant = *this->program->get_type(generic_parameter.type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 18 /* TypeVariable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeVariable;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(name);
-};/*case end*/
+return name;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Unknown kind of generic parameter in struct definition"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
-Jakt::ids::TypeId const t = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId,ErrorOr<Jakt::types::Value>> {
-auto __jakt_enum_value = (i < args.size());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(args.operator[](i));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::Unknown()));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}();
+Jakt::ids::TypeId const t = [&]() -> Jakt::ids::TypeId { auto __jakt_enum_value = i < args.size();
+if (__jakt_enum_value) {return args[i];}else if (!__jakt_enum_value) {return Jakt::types::builtin(Jakt::types::BuiltinType::Unknown());}VERIFY_NOT_REACHED();
+ 
+}();
 result.push(TRY((this->tuple_value(DynamicArray<Jakt::types::Value>::create_with({TRY((this->string_value(name,span))), TRY((this->reflect_type(t,span,scope)))}),tuple_type,span))));
 i += static_cast<size_t>(1ULL);
 }
@@ -17310,36 +12482,24 @@ i += static_cast<size_t>(1ULL);
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::DynamicArray<Jakt::types::Value>>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(DynamicArray<Jakt::types::Value>::create_with({}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),tuple_type,span)));
-Jakt::ids::StructId const field_struct_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::StructId, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Field"sv))));
+default:return DynamicArray<Jakt::types::Value>::create_with({});}/*switch end*/
+ 
+}())),tuple_type,span)));
+Jakt::ids::StructId const field_struct_id = TRY(([&]() -> ErrorOr<Jakt::ids::StructId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Field"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected Field to be a struct"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 JaktInternal::DynamicArray<Jakt::types::Value> record_type_fields = DynamicArray<Jakt::types::Value>::create_with({});
 if (is_value_enum){
 JaktInternal::DynamicArray<Jakt::types::Value> const variants = TRY((this->reflect_value_enum_variants(subject_enum,span,scope)));
@@ -17351,7 +12511,7 @@ record_type_fields = DynamicArray<Jakt::types::Value>::create_with({TRY((this->b
 }
 
 fields = DynamicArray<Jakt::types::Value>::create_with({Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({TRY((this->string_value(subject_enum.name,span))), methods, generic_parameters, Jakt::types::Value(Jakt::types::ValueImpl::Enum(record_type_fields,record_type_enum_id,record_type_struct_constructor),span)}),record_struct_id,record_struct_constructor),span)});
-return JaktInternal::ExplicitValue<Jakt::ids::FunctionId>(constructor.value());
+return constructor.value();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -17364,60 +12524,37 @@ if (!constructor.has_value()){
 TRY((this->error(ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv),span)));
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
-Jakt::ids::StructId const record_struct_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::StructId, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Record"sv))));
+Jakt::ids::StructId const record_struct_id = TRY(([&]() -> ErrorOr<Jakt::ids::StructId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Record"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected Record to be a struct"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::ids::FunctionId const record_struct_constructor = TRY((this->program->find_function_in_scope(this->program->get_struct(record_struct_id).scope_id,ByteString::from_utf8_without_validation("Record"sv),JaktInternal::OptionalNone()))).value();
-Jakt::ids::EnumId const record_type_enum_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::EnumId, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("RecordType"sv))));
+Jakt::ids::EnumId const record_type_enum_id = TRY(([&]() -> ErrorOr<Jakt::ids::EnumId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("RecordType"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected RecordType to be an enum"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 bool const is_value_enum = subject_enum.underlying_type_id.equals(Jakt::types::unknown_type_id());
-Jakt::ids::FunctionId const record_type_struct_constructor = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::FunctionId,ErrorOr<Jakt::types::Value>> {
-auto __jakt_enum_value = (is_value_enum);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->program->find_function_in_scope(this->program->get_enum(record_type_enum_id).scope_id,ByteString::from_utf8_without_validation("ValueEnum"sv),JaktInternal::OptionalNone()))).value());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->program->find_function_in_scope(this->program->get_enum(record_type_enum_id).scope_id,ByteString::from_utf8_without_validation("SumEnum"sv),JaktInternal::OptionalNone()))).value());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+Jakt::ids::FunctionId const record_type_struct_constructor = TRY(([&]() -> ErrorOr<Jakt::ids::FunctionId> { auto __jakt_enum_value = is_value_enum;
+if (__jakt_enum_value) {return TRY((this->program->find_function_in_scope(this->program->get_enum(record_type_enum_id).scope_id,ByteString::from_utf8_without_validation("ValueEnum"sv),JaktInternal::OptionalNone()))).value();}else if (!__jakt_enum_value) {return TRY((this->program->find_function_in_scope(this->program->get_enum(record_type_enum_id).scope_id,ByteString::from_utf8_without_validation("SumEnum"sv),JaktInternal::OptionalNone()))).value();}VERIFY_NOT_REACHED();
+ 
+}()));
 Jakt::types::Value const methods = TRY((this->reflect_methods(subject_enum.scope_id,span,scope)));
 Jakt::ids::TypeId const tuple_type = TRY((this->tuple_type(DynamicArray<Jakt::ids::TypeId>::create_with({TRY((this->string_type())), reflected_enum.type_id}))));
-Jakt::types::Value const generic_parameters = TRY((this->array_value_of_type(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::types::Value>, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *type;
+Jakt::types::Value const generic_parameters = TRY((this->array_value_of_type(TRY(([&]() -> ErrorOr<JaktInternal::DynamicArray<Jakt::types::Value>> { auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -17433,43 +12570,21 @@ break;
 }
 Jakt::types::CheckedGenericParameter generic_parameter = _magic_value.value();
 {
-ByteString const name = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *this->program->get_type(generic_parameter.type_id);
+ByteString const name = [&]() -> ByteString { auto&& __jakt_match_variant = *this->program->get_type(generic_parameter.type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 18 /* TypeVariable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeVariable;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(name);
-};/*case end*/
+return name;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Unknown kind of generic parameter in struct definition"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
-Jakt::ids::TypeId const t = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId,ErrorOr<Jakt::types::Value>> {
-auto __jakt_enum_value = (i < args.size());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(args.operator[](i));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::Unknown()));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}();
+Jakt::ids::TypeId const t = [&]() -> Jakt::ids::TypeId { auto __jakt_enum_value = i < args.size();
+if (__jakt_enum_value) {return args[i];}else if (!__jakt_enum_value) {return Jakt::types::builtin(Jakt::types::BuiltinType::Unknown());}VERIFY_NOT_REACHED();
+ 
+}();
 result.push(TRY((this->tuple_value(DynamicArray<Jakt::types::Value>::create_with({TRY((this->string_value(name,span))), TRY((this->reflect_type(t,span,scope)))}),tuple_type,span))));
 i += static_cast<size_t>(1ULL);
 }
@@ -17477,36 +12592,24 @@ i += static_cast<size_t>(1ULL);
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::DynamicArray<Jakt::types::Value>>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(DynamicArray<Jakt::types::Value>::create_with({}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),tuple_type,span)));
-Jakt::ids::StructId const field_struct_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::StructId, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Field"sv))));
+default:return DynamicArray<Jakt::types::Value>::create_with({});}/*switch end*/
+ 
+}())),tuple_type,span)));
+Jakt::ids::StructId const field_struct_id = TRY(([&]() -> ErrorOr<Jakt::ids::StructId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Field"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected Field to be a struct"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 JaktInternal::DynamicArray<Jakt::types::Value> record_type_fields = DynamicArray<Jakt::types::Value>::create_with({});
 if (is_value_enum){
 JaktInternal::DynamicArray<Jakt::types::Value> const variants = TRY((this->reflect_value_enum_variants(subject_enum,span,scope)));
@@ -17518,7 +12621,7 @@ record_type_fields = DynamicArray<Jakt::types::Value>::create_with({TRY((this->b
 }
 
 fields = DynamicArray<Jakt::types::Value>::create_with({Jakt::types::Value(Jakt::types::ValueImpl::Struct(DynamicArray<Jakt::types::Value>::create_with({TRY((this->string_value(subject_enum.name,span))), methods, generic_parameters, Jakt::types::Value(Jakt::types::ValueImpl::Enum(record_type_fields,record_type_enum_id,record_type_struct_constructor),span)}),record_struct_id,record_struct_constructor),span)});
-return JaktInternal::ExplicitValue<Jakt::ids::FunctionId>(constructor.value());
+return constructor.value();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -17529,25 +12632,19 @@ TRY((this->error(ByteString::from_utf8_without_validation("Attempted to access a
 this->compiler->panic(ByteString::from_utf8_without_validation("Invalid type"sv));
 }
 fields = DynamicArray<Jakt::types::Value>::create_with({});
-return JaktInternal::ExplicitValue<Jakt::ids::FunctionId>(constructor.value());
+return constructor.value();
 }
 VERIFY_NOT_REACHED();
 default:{
 Jakt::ids::FunctionId const constructor = TRY((this->program->find_function_in_scope(this->program->get_enum(reflected_enum_id).scope_id,ByteString::from_utf8_without_validation("Unknown"sv),JaktInternal::OptionalNone()))).value();
 fields = DynamicArray<Jakt::types::Value>::create_with({});
-return JaktInternal::ExplicitValue<Jakt::ids::FunctionId>(constructor);
+return constructor;
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::types::Value>>{
-auto&& __jakt_match_variant = *result.impl;
+ 
+}()));
+{auto&& __jakt_match_variant = *result.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 19 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;JaktInternal::DynamicArray<Jakt::types::Value>& x = __jakt_match_value.fields;
@@ -17556,18 +12653,11 @@ Jakt::ids::FunctionId& constructor = __jakt_match_value.constructor;
 constructor = found_constructor;
 x = fields;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_107;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_107;}/*switch end*/
+}goto __jakt_label_107; __jakt_label_107:;;
 return result;
 }
 }

--- a/bootstrap/stage0/jakt__arguments.cpp
+++ b/bootstrap/stage0/jakt__arguments.cpp
@@ -35,7 +35,7 @@ break;
 }
 ByteString name = _magic_value.value();
 {
-if (this->args.operator[](i) == name){
+if (this->args[i] == name){
 this->removed_indices.push(i);
 return true;
 }
@@ -73,18 +73,18 @@ break;
 }
 ByteString name = _magic_value.value();
 {
-if (this->args.operator[](i) == name){
+if (this->args[i] == name){
 if (this->args.size() <= JaktInternal::checked_add(i,static_cast<size_t>(1ULL))){
 warnln(StringView::from_string_literal("The option '{}' requires a value, but none was supplied"sv),name);
 return Error::from_errno(static_cast<i32>(200));
 }
 this->removed_indices.push(i);
 this->removed_indices.push(JaktInternal::checked_add(i,static_cast<size_t>(1ULL)));
-return this->args.operator[](JaktInternal::checked_add(i,static_cast<size_t>(1ULL)));
+return this->args[JaktInternal::checked_add(i,static_cast<size_t>(1ULL))];
 }
-if (this->args.operator[](i).starts_with(name)){
+if (this->args[i].starts_with(name)){
 this->removed_indices.push(i);
-return this->args.operator[](i).substring(name.length(),JaktInternal::checked_sub(this->args.operator[](i).length(),name.length()));
+return this->args[i].substring(name.length(),JaktInternal::checked_sub(this->args[i].length(),name.length()));
 }
 }
 
@@ -121,19 +121,19 @@ break;
 }
 ByteString name = _magic_value.value();
 {
-if (this->args.operator[](i) == name){
+if (this->args[i] == name){
 if (this->args.size() <= JaktInternal::checked_add(i,static_cast<size_t>(1ULL))){
 warnln(StringView::from_string_literal("The option '{}' requires a value, but none was supplied"sv),name);
 return Error::from_errno(static_cast<i32>(200));
 }
 this->removed_indices.push(i);
 this->removed_indices.push(JaktInternal::checked_add(i,static_cast<size_t>(1ULL)));
-result.push(this->args.operator[](JaktInternal::checked_add(i,static_cast<size_t>(1ULL))));
+result.push(this->args[JaktInternal::checked_add(i,static_cast<size_t>(1ULL))]);
 continue;
 }
-if (this->args.operator[](i).starts_with(name)){
+if (this->args[i].starts_with(name)){
 this->removed_indices.push(i);
-result.push(this->args.operator[](i).substring(name.length(),JaktInternal::checked_sub(this->args.operator[](i).length(),name.length())));
+result.push(this->args[i].substring(name.length(),JaktInternal::checked_sub(this->args[i].length(),name.length())));
 }
 }
 
@@ -163,8 +163,8 @@ break;
 ByteString arg = _magic_value.value();
 {
 if (arg == ByteString::from_utf8_without_validation("--"sv)){
-parser.definitely_positional_args = parser.args.operator[](JaktInternal::Range<size_t>{static_cast<size_t>(JaktInternal::checked_add(i,static_cast<size_t>(1ULL))),static_cast<size_t>(parser.args.size())}).to_array();
-parser.args = parser.args.operator[](JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(i)}).to_array();
+parser.definitely_positional_args = parser.args[JaktInternal::Range<size_t>{static_cast<size_t>(JaktInternal::checked_add(i,static_cast<size_t>(1ULL))),static_cast<size_t>(parser.args.size())}].to_array();
+parser.args = parser.args[JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(i)}].to_array();
 break;
 }
 i += static_cast<size_t>(1ULL);
@@ -190,7 +190,7 @@ break;
 size_t i = _magic_value.value();
 {
 if (!this->removed_indices.contains(i)){
-remaining.push(this->args.operator[](i));
+remaining.push(this->args[i]);
 }
 }
 

--- a/bootstrap/stage0/jakt__path.cpp
+++ b/bootstrap/stage0/jakt__path.cpp
@@ -157,16 +157,9 @@ ErrorOr<Jakt::jakt__path::Path> Jakt::jakt__path::Path::replace_extension(ByteSt
 {
 JaktInternal::Tuple<ByteString,ByteString> const parts = this->split_at_last_slash();
 ByteString const basename = this->basename(true);
-ByteString const extension = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<Jakt::jakt__path::Path>> {
-auto __jakt_enum_value = (new_extension);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation(""sv)) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}else {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("."sv) + new_extension);
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const extension = [&]() -> ByteString { auto __jakt_enum_value = new_extension;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation(""sv)) {return ByteString::from_utf8_without_validation(""sv);}else {return ByteString::from_utf8_without_validation("."sv) + new_extension;} 
+}();
 return Jakt::jakt__path::Path::from_parts(DynamicArray<ByteString>::create_with({parts.template get<0>(), basename + extension}));
 }
 }
@@ -243,7 +236,7 @@ Jakt::jakt__path::Path Jakt::jakt__path::Path::relative_to(Jakt::jakt__path::Pat
 JaktInternal::DynamicArray<ByteString> const base_parts = base.components();
 JaktInternal::DynamicArray<ByteString> const this_parts = this->components();
 size_t common = static_cast<size_t>(0ULL);
-while ((common < base_parts.size()) && ((common < this_parts.size()) && (base_parts.operator[](common) == this_parts.operator[](common)))){
+while ((common < base_parts.size()) && ((common < this_parts.size()) && (base_parts[common] == this_parts[common]))){
 common += static_cast<size_t>(1ULL);
 }
 JaktInternal::DynamicArray<ByteString> relative_parts = DynamicArray<ByteString>::create_with({});
@@ -271,7 +264,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-relative_parts.push(this_parts.operator[](i));
+relative_parts.push(this_parts[i]);
 }
 
 }

--- a/bootstrap/stage0/jakt__platform.cpp
+++ b/bootstrap/stage0/jakt__platform.cpp
@@ -8,28 +8,9 @@ namespace jakt__platform {
 ErrorOr<JaktInternal::DynamicArray<ByteString>> platform_import_names() {
 {
 Jakt::jakt__platform::Target const target = TRY((Jakt::jakt__platform::Target::active()));
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<ByteString>,ErrorOr<JaktInternal::DynamicArray<ByteString>>> {
-auto __jakt_enum_value = (target.os);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("windows"sv)) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<ByteString>,ErrorOr<JaktInternal::DynamicArray<ByteString>>> {
-auto __jakt_enum_value = (target.arch);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("x86_64"sv)) {return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("win64"sv), ByteString::from_utf8_without_validation("windows"sv)}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("i686"sv)) {return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("win32"sv), ByteString::from_utf8_without_validation("windows"sv)}));
-}else {return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("windows"sv)}));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("darwin"sv)) {return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("darwin"sv), ByteString::from_utf8_without_validation("posix"sv)}));
-}else if ((__jakt_enum_value == ByteString::from_utf8_without_validation("linux"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("openbsd"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("serenityos"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("serenity"sv))) {return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({target.os, ByteString::from_utf8_without_validation("posix"sv)}));
-}else {return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({target.os, ByteString::from_utf8_without_validation("unknown"sv)}));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = target.os;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("windows"sv)) {{auto __jakt_enum_value = target.arch;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("x86_64"sv)) {return DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("win64"sv), ByteString::from_utf8_without_validation("windows"sv)});}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("i686"sv)) {return DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("win32"sv), ByteString::from_utf8_without_validation("windows"sv)});}else {return DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("windows"sv)});}}}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("darwin"sv)) {return DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("darwin"sv), ByteString::from_utf8_without_validation("posix"sv)});}else if ((__jakt_enum_value == ByteString::from_utf8_without_validation("linux"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("openbsd"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("serenityos"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("serenity"sv))) {return DynamicArray<ByteString>::create_with({target.os, ByteString::from_utf8_without_validation("posix"sv)});}else {return DynamicArray<ByteString>::create_with({target.os, ByteString::from_utf8_without_validation("unknown"sv)});}}
 }
 }
 
@@ -87,7 +68,7 @@ if (parts.size() != static_cast<size_t>(4ULL)){
 warnln(StringView::from_string_literal("Invalid target triple '{}'"sv),triple);
 return Error::from_errno(static_cast<i32>(22));
 }
-return Jakt::jakt__platform::Target(parts.operator[](static_cast<i64>(0LL)),parts.operator[](static_cast<i64>(1LL)),parts.operator[](static_cast<i64>(2LL)),parts.operator[](static_cast<i64>(3LL)));
+return Jakt::jakt__platform::Target(parts[static_cast<i64>(0LL)],parts[static_cast<i64>(1LL)],parts[static_cast<i64>(2LL)],parts[static_cast<i64>(3LL)]);
 }
 }
 
@@ -100,17 +81,9 @@ return Jakt::jakt__platform::Target::from_triple(triple);
 
 ErrorOr<ByteString> Jakt::jakt__platform::Target::name(bool const abbreviate) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (abbreviate);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}-{}-{}"sv),this->arch,this->platform,this->os));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}-{}-{}-{}"sv),this->arch,this->platform,this->os,this->abi));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = abbreviate;
+if (__jakt_enum_value) {return __jakt_format(StringView::from_string_literal("{}-{}-{}"sv),this->arch,this->platform,this->os);}else if (!__jakt_enum_value) {return __jakt_format(StringView::from_string_literal("{}-{}-{}-{}"sv),this->arch,this->platform,this->os,this->abi);}VERIFY_NOT_REACHED();
+}
 }
 }
 
@@ -118,55 +91,31 @@ Jakt::jakt__platform::Target::Target(ByteString a_arch, ByteString a_platform, B
 
 ErrorOr<size_t> Jakt::jakt__platform::Target::size_t_size() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<size_t>> {
-auto __jakt_enum_value = (this->arch);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("x86_64"sv)) {return JaktInternal::ExplicitValue(static_cast<size_t>(8ULL));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("x86"sv)) {return JaktInternal::ExplicitValue(static_cast<size_t>(4ULL));
-}else {{
+{auto __jakt_enum_value = this->arch;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("x86_64"sv)) {return static_cast<size_t>(8ULL);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("x86"sv)) {return static_cast<size_t>(4ULL);}else {{
 return Error::__jakt_from_string_literal(StringView::from_string_literal("size_t size is unknown for this architecture"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}}
 }
 }
 
 ErrorOr<size_t> Jakt::jakt__platform::Target::pointer_size() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<size_t>> {
-auto __jakt_enum_value = (this->arch);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("x86_64"sv)) {return JaktInternal::ExplicitValue(static_cast<size_t>(8ULL));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("x86"sv)) {return JaktInternal::ExplicitValue(static_cast<size_t>(4ULL));
-}else {{
+{auto __jakt_enum_value = this->arch;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("x86_64"sv)) {return static_cast<size_t>(8ULL);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("x86"sv)) {return static_cast<size_t>(4ULL);}else {{
 return Error::__jakt_from_string_literal(StringView::from_string_literal("pointer size is unknown for this architecture"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}}
 }
 }
 
 ErrorOr<size_t> Jakt::jakt__platform::Target::int_size() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<size_t>> {
-auto __jakt_enum_value = (this->arch);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("x86_64"sv)) {return JaktInternal::ExplicitValue(static_cast<size_t>(4ULL));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("x86"sv)) {return JaktInternal::ExplicitValue(static_cast<size_t>(4ULL));
-}else {{
+{auto __jakt_enum_value = this->arch;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("x86_64"sv)) {return static_cast<size_t>(4ULL);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("x86"sv)) {return static_cast<size_t>(4ULL);}else {{
 return Error::__jakt_from_string_literal(StringView::from_string_literal("int size is unknown for this architecture"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}}
 }
 }
 

--- a/bootstrap/stage0/lexer.cpp
+++ b/bootstrap/stage0/lexer.cpp
@@ -60,7 +60,7 @@ u8 Jakt::lexer::Lexer::peek() const {
 if (this->eof()){
 return static_cast<u8>(0);
 }
-return this->input.operator[](this->index);
+return this->input[this->index];
 }
 }
 
@@ -69,7 +69,7 @@ u8 Jakt::lexer::Lexer::peek_ahead(size_t const steps) const {
 if (JaktInternal::checked_add(this->index,steps) >= this->input.size()){
 return static_cast<u8>(0);
 }
-return this->input.operator[](JaktInternal::checked_add(this->index,steps));
+return this->input[JaktInternal::checked_add(this->index,steps)];
 }
 }
 
@@ -78,7 +78,7 @@ u8 Jakt::lexer::Lexer::peek_behind(size_t const steps) const {
 if (this->index < steps){
 return static_cast<u8>(0);
 }
-return this->input.operator[](JaktInternal::checked_sub(this->index,steps));
+return this->input[JaktInternal::checked_sub(this->index,steps)];
 }
 }
 
@@ -100,7 +100,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-builder.append(this->input.operator[](i));
+builder.append(this->input[i]);
 }
 
 }
@@ -115,17 +115,9 @@ Jakt::lexer::Token Jakt::lexer::Lexer::lex_character_constant_or_name() {
 if (this->peek_ahead(static_cast<size_t>(1ULL)) != static_cast<u8>(u8'\'')){
 return this->lex_number_or_name();
 }
-JaktInternal::Optional<ByteString> const prefix = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8'b')) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("b"sv));
-}else if (__jakt_enum_value == static_cast<u8>(u8'c')) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("c"sv));
-}else {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+JaktInternal::Optional<ByteString> const prefix = [&]() -> JaktInternal::Optional<ByteString> { auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8'b')) {return ByteString::from_utf8_without_validation("b"sv);}else if (__jakt_enum_value == static_cast<u8>(u8'c')) {return ByteString::from_utf8_without_validation("c"sv);}else {return JaktInternal::OptionalNone();} 
+}();
 if (prefix.has_value()){
 this->index += static_cast<size_t>(1ULL);
 }
@@ -149,9 +141,9 @@ this->error(ByteString::from_utf8_without_validation("Expected single quote"sv),
 }
 this->index += static_cast<size_t>(1ULL);
 ByteStringBuilder builder = ByteStringBuilder::create();
-builder.append(this->input.operator[](JaktInternal::checked_add(start,static_cast<size_t>(1ULL))));
+builder.append(this->input[JaktInternal::checked_add(start,static_cast<size_t>(1ULL))]);
 if (escaped){
-builder.append(this->input.operator[](JaktInternal::checked_add(start,static_cast<size_t>(2ULL))));
+builder.append(this->input[JaktInternal::checked_add(start,static_cast<size_t>(2ULL))]);
 }
 ByteString const quote = builder.to_string();
 size_t const end = this->index;
@@ -172,7 +164,7 @@ return this->lex_number();
 else if (Jakt::utility::is_ascii_alpha(this->peek()) || (this->peek() == static_cast<u8>(u8'_'))){
 ByteStringBuilder string_builder = ByteStringBuilder::create();
 while (Jakt::utility::is_ascii_alphanumeric(this->peek()) || (this->peek() == static_cast<u8>(u8'_'))){
-u8 const value = this->input.operator[](this->index);
+u8 const value = this->input[this->index];
 ++this->index;
 string_builder.append(value);
 }
@@ -187,7 +179,7 @@ this->error(ByteString::from_utf8_without_validation("C++ keywords are not allow
 }
 return Jakt::lexer::Token::from_keyword_or_identifier(string,span);
 }
-u8 const unknown_char = this->input.operator[](this->index);
+u8 const unknown_char = this->input[this->index];
 size_t const end = ++this->index;
 this->error(__jakt_format(StringView::from_string_literal("unknown character: {:c}"sv),unknown_char),this->span(start,end));
 return Jakt::lexer::Token::Garbage(__jakt_format(StringView::from_string_literal("{:c}"sv),unknown_char),this->span(start,end));
@@ -196,21 +188,10 @@ return Jakt::lexer::Token::Garbage(__jakt_format(StringView::from_string_literal
 
 bool Jakt::lexer::Lexer::valid_digit(Jakt::lexer::LiteralPrefix const prefix,u8 const digit,bool const decimal_allowed) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = prefix;
+{auto&& __jakt_match_variant = prefix;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 1 /* Hexadecimal */:return JaktInternal::ExplicitValue(Jakt::utility::is_ascii_hexdigit(digit));
-case 2 /* Octal */:return JaktInternal::ExplicitValue(Jakt::utility::is_ascii_octdigit(digit));
-case 3 /* Binary */:return JaktInternal::ExplicitValue(Jakt::utility::is_ascii_binary(digit));
-default:return JaktInternal::ExplicitValue(Jakt::utility::is_ascii_digit(digit) || (decimal_allowed && (digit == static_cast<u8>(u8'.'))));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 1 /* Hexadecimal */:return Jakt::utility::is_ascii_hexdigit(digit);case 2 /* Octal */:return Jakt::utility::is_ascii_octdigit(digit);case 3 /* Binary */:return Jakt::utility::is_ascii_binary(digit);default:return Jakt::utility::is_ascii_digit(digit) || (decimal_allowed && (digit == static_cast<u8>(u8'.')));}/*switch end*/
+}
 }
 }
 
@@ -221,36 +202,25 @@ bool floating = false;
 Jakt::lexer::LiteralPrefix prefix = Jakt::lexer::LiteralPrefix::None();
 ByteStringBuilder number = ByteStringBuilder::create();
 if (this->peek() == static_cast<u8>(u8'0')){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek_ahead(static_cast<size_t>(1ULL)));
+{auto __jakt_enum_value = this->peek_ahead(static_cast<size_t>(1ULL));
 if (__jakt_enum_value == static_cast<u8>(u8'x')) {{
 prefix = Jakt::lexer::LiteralPrefix::Hexadecimal();
 this->index += static_cast<size_t>(2ULL);
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == static_cast<u8>(u8'o')) {{
+goto __jakt_label_5;}else if (__jakt_enum_value == static_cast<u8>(u8'o')) {{
 prefix = Jakt::lexer::LiteralPrefix::Octal();
 this->index += static_cast<size_t>(2ULL);
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == static_cast<u8>(u8'b')) {{
+goto __jakt_label_5;}else if (__jakt_enum_value == static_cast<u8>(u8'b')) {{
 prefix = Jakt::lexer::LiteralPrefix::Binary();
 this->index += static_cast<size_t>(2ULL);
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_5;}else {{
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_5;}}goto __jakt_label_5; __jakt_label_5:;;
 }
 while (!this->eof()){
-u8 const value = this->input.operator[](this->index);
+u8 const value = this->input[this->index];
 if (!this->valid_digit(prefix,value,true)){
 break;
 }
@@ -283,22 +253,13 @@ return Jakt::lexer::Token::Number(prefix,number.to_string(),suffix,this->span(st
 
 Jakt::lexer::LiteralSuffix Jakt::lexer::Lexer::consume_numeric_literal_suffix() {
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,Jakt::lexer::LiteralSuffix> {
-auto __jakt_enum_value = (this->peek());
+{auto __jakt_enum_value = this->peek();
 if ((__jakt_enum_value == static_cast<u8>(u8'u'))||(__jakt_enum_value == static_cast<u8>(u8'i'))||(__jakt_enum_value == static_cast<u8>(u8'f'))) {{
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_6;}else {{
 return Jakt::lexer::LiteralSuffix::None();
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_6;}}goto __jakt_label_6; __jakt_label_6:;;
 if ((this->peek() == static_cast<u8>(u8'u')) && (this->peek_ahead(static_cast<size_t>(1ULL)) == static_cast<u8>(u8'z'))){
 this->index += static_cast<size_t>(2ULL);
 return Jakt::lexer::LiteralSuffix::UZ();
@@ -309,57 +270,17 @@ while (Jakt::utility::is_ascii_digit(this->peek_ahead(local_index))){
 if (local_index > static_cast<size_t>(3ULL)){
 return Jakt::lexer::LiteralSuffix::None();
 }
-u8 const value = this->input.operator[](JaktInternal::checked_add(this->index,local_index));
+u8 const value = this->input[JaktInternal::checked_add(this->index,local_index)];
 ++local_index;
 i64 const digit = Jakt::as_saturated<i64, u8>(JaktInternal::checked_sub(value,static_cast<u8>(u8'0')));
 width = JaktInternal::checked_add(JaktInternal::checked_mul(width,static_cast<i64>(10LL)),digit);
 }
-Jakt::lexer::LiteralSuffix const suffix = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::LiteralSuffix,Jakt::lexer::LiteralSuffix> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8'u')) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::LiteralSuffix,Jakt::lexer::LiteralSuffix> {
-auto __jakt_enum_value = (width);
-if (__jakt_enum_value == static_cast<i64>(8LL)) {return JaktInternal::ExplicitValue(Jakt::lexer::LiteralSuffix::U8());
-}else if (__jakt_enum_value == static_cast<i64>(16LL)) {return JaktInternal::ExplicitValue(Jakt::lexer::LiteralSuffix::U16());
-}else if (__jakt_enum_value == static_cast<i64>(32LL)) {return JaktInternal::ExplicitValue(Jakt::lexer::LiteralSuffix::U32());
-}else if (__jakt_enum_value == static_cast<i64>(64LL)) {return JaktInternal::ExplicitValue(Jakt::lexer::LiteralSuffix::U64());
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::LiteralSuffix::None());
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == static_cast<u8>(u8'i')) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::LiteralSuffix,Jakt::lexer::LiteralSuffix> {
-auto __jakt_enum_value = (width);
-if (__jakt_enum_value == static_cast<i64>(8LL)) {return JaktInternal::ExplicitValue(Jakt::lexer::LiteralSuffix::I8());
-}else if (__jakt_enum_value == static_cast<i64>(16LL)) {return JaktInternal::ExplicitValue(Jakt::lexer::LiteralSuffix::I16());
-}else if (__jakt_enum_value == static_cast<i64>(32LL)) {return JaktInternal::ExplicitValue(Jakt::lexer::LiteralSuffix::I32());
-}else if (__jakt_enum_value == static_cast<i64>(64LL)) {return JaktInternal::ExplicitValue(Jakt::lexer::LiteralSuffix::I64());
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::LiteralSuffix::None());
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else if (__jakt_enum_value == static_cast<u8>(u8'f')) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::LiteralSuffix,Jakt::lexer::LiteralSuffix> {
-auto __jakt_enum_value = (width);
-if (__jakt_enum_value == static_cast<i64>(32LL)) {return JaktInternal::ExplicitValue(Jakt::lexer::LiteralSuffix::F32());
-}else if (__jakt_enum_value == static_cast<i64>(64LL)) {return JaktInternal::ExplicitValue(Jakt::lexer::LiteralSuffix::F64());
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::LiteralSuffix::None());
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::LiteralSuffix::None());
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+Jakt::lexer::LiteralSuffix const suffix = [&]() -> Jakt::lexer::LiteralSuffix { auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8'u')) {{auto __jakt_enum_value = width;
+if (__jakt_enum_value == static_cast<i64>(8LL)) {return Jakt::lexer::LiteralSuffix::U8();}else if (__jakt_enum_value == static_cast<i64>(16LL)) {return Jakt::lexer::LiteralSuffix::U16();}else if (__jakt_enum_value == static_cast<i64>(32LL)) {return Jakt::lexer::LiteralSuffix::U32();}else if (__jakt_enum_value == static_cast<i64>(64LL)) {return Jakt::lexer::LiteralSuffix::U64();}else {return Jakt::lexer::LiteralSuffix::None();}}}else if (__jakt_enum_value == static_cast<u8>(u8'i')) {{auto __jakt_enum_value = width;
+if (__jakt_enum_value == static_cast<i64>(8LL)) {return Jakt::lexer::LiteralSuffix::I8();}else if (__jakt_enum_value == static_cast<i64>(16LL)) {return Jakt::lexer::LiteralSuffix::I16();}else if (__jakt_enum_value == static_cast<i64>(32LL)) {return Jakt::lexer::LiteralSuffix::I32();}else if (__jakt_enum_value == static_cast<i64>(64LL)) {return Jakt::lexer::LiteralSuffix::I64();}else {return Jakt::lexer::LiteralSuffix::None();}}}else if (__jakt_enum_value == static_cast<u8>(u8'f')) {{auto __jakt_enum_value = width;
+if (__jakt_enum_value == static_cast<i64>(32LL)) {return Jakt::lexer::LiteralSuffix::F32();}else if (__jakt_enum_value == static_cast<i64>(64LL)) {return Jakt::lexer::LiteralSuffix::F64();}else {return Jakt::lexer::LiteralSuffix::None();}}}else {return Jakt::lexer::LiteralSuffix::None();} 
+}();
 if (!(suffix.__jakt_init_index() == 0 /* None */)){
 this->index += local_index;
 }
@@ -403,51 +324,24 @@ return Jakt::lexer::Token::QuotedString(str,this->span(start,end));
 Jakt::lexer::Token Jakt::lexer::Lexer::lex_plus() {
 {
 size_t const start = this->index++;
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8'=')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::PlusEqual(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8'+')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::PlusPlus(this->span(start,++this->index)));
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Plus(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index)));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8'=')) {return Jakt::lexer::Token::PlusEqual(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8'+')) {return Jakt::lexer::Token::PlusPlus(this->span(start,++this->index));}else {return Jakt::lexer::Token::Plus(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index));}}
 }
 }
 
 Jakt::lexer::Token Jakt::lexer::Lexer::lex_minus() {
 {
 size_t const start = this->index++;
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8'=')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::MinusEqual(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8'-')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::MinusMinus(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8'>')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Arrow(this->span(start,++this->index)));
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Minus(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index)));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8'=')) {return Jakt::lexer::Token::MinusEqual(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8'-')) {return Jakt::lexer::Token::MinusMinus(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8'>')) {return Jakt::lexer::Token::Arrow(this->span(start,++this->index));}else {return Jakt::lexer::Token::Minus(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index));}}
 }
 }
 
 Jakt::lexer::Token Jakt::lexer::Lexer::lex_asterisk() {
 {
 size_t const start = this->index++;
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8'=')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::AsteriskEqual(this->span(start,++this->index)));
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Asterisk(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index)));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8'=')) {return Jakt::lexer::Token::AsteriskEqual(this->span(start,++this->index));}else {return Jakt::lexer::Token::Asterisk(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index));}}
 }
 }
 
@@ -474,7 +368,7 @@ this->index--;
 break;
 }
 }
-this->comment_contents = this->input.operator[](JaktInternal::Range<size_t>{static_cast<size_t>(comment_start_index),static_cast<size_t>(this->index)}).to_array();
+this->comment_contents = this->input[JaktInternal::Range<size_t>{static_cast<size_t>(comment_start_index),static_cast<size_t>(this->index)}].to_array();
 return this->next().value_or_lazy_evaluated([&] { return Jakt::lexer::Token::Eof(this->span(this->index,this->index)); });
 }
 }
@@ -482,222 +376,106 @@ return this->next().value_or_lazy_evaluated([&] { return Jakt::lexer::Token::Eof
 Jakt::lexer::Token Jakt::lexer::Lexer::lex_caret() {
 {
 size_t const start = this->index++;
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8'=')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::CaretEqual(this->span(start,++this->index)));
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Caret(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index)));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8'=')) {return Jakt::lexer::Token::CaretEqual(this->span(start,++this->index));}else {return Jakt::lexer::Token::Caret(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index));}}
 }
 }
 
 Jakt::lexer::Token Jakt::lexer::Lexer::lex_pipe() {
 {
 size_t const start = this->index++;
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8'=')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::PipeEqual(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8'|')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::PipePipe(this->span(start,++this->index)));
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Pipe(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index)));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8'=')) {return Jakt::lexer::Token::PipeEqual(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8'|')) {return Jakt::lexer::Token::PipePipe(this->span(start,++this->index));}else {return Jakt::lexer::Token::Pipe(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index));}}
 }
 }
 
 Jakt::lexer::Token Jakt::lexer::Lexer::lex_percent_sign() {
 {
 size_t const start = this->index++;
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8'=')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::PercentSignEqual(this->span(start,++this->index)));
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::PercentSign(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index)));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8'=')) {return Jakt::lexer::Token::PercentSignEqual(this->span(start,++this->index));}else {return Jakt::lexer::Token::PercentSign(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index));}}
 }
 }
 
 Jakt::lexer::Token Jakt::lexer::Lexer::lex_exclamation_point() {
 {
 size_t const start = this->index++;
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8'=')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::NotEqual(this->span(start,++this->index)));
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::ExclamationPoint(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index)));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8'=')) {return Jakt::lexer::Token::NotEqual(this->span(start,++this->index));}else {return Jakt::lexer::Token::ExclamationPoint(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index));}}
 }
 }
 
 Jakt::lexer::Token Jakt::lexer::Lexer::lex_ampersand() {
 {
 size_t const start = this->index++;
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8'=')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::AmpersandEqual(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8'&')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::AmpersandAmpersand(this->span(start,++this->index)));
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Ampersand(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index)));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8'=')) {return Jakt::lexer::Token::AmpersandEqual(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8'&')) {return Jakt::lexer::Token::AmpersandAmpersand(this->span(start,++this->index));}else {return Jakt::lexer::Token::Ampersand(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index));}}
 }
 }
 
 Jakt::lexer::Token Jakt::lexer::Lexer::lex_less_than() {
 {
 size_t const start = this->index++;
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8'=')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::LessThanOrEqual(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8'<')) {{
+{auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8'=')) {return Jakt::lexer::Token::LessThanOrEqual(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8'<')) {{
 this->index++;
-return JaktInternal::ExplicitValue<Jakt::lexer::Token>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8'<')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::LeftArithmeticShift(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8'=')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::LeftShiftEqual(this->span(start,++this->index)));
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::LeftShift(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index)));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+{auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8'<')) {return Jakt::lexer::Token::LeftArithmeticShift(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8'=')) {return Jakt::lexer::Token::LeftShiftEqual(this->span(start,++this->index));}else {return Jakt::lexer::Token::LeftShift(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index));}}
 }
 VERIFY_NOT_REACHED();
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::LessThan(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index)));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}else {return Jakt::lexer::Token::LessThan(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index));}}
 }
 }
 
 Jakt::lexer::Token Jakt::lexer::Lexer::lex_greater_than() {
 {
 size_t const start = this->index++;
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8'=')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::GreaterThanOrEqual(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8'>')) {{
+{auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8'=')) {return Jakt::lexer::Token::GreaterThanOrEqual(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8'>')) {{
 this->index++;
-return JaktInternal::ExplicitValue<Jakt::lexer::Token>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8'>')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::RightArithmeticShift(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8'=')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::RightShiftEqual(this->span(start,++this->index)));
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::RightShift(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index)));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+{auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8'>')) {return Jakt::lexer::Token::RightArithmeticShift(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8'=')) {return Jakt::lexer::Token::RightShiftEqual(this->span(start,++this->index));}else {return Jakt::lexer::Token::RightShift(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index));}}
 }
 VERIFY_NOT_REACHED();
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::GreaterThan(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index)));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}else {return Jakt::lexer::Token::GreaterThan(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index));}}
 }
 }
 
 Jakt::lexer::Token Jakt::lexer::Lexer::lex_dot() {
 {
 size_t const start = this->index++;
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8'.')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::DotDot(this->span(start,++this->index)));
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Dot(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index)));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8'.')) {return Jakt::lexer::Token::DotDot(this->span(start,++this->index));}else {return Jakt::lexer::Token::Dot(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index));}}
 }
 }
 
 Jakt::lexer::Token Jakt::lexer::Lexer::lex_colon() {
 {
 size_t const start = this->index++;
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8':')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::ColonColon(this->span(start,++this->index)));
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Colon(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index)));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8':')) {return Jakt::lexer::Token::ColonColon(this->span(start,++this->index));}else {return Jakt::lexer::Token::Colon(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index));}}
 }
 }
 
 Jakt::lexer::Token Jakt::lexer::Lexer::lex_question_mark() {
 {
 size_t const start = this->index++;
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
+{auto __jakt_enum_value = this->peek();
 if (__jakt_enum_value == static_cast<u8>(u8'?')) {{
 this->index++;
-return JaktInternal::ExplicitValue<Jakt::lexer::Token>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8'=')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::QuestionMarkQuestionMarkEqual(this->span(start,++this->index)));
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::QuestionMarkQuestionMark(this->span(start,this->index)));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+{auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8'=')) {return Jakt::lexer::Token::QuestionMarkQuestionMarkEqual(this->span(start,++this->index));}else {return Jakt::lexer::Token::QuestionMarkQuestionMark(this->span(start,this->index));}}
 }
 VERIFY_NOT_REACHED();
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::QuestionMark(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index)));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}else {return Jakt::lexer::Token::QuestionMark(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index));}}
 }
 }
 
 Jakt::lexer::Token Jakt::lexer::Lexer::lex_equals() {
 {
 size_t const start = this->index++;
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (this->peek());
-if (__jakt_enum_value == static_cast<u8>(u8'=')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::DoubleEqual(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8'>')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::FatArrow(this->span(start,++this->index)));
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Equal(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index)));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = this->peek();
+if (__jakt_enum_value == static_cast<u8>(u8'=')) {return Jakt::lexer::Token::DoubleEqual(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8'>')) {return Jakt::lexer::Token::FatArrow(this->span(start,++this->index));}else {return Jakt::lexer::Token::Equal(this->span(JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)),this->index));}}
 }
 }
 
@@ -748,45 +526,8 @@ break;
 
 }
 size_t const start = this->index;
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::lexer::Token>,JaktInternal::Optional<Jakt::lexer::Token>> {
-auto __jakt_enum_value = (this->input.operator[](this->index));
-if (__jakt_enum_value == static_cast<u8>(u8'(')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::LParen(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8')')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::RParen(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8'[')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::LSquare(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8']')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::RSquare(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8'{')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::LCurly(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8'}')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::RCurly(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8'<')) {return JaktInternal::ExplicitValue(this->lex_less_than());
-}else if (__jakt_enum_value == static_cast<u8>(u8'>')) {return JaktInternal::ExplicitValue(this->lex_greater_than());
-}else if (__jakt_enum_value == static_cast<u8>(u8'.')) {return JaktInternal::ExplicitValue(this->lex_dot());
-}else if (__jakt_enum_value == static_cast<u8>(u8',')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Comma(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8'~')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Tilde(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8';')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Semicolon(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8':')) {return JaktInternal::ExplicitValue(this->lex_colon());
-}else if (__jakt_enum_value == static_cast<u8>(u8'?')) {return JaktInternal::ExplicitValue(this->lex_question_mark());
-}else if (__jakt_enum_value == static_cast<u8>(u8'+')) {return JaktInternal::ExplicitValue(this->lex_plus());
-}else if (__jakt_enum_value == static_cast<u8>(u8'-')) {return JaktInternal::ExplicitValue(this->lex_minus());
-}else if (__jakt_enum_value == static_cast<u8>(u8'*')) {return JaktInternal::ExplicitValue(this->lex_asterisk());
-}else if (__jakt_enum_value == static_cast<u8>(u8'/')) {return JaktInternal::ExplicitValue(this->lex_forward_slash());
-}else if (__jakt_enum_value == static_cast<u8>(u8'^')) {return JaktInternal::ExplicitValue(this->lex_caret());
-}else if (__jakt_enum_value == static_cast<u8>(u8'|')) {return JaktInternal::ExplicitValue(this->lex_pipe());
-}else if (__jakt_enum_value == static_cast<u8>(u8'%')) {return JaktInternal::ExplicitValue(this->lex_percent_sign());
-}else if (__jakt_enum_value == static_cast<u8>(u8'!')) {return JaktInternal::ExplicitValue(this->lex_exclamation_point());
-}else if (__jakt_enum_value == static_cast<u8>(u8'&')) {return JaktInternal::ExplicitValue(this->lex_ampersand());
-}else if (__jakt_enum_value == static_cast<u8>(u8'$')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Dollar(this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8'=')) {return JaktInternal::ExplicitValue(this->lex_equals());
-}else if (__jakt_enum_value == static_cast<u8>(u8'\n')) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Eol(this->consume_comment_contents(),this->span(start,++this->index)));
-}else if (__jakt_enum_value == static_cast<u8>(u8'\'')) {return JaktInternal::ExplicitValue(this->lex_quoted_string(static_cast<u8>(u8'\'')));
-}else if (__jakt_enum_value == static_cast<u8>(u8'\"')) {return JaktInternal::ExplicitValue(this->lex_quoted_string(static_cast<u8>(u8'"')));
-}else if (__jakt_enum_value == static_cast<u8>(u8'b')) {return JaktInternal::ExplicitValue(this->lex_character_constant_or_name());
-}else if (__jakt_enum_value == static_cast<u8>(u8'c')) {return JaktInternal::ExplicitValue(this->lex_character_constant_or_name());
-}else {return JaktInternal::ExplicitValue(this->lex_number_or_name());
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = this->input[this->index];
+if (__jakt_enum_value == static_cast<u8>(u8'(')) {return Jakt::lexer::Token::LParen(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8')')) {return Jakt::lexer::Token::RParen(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8'[')) {return Jakt::lexer::Token::LSquare(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8']')) {return Jakt::lexer::Token::RSquare(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8'{')) {return Jakt::lexer::Token::LCurly(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8'}')) {return Jakt::lexer::Token::RCurly(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8'<')) {return this->lex_less_than();}else if (__jakt_enum_value == static_cast<u8>(u8'>')) {return this->lex_greater_than();}else if (__jakt_enum_value == static_cast<u8>(u8'.')) {return this->lex_dot();}else if (__jakt_enum_value == static_cast<u8>(u8',')) {return Jakt::lexer::Token::Comma(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8'~')) {return Jakt::lexer::Token::Tilde(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8';')) {return Jakt::lexer::Token::Semicolon(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8':')) {return this->lex_colon();}else if (__jakt_enum_value == static_cast<u8>(u8'?')) {return this->lex_question_mark();}else if (__jakt_enum_value == static_cast<u8>(u8'+')) {return this->lex_plus();}else if (__jakt_enum_value == static_cast<u8>(u8'-')) {return this->lex_minus();}else if (__jakt_enum_value == static_cast<u8>(u8'*')) {return this->lex_asterisk();}else if (__jakt_enum_value == static_cast<u8>(u8'/')) {return this->lex_forward_slash();}else if (__jakt_enum_value == static_cast<u8>(u8'^')) {return this->lex_caret();}else if (__jakt_enum_value == static_cast<u8>(u8'|')) {return this->lex_pipe();}else if (__jakt_enum_value == static_cast<u8>(u8'%')) {return this->lex_percent_sign();}else if (__jakt_enum_value == static_cast<u8>(u8'!')) {return this->lex_exclamation_point();}else if (__jakt_enum_value == static_cast<u8>(u8'&')) {return this->lex_ampersand();}else if (__jakt_enum_value == static_cast<u8>(u8'$')) {return Jakt::lexer::Token::Dollar(this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8'=')) {return this->lex_equals();}else if (__jakt_enum_value == static_cast<u8>(u8'\n')) {return Jakt::lexer::Token::Eol(this->consume_comment_contents(),this->span(start,++this->index));}else if (__jakt_enum_value == static_cast<u8>(u8'\'')) {return this->lex_quoted_string(static_cast<u8>(u8'\''));}else if (__jakt_enum_value == static_cast<u8>(u8'\"')) {return this->lex_quoted_string(static_cast<u8>(u8'"'));}else if (__jakt_enum_value == static_cast<u8>(u8'b')) {return this->lex_character_constant_or_name();}else if (__jakt_enum_value == static_cast<u8>(u8'c')) {return this->lex_character_constant_or_name();}else {return this->lex_number_or_name();}}
 }
 }
 
@@ -4536,546 +4277,362 @@ break;
 }
 Jakt::utility::Span Jakt::lexer::Token::span() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::utility::Span, Jakt::utility::Span>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 4 /* Semicolon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Semicolon;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 5 /* Colon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Colon;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 6 /* ColonColon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ColonColon;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 7 /* LParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LParen;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 8 /* RParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RParen;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 9 /* LCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LCurly;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 10 /* RCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RCurly;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 11 /* LSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LSquare;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 12 /* RSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RSquare;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 13 /* PercentSign */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSign;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 14 /* Plus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Plus;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 15 /* Minus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Minus;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 16 /* Equal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Equal;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 17 /* PlusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 18 /* PlusPlus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusPlus;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 19 /* MinusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 20 /* MinusMinus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusMinus;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 21 /* AsteriskEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AsteriskEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 22 /* ForwardSlashEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlashEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 23 /* PercentSignEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSignEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 24 /* NotEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NotEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 25 /* DoubleEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DoubleEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 26 /* GreaterThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThan;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 27 /* GreaterThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThanOrEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 28 /* LessThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThan;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 29 /* LessThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThanOrEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 30 /* LeftArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftArithmeticShift;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 31 /* LeftShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShift;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 32 /* LeftShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShiftEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 33 /* RightShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShift;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 34 /* RightArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightArithmeticShift;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 35 /* RightShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShiftEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 36 /* Asterisk */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Asterisk;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 37 /* Ampersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Ampersand;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 38 /* AmpersandEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 39 /* AmpersandAmpersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandAmpersand;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 40 /* Pipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Pipe;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 41 /* PipeEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipeEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 42 /* PipePipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipePipe;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 43 /* Caret */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Caret;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 44 /* CaretEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CaretEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 45 /* Dollar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dollar;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 46 /* Tilde */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Tilde;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 47 /* ForwardSlash */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlash;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 48 /* ExclamationPoint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ExclamationPoint;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 49 /* QuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMark;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 50 /* QuestionMarkQuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMark;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 51 /* QuestionMarkQuestionMarkEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMarkEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 52 /* Comma */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comma;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 54 /* DotDot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DotDot;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 55 /* Eol */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eol;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 56 /* Eof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eof;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 57 /* FatArrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.FatArrow;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 58 /* Arrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Arrow;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 59 /* And */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.And;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 60 /* Anon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Anon;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 61 /* As */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.As;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 62 /* Boxed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boxed;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 63 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 64 /* Catch */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Catch;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 65 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 66 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 67 /* Cpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Cpp;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 68 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 69 /* Destructor */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Destructor;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 70 /* Else */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Else;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 71 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 72 /* Extern */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Extern;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 73 /* Export */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Export;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 74 /* False */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.False;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 75 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 76 /* Fn */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Fn;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 77 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 78 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 79 /* Import */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Import;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 80 /* Relative */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Relative;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 81 /* In */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.In;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 82 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 83 /* Let */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Let;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 84 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 85 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 86 /* Must */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Must;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 87 /* Mut */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Mut;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 88 /* Namespace */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Namespace;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 89 /* Not */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Not;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 90 /* Or */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Or;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 91 /* Override */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Override;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 92 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 93 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 94 /* Raw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Raw;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 95 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 96 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 97 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 98 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 99 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 100 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 101 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 102 /* Throws */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throws;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 103 /* True */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.True;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 104 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 105 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 106 /* Virtual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Virtual;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 107 /* Weak */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Weak;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 108 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 109 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 110 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 111 /* Implements */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Implements;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 112 /* Requires */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Requires;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 113 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 114 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 Jakt::lexer::Token Jakt::lexer::Token::from_keyword_or_identifier(ByteString const string,Jakt::utility::Span const span) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::lexer::Token,Jakt::lexer::Token> {
-auto __jakt_enum_value = (string);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("and"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::And(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("anon"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Anon(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("as"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::As(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("boxed"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Boxed(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("break"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Break(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("catch"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Catch(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("class"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Class(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("continue"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Continue(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("cpp"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Cpp(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("defer"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Defer(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("destructor"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Destructor(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("else"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Else(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("enum"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Enum(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("extern"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Extern(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("export"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Export(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("false"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::False(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("for"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::For(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("fn"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Fn(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("comptime"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Comptime(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("if"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::If(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("import"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Import(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("relative"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Relative(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("in"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::In(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("is"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Is(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("let"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Let(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("loop"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Loop(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("match"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Match(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("must"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Must(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("mut"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Mut(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("namespace"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Namespace(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("not"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Not(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("or"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Or(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("override"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Override(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("private"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Private(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("public"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Public(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("raw"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Raw(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("reflect"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Reflect(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("return"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Return(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("restricted"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Restricted(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("sizeof"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Sizeof(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("struct"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Struct(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("this"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::This(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("throw"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Throw(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("throws"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Throws(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("true"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::True(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("try"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Try(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("unsafe"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Unsafe(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("virtual"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Virtual(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("weak"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Weak(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("while"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::While(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("yield"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Yield(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("guard"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Guard(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("requires"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Requires(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("implements"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Implements(span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("trait"sv)) {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Trait(span));
-}else {return JaktInternal::ExplicitValue(Jakt::lexer::Token::Identifier(string,span));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = string;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("and"sv)) {return Jakt::lexer::Token::And(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("anon"sv)) {return Jakt::lexer::Token::Anon(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("as"sv)) {return Jakt::lexer::Token::As(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("boxed"sv)) {return Jakt::lexer::Token::Boxed(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("break"sv)) {return Jakt::lexer::Token::Break(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("catch"sv)) {return Jakt::lexer::Token::Catch(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("class"sv)) {return Jakt::lexer::Token::Class(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("continue"sv)) {return Jakt::lexer::Token::Continue(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("cpp"sv)) {return Jakt::lexer::Token::Cpp(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("defer"sv)) {return Jakt::lexer::Token::Defer(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("destructor"sv)) {return Jakt::lexer::Token::Destructor(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("else"sv)) {return Jakt::lexer::Token::Else(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("enum"sv)) {return Jakt::lexer::Token::Enum(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("extern"sv)) {return Jakt::lexer::Token::Extern(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("export"sv)) {return Jakt::lexer::Token::Export(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("false"sv)) {return Jakt::lexer::Token::False(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("for"sv)) {return Jakt::lexer::Token::For(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("fn"sv)) {return Jakt::lexer::Token::Fn(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("comptime"sv)) {return Jakt::lexer::Token::Comptime(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("if"sv)) {return Jakt::lexer::Token::If(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("import"sv)) {return Jakt::lexer::Token::Import(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("relative"sv)) {return Jakt::lexer::Token::Relative(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("in"sv)) {return Jakt::lexer::Token::In(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("is"sv)) {return Jakt::lexer::Token::Is(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("let"sv)) {return Jakt::lexer::Token::Let(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("loop"sv)) {return Jakt::lexer::Token::Loop(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("match"sv)) {return Jakt::lexer::Token::Match(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("must"sv)) {return Jakt::lexer::Token::Must(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("mut"sv)) {return Jakt::lexer::Token::Mut(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("namespace"sv)) {return Jakt::lexer::Token::Namespace(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("not"sv)) {return Jakt::lexer::Token::Not(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("or"sv)) {return Jakt::lexer::Token::Or(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("override"sv)) {return Jakt::lexer::Token::Override(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("private"sv)) {return Jakt::lexer::Token::Private(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("public"sv)) {return Jakt::lexer::Token::Public(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("raw"sv)) {return Jakt::lexer::Token::Raw(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("reflect"sv)) {return Jakt::lexer::Token::Reflect(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("return"sv)) {return Jakt::lexer::Token::Return(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("restricted"sv)) {return Jakt::lexer::Token::Restricted(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("sizeof"sv)) {return Jakt::lexer::Token::Sizeof(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("struct"sv)) {return Jakt::lexer::Token::Struct(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("this"sv)) {return Jakt::lexer::Token::This(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("throw"sv)) {return Jakt::lexer::Token::Throw(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("throws"sv)) {return Jakt::lexer::Token::Throws(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("true"sv)) {return Jakt::lexer::Token::True(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("try"sv)) {return Jakt::lexer::Token::Try(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("unsafe"sv)) {return Jakt::lexer::Token::Unsafe(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("virtual"sv)) {return Jakt::lexer::Token::Virtual(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("weak"sv)) {return Jakt::lexer::Token::Weak(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("while"sv)) {return Jakt::lexer::Token::While(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("yield"sv)) {return Jakt::lexer::Token::Yield(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("guard"sv)) {return Jakt::lexer::Token::Guard(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("requires"sv)) {return Jakt::lexer::Token::Requires(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("implements"sv)) {return Jakt::lexer::Token::Implements(span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("trait"sv)) {return Jakt::lexer::Token::Trait(span);}else {return Jakt::lexer::Token::Identifier(string,span);}}
 }
 }
 
@@ -5216,21 +4773,10 @@ case 3 /* Binary */:break;
 }
 ByteString Jakt::lexer::LiteralPrefix::to_string() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ByteString>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* None */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-case 1 /* Hexadecimal */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("0x"sv));
-case 2 /* Octal */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("0o"sv));
-case 3 /* Binary */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("0b"sv));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 0 /* None */:return ByteString::from_utf8_without_validation(""sv);case 1 /* Hexadecimal */:return ByteString::from_utf8_without_validation("0x"sv);case 2 /* Octal */:return ByteString::from_utf8_without_validation("0o"sv);case 3 /* Binary */:return ByteString::from_utf8_without_validation("0b"sv);default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
@@ -5539,29 +5085,10 @@ case 11 /* F64 */:break;
 }
 ByteString Jakt::lexer::LiteralSuffix::to_string() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ByteString>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* None */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-case 1 /* UZ */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("uz"sv));
-case 2 /* U8 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u8"sv));
-case 3 /* U16 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u16"sv));
-case 4 /* U32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u32"sv));
-case 5 /* U64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u64"sv));
-case 6 /* I8 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i8"sv));
-case 7 /* I16 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i16"sv));
-case 8 /* I32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i32"sv));
-case 9 /* I64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i64"sv));
-case 10 /* F32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("f32"sv));
-case 11 /* F64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("f64"sv));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 0 /* None */:return ByteString::from_utf8_without_validation(""sv);case 1 /* UZ */:return ByteString::from_utf8_without_validation("uz"sv);case 2 /* U8 */:return ByteString::from_utf8_without_validation("u8"sv);case 3 /* U16 */:return ByteString::from_utf8_without_validation("u16"sv);case 4 /* U32 */:return ByteString::from_utf8_without_validation("u32"sv);case 5 /* U64 */:return ByteString::from_utf8_without_validation("u64"sv);case 6 /* I8 */:return ByteString::from_utf8_without_validation("i8"sv);case 7 /* I16 */:return ByteString::from_utf8_without_validation("i16"sv);case 8 /* I32 */:return ByteString::from_utf8_without_validation("i32"sv);case 9 /* I64 */:return ByteString::from_utf8_without_validation("i64"sv);case 10 /* F32 */:return ByteString::from_utf8_without_validation("f32"sv);case 11 /* F64 */:return ByteString::from_utf8_without_validation("f64"sv);default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 

--- a/bootstrap/stage0/main.cpp
+++ b/bootstrap/stage0/main.cpp
@@ -405,17 +405,17 @@ JaktInternal::DynamicArray<ByteString> const parts = range.split(':');
 if (parts.is_empty()){
 return Jakt::FormatRange(static_cast<size_t>(0ULL),input_file_length);
 }
-JaktInternal::Optional<u32> const start_input = parts.operator[](static_cast<i64>(0LL)).template to_number<u32>();
+JaktInternal::Optional<u32> const start_input = parts[static_cast<i64>(0LL)].template to_number<u32>();
 if (!start_input.has_value()){
 return JaktInternal::OptionalNone();
 }
 size_t const start = infallible_integer_cast<size_t>(start_input.value());
 size_t const end = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,JaktInternal::Optional<Jakt::FormatRange>> {
-auto __jakt_enum_value = (parts.size());
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, JaktInternal::Optional<Jakt::FormatRange>>{
+auto __jakt_enum_value = parts.size();
 if (__jakt_enum_value == static_cast<size_t>(1ULL)) {return JaktInternal::ExplicitValue(input_file_length);
 }else if (__jakt_enum_value == static_cast<size_t>(2ULL)) {{
-JaktInternal::Optional<u32> const end_input = parts.operator[](static_cast<i64>(1LL)).template to_number<u32>();
+JaktInternal::Optional<u32> const end_input = parts[static_cast<i64>(1LL)].template to_number<u32>();
 if (!end_input.has_value()){
 return JaktInternal::OptionalNone();
 }
@@ -425,7 +425,8 @@ VERIFY_NOT_REACHED();
 }else {{
 return JaktInternal::OptionalNone();
 }
-}}());
+}}()
+);
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
@@ -450,7 +451,7 @@ if (args.size() <= static_cast<size_t>(1ULL)){
 warnln(StringView::from_string_literal("{}"sv),Jakt::usage());
 return static_cast<int>(1);
 }
-if (args.operator[](static_cast<i64>(1LL)) == ByteString::from_utf8_without_validation("cross"sv)){
+if (args[static_cast<i64>(1LL)] == ByteString::from_utf8_without_validation("cross"sv)){
 return Jakt::selfhost_crosscompiler_main(args);
 }
 return Jakt::compiler_main(args);
@@ -501,7 +502,7 @@ break;
 }
 size_t bytes_written = static_cast<size_t>(0ULL);
 while (bytes_written < bytes_read){
-bytes_written += TRY((output_file->write(buffer.operator[](JaktInternal::Range<size_t>{static_cast<size_t>(bytes_written),static_cast<size_t>(bytes_read)}).to_array())));
+bytes_written += TRY((output_file->write(buffer[JaktInternal::Range<size_t>{static_cast<size_t>(bytes_written),static_cast<size_t>(bytes_read)}].to_array())));
 }
 if (bytes_written != bytes_read){
 return Error::__jakt_from_string_literal(StringView::from_string_literal("Failed to write to file"sv));
@@ -535,7 +536,7 @@ bool only_support_libs = false;
 bool target_links_ak = false;
 AK::Queue<ByteString> args_to_process = AK::Queue<ByteString>();
 {
-JaktInternal::ArrayIterator<ByteString> _magic = args.operator[](JaktInternal::Range<i64>{static_cast<i64>(static_cast<i64>(1LL)),static_cast<i64>(9223372036854775807LL)}).iterator();
+JaktInternal::ArrayIterator<ByteString> _magic = args[JaktInternal::Range<i64>{static_cast<i64>(static_cast<i64>(1LL)),static_cast<i64>(9223372036854775807LL)}].iterator();
 for (;;){
 JaktInternal::Optional<ByteString> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
@@ -551,75 +552,50 @@ args_to_process.enqueue(arg);
 
 while (!args_to_process.is_empty()){
 ByteString const arg = args_to_process.dequeue();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<int>> {
-auto __jakt_enum_value = (arg);
+{auto __jakt_enum_value = arg;
 if ((__jakt_enum_value == ByteString::from_utf8_without_validation("--target-triple"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("-T"sv))) {{
 target_triple = args_to_process.dequeue();
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--sysroot"sv)) {{
+goto __jakt_label_203;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--sysroot"sv)) {{
 sysroot = args_to_process.dequeue();
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--system-lib-dir"sv)) {{
+goto __jakt_label_203;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--system-lib-dir"sv)) {{
 system_lib_dirs.push(args_to_process.dequeue());
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--system-include-dir"sv)) {{
+goto __jakt_label_203;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--system-include-dir"sv)) {{
 system_include_dirs.push(args_to_process.dequeue());
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--compiler-include-dir"sv)) {{
+goto __jakt_label_203;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--compiler-include-dir"sv)) {{
 compiler_include_dir = args_to_process.dequeue();
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--compiler-lib-dir"sv)) {{
+goto __jakt_label_203;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--compiler-lib-dir"sv)) {{
 compiler_lib_dir = args_to_process.dequeue();
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--install-root"sv)) {{
+goto __jakt_label_203;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--install-root"sv)) {{
 install_root = args_to_process.dequeue();
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--runtime-lib-path"sv)) {{
+goto __jakt_label_203;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--runtime-lib-path"sv)) {{
 runtime_lib_path = Jakt::jakt__path::Path::from_string(args_to_process.dequeue());
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--runtime-path"sv)) {{
+goto __jakt_label_203;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--runtime-path"sv)) {{
 runtime_path = Jakt::jakt__path::Path::from_string(args_to_process.dequeue());
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--source-file"sv)) {{
+goto __jakt_label_203;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--source-file"sv)) {{
 source_file = args_to_process.dequeue();
 }
-return JaktInternal::ExplicitValue<void>();
-}else if ((__jakt_enum_value == ByteString::from_utf8_without_validation("--output-filename"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("-o"sv))) {{
+goto __jakt_label_203;}else if ((__jakt_enum_value == ByteString::from_utf8_without_validation("--output-filename"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("-o"sv))) {{
 output_filename = args_to_process.dequeue();
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--target-links-ak"sv)) {{
+goto __jakt_label_203;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--target-links-ak"sv)) {{
 target_links_ak = true;
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--only-support-libs"sv)) {{
+goto __jakt_label_203;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("--only-support-libs"sv)) {{
 only_support_libs = true;
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_203;}else {{
 compiler_args.push(arg);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_203;}}goto __jakt_label_203; __jakt_label_203:;;
 }
 if (!source_file.has_value() && (!only_support_libs)){
 warnln(StringView::from_string_literal("error: Expected --source_file to be passed"sv));
@@ -647,7 +623,7 @@ if (!runtime_lib_path.has_value()){
 runtime_lib_path = local_install_base_path.join(ByteString::from_utf8_without_validation("lib"sv)).join(TRY((TRY((Jakt::jakt__platform::Target::active())).name(false))));
 }
 Function<JaktInternal::DynamicArray<ByteString>()> const compiler_invocation_args = [&compiler_args, &abbreviated_triple, &sysroot, &compiler_include_dir, &compiler_lib_dir, &system_include_dirs, &system_lib_dirs, &runtime_lib_path, &runtime_path]() -> JaktInternal::DynamicArray<ByteString> {{
-JaktInternal::DynamicArray<ByteString> args = compiler_args.operator[](JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}).to_array();
+JaktInternal::DynamicArray<ByteString> args = compiler_args[JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}].to_array();
 args.push(ByteString::from_utf8_without_validation("--target-triple"sv));
 args.push(__jakt_format(StringView::from_string_literal("{}-unknown"sv),abbreviated_triple));
 if (sysroot.has_value()){
@@ -780,9 +756,9 @@ JaktInternal::DynamicArray<ByteString> const components = path.components();
 if (components.is_empty()){
 return {};
 }
-Jakt::jakt__path::Path current_path = Jakt::jakt__path::Path::from_string(components.operator[](static_cast<i64>(0LL)));
+Jakt::jakt__path::Path current_path = Jakt::jakt__path::Path::from_string(components[static_cast<i64>(0LL)]);
 {
-JaktInternal::ArrayIterator<ByteString> _magic = components.operator[](JaktInternal::Range<i64>{static_cast<i64>(static_cast<i64>(1LL)),static_cast<i64>(9223372036854775807LL)}).iterator();
+JaktInternal::ArrayIterator<ByteString> _magic = components[JaktInternal::Range<i64>{static_cast<i64>(static_cast<i64>(1LL)),static_cast<i64>(9223372036854775807LL)}].iterator();
 for (;;){
 JaktInternal::Optional<ByteString> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
@@ -866,16 +842,9 @@ Jakt::jakt__path::Path const current_executable_path = Jakt::jakt__path::Path::f
 Jakt::jakt__path::Path const install_base_path = current_executable_path.parent().parent();
 Jakt::jakt__path::Path const default_runtime_path = install_base_path.join(ByteString::from_utf8_without_validation("include/runtime"sv));
 Jakt::jakt__path::Path const default_runtime_library_path = install_base_path.join(ByteString::from_utf8_without_validation("lib"sv));
-ByteString const default_compiler_path = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<int>> {
-auto __jakt_enum_value = (false);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("clang-cl"sv));
-}else {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("clang++"sv));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const default_compiler_path = [&]() -> ByteString { auto __jakt_enum_value = false;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation("clang-cl"sv);}else {return ByteString::from_utf8_without_validation("clang++"sv);} 
+}();
 bool const optimize = TRY((args_parser.flag(DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("-O"sv)}))));
 bool const lexer_debug = TRY((args_parser.flag(DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("-dl"sv)}))));
 bool const parser_debug = TRY((args_parser.flag(DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("-dp"sv)}))));
@@ -934,32 +903,18 @@ break;
 ByteString spec = _magic_value.value();
 {
 JaktInternal::DynamicArray<ByteString> const parts = spec.split('=');
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<int>> {
-auto __jakt_enum_value = (parts.size());
+{auto __jakt_enum_value = parts.size();
 if (__jakt_enum_value == static_cast<size_t>(1ULL)) {{
-user_configuration.set(parts.operator[](static_cast<i64>(0LL)), ByteString::from_utf8_without_validation("true"sv));
+user_configuration.set(parts[static_cast<i64>(0LL)], ByteString::from_utf8_without_validation("true"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == static_cast<size_t>(2ULL)) {{
-user_configuration.set(parts.operator[](static_cast<i64>(0LL)), parts.operator[](static_cast<i64>(1LL)));
+goto __jakt_label_204;}else if (__jakt_enum_value == static_cast<size_t>(2ULL)) {{
+user_configuration.set(parts[static_cast<i64>(0LL)], parts[static_cast<i64>(1LL)]);
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_204;}else {{
 warnln(StringView::from_string_literal("error: invalid configuration specification: {}"sv),spec);
 return static_cast<int>(1);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_204;}}goto __jakt_label_204; __jakt_label_204:;;
 }
 
 }
@@ -1037,17 +992,10 @@ Jakt::jakt__path::Path const file_path = Jakt::jakt__path::Path::from_string(fil
 ByteString const guessed_output_filename = file_path.basename(true);
 ByteString const output_filename = binary_dir.join(set_output_filename.value_or_lazy_evaluated([&] { return guessed_output_filename; })).to_string();
 JaktInternal::DynamicArray<Jakt::error::JaktError> errors = DynamicArray<Jakt::error::JaktError>::create_with({});
-NonnullRefPtr<Jakt::compiler::Compiler> compiler = Jakt::compiler::Compiler::__jakt_create(DynamicArray<Jakt::jakt__path::Path>::create_with({}),Dictionary<ByteString, Jakt::utility::FileId>::create_with_entries({}),DynamicArray<Jakt::error::JaktError>::create_with({}),JaktInternal::OptionalNone(),DynamicArray<u8>::create_with({}),lexer_debug,parser_debug,false,debug_print,debug_print_cpp_import,Jakt::jakt__path::Path::from_parts(DynamicArray<ByteString>::create_with({runtime_path, ByteString::from_utf8_without_validation("jaktlib"sv)})),Jakt::jakt__path::Path::from_parts(DynamicArray<ByteString>::create_with({runtime_path, ByteString::from_utf8_without_validation("prelude.jakt"sv)})),extra_include_paths,json_errors,dump_type_hints,dump_try_hints,optimize,target_triple,user_configuration,binary_dir,exports_dir,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::jakt__path::Path>,ErrorOr<int>> {
-auto __jakt_enum_value = (assume_main_file_path.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<Jakt::jakt__path::Path>>(Jakt::jakt__path::Path::from_string(assume_main_file_path.value())));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),Set<ByteString>::create_with_values({}));
+NonnullRefPtr<Jakt::compiler::Compiler> compiler = Jakt::compiler::Compiler::__jakt_create(DynamicArray<Jakt::jakt__path::Path>::create_with({}),Dictionary<ByteString, Jakt::utility::FileId>::create_with_entries({}),DynamicArray<Jakt::error::JaktError>::create_with({}),JaktInternal::OptionalNone(),DynamicArray<u8>::create_with({}),lexer_debug,parser_debug,false,debug_print,debug_print_cpp_import,Jakt::jakt__path::Path::from_parts(DynamicArray<ByteString>::create_with({runtime_path, ByteString::from_utf8_without_validation("jaktlib"sv)})),Jakt::jakt__path::Path::from_parts(DynamicArray<ByteString>::create_with({runtime_path, ByteString::from_utf8_without_validation("prelude.jakt"sv)})),extra_include_paths,json_errors,dump_type_hints,dump_try_hints,optimize,target_triple,user_configuration,binary_dir,exports_dir,[&]() -> JaktInternal::Optional<Jakt::jakt__path::Path> { auto __jakt_enum_value = assume_main_file_path.has_value();
+if (__jakt_enum_value) {return static_cast<JaktInternal::Optional<Jakt::jakt__path::Path>>(Jakt::jakt__path::Path::from_string(assume_main_file_path.value()));}else if (!__jakt_enum_value) {return JaktInternal::OptionalNone();}VERIFY_NOT_REACHED();
+ 
+}(),Set<ByteString>::create_with_values({}));
 TRY((compiler->load_prelude()));
 if ((format || format_debug) || format_inplace){
 NonnullRefPtr<Jakt::jakt__file_iterator::RecursiveFileIterator> const directory_or_file_paths = TRY((Jakt::jakt__file_iterator::RecursiveFileIterator::make(file_path,ByteString::from_utf8_without_validation("jakt"sv))));
@@ -1168,7 +1116,7 @@ ByteString const function_name = jakt__function_name__overload_set__.template ge
 JaktInternal::DynamicArray<Jakt::ids::FunctionId> const overload_set = jakt__function_name__overload_set__.template get<1>();
 
 if (function_name == ByteString::from_utf8_without_validation("main"sv)){
-main_function_id = overload_set.operator[](static_cast<i64>(0LL));
+main_function_id = overload_set[static_cast<i64>(0LL)];
 break;
 }
 }
@@ -1199,9 +1147,7 @@ return static_cast<int>(1);
 JaktInternal::DynamicArray<Jakt::types::ResolvedNamespace> const namespace_ = DynamicArray<Jakt::types::ResolvedNamespace>::create_with({});
 Jakt::utility::Span const call_span = Jakt::utility::Span(Jakt::utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL));
 JaktInternal::Optional<Jakt::types::CheckedParameter> const first_main_param = checked_program->get_function(main_function_id.value())->params.first();
-JaktInternal::DynamicArray<Jakt::types::Value> const arguments = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::types::Value>,ErrorOr<int>> {
-auto __jakt_enum_value = (first_main_param.has_value());
+JaktInternal::DynamicArray<Jakt::types::Value> const arguments = [&]() -> JaktInternal::DynamicArray<Jakt::types::Value> { auto __jakt_enum_value = first_main_param.has_value();
 if (__jakt_enum_value) {{
 JaktInternal::DynamicArray<Jakt::types::Value> passed_arguments = DynamicArray<Jakt::types::Value>::create_with({Jakt::types::Value(Jakt::types::ValueImpl::JaktString(file_name.value()),call_span)});
 {
@@ -1219,73 +1165,49 @@ passed_arguments.push(Jakt::types::Value(Jakt::types::ValueImpl::JaktString(argu
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::DynamicArray<Jakt::types::Value>>(DynamicArray<Jakt::types::Value>::create_with({Jakt::types::Value(Jakt::types::ValueImpl::JaktArray(passed_arguments,first_main_param.value().variable->type_id),call_span)}));
+return DynamicArray<Jakt::types::Value>::create_with({Jakt::types::Value(Jakt::types::ValueImpl::JaktArray(passed_arguments,first_main_param.value().variable->type_id),call_span)});
 }
 VERIFY_NOT_REACHED();
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(DynamicArray<Jakt::types::Value>::create_with({}));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}else if (!__jakt_enum_value) {return DynamicArray<Jakt::types::Value>::create_with({});}VERIFY_NOT_REACHED();
+ 
+}();
 Jakt::interpreter::ExecutionResult const main_result = TRY((interpreter->execute(main_function_id.value(),namespace_,JaktInternal::OptionalNone(),arguments,call_span,JaktInternal::OptionalNone(),true)));
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<int>>{
-auto&& __jakt_match_variant = main_result;
+{auto&& __jakt_match_variant = main_result;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& x = __jakt_match_value.value;
-return ({({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<int>>{
-auto&& __jakt_match_variant = *x.impl;
+{auto&& __jakt_match_variant = *x.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 16 /* CInt */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CInt;int const& ret_val = __jakt_match_value.value;
 {
-return infallible_integer_cast<int>(ret_val);
+return static_cast<int>(ret_val);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_206;};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& ret_val = __jakt_match_value.value;
 {
 return infallible_integer_cast<int>(ret_val);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_206;};/*case end*/
 case 0 /* Void */:{
 return static_cast<int>(0);
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_206;default:{
 warnln(StringView::from_string_literal("Error: Main function  must return an integer"sv));
 return static_cast<int>(1);
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_206;}/*switch end*/
+}goto __jakt_label_206; __jakt_label_206:;;goto __jakt_label_205;};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& x = __jakt_match_value.value;
 {
 warnln(StringView::from_string_literal("Error: Main function  threw: {}"sv),TRY((Jakt::repl::serialize_ast_node(TRY((Jakt::interpreter::value_to_checked_expression(x,interpreter)))))));
 return static_cast<int>(1);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_205;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}goto __jakt_label_205; __jakt_label_205:;;
 }
 if (goto_def.has_value()){
 size_t const index = infallible_integer_cast<size_t>(goto_def.value().template to_number<u32>().value());
@@ -1673,17 +1595,10 @@ return static_cast<int>(1);
 }
 ;
 Jakt::jakt__path::Path const runtime_lib_path = Jakt::jakt__path::Path::from_string(runtime_library_path);
-Jakt::jakt__platform::Target const target = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::jakt__platform::Target,ErrorOr<int>> {
-auto __jakt_enum_value = (target_triple.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((Jakt::jakt__platform::Target::from_triple(target_triple.value()))));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((Jakt::jakt__platform::Target::active())));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+Jakt::jakt__platform::Target const target = TRY(([&]() -> ErrorOr<Jakt::jakt__platform::Target> { auto __jakt_enum_value = target_triple.has_value();
+if (__jakt_enum_value) {return Jakt::jakt__platform::Target::from_triple(target_triple.value());}else if (!__jakt_enum_value) {return Jakt::jakt__platform::Target::active();}VERIFY_NOT_REACHED();
+ 
+}()));
 if (link_archive.has_value()){
 JaktInternal::DynamicArray<ByteString> extra_arguments = DynamicArray<ByteString>::create_with({});
 if (archive_link_support_libs){
@@ -1833,9 +1748,7 @@ formatted_file.append(byte);
 }
 }
 
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = formatted_token.token;
+{auto&& __jakt_match_variant = formatted_token.token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 55 /* Eol */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eol;JaktInternal::Optional<ByteString> const& comment = __jakt_match_value.comment;
@@ -1845,40 +1758,17 @@ u8 next_char = static_cast<u8>(u8' ');
 if (comment.value().length() != static_cast<size_t>(0ULL)){
 next_char = comment.value().byte_at(static_cast<size_t>(0ULL));
 }
-ByteString const space = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (next_char);
-if ((__jakt_enum_value == static_cast<u8>(u8' '))||(__jakt_enum_value == static_cast<u8>(u8'\t'))||(__jakt_enum_value == static_cast<u8>(u8'/'))) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}else {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(" "sv));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
-ByteString const lhs_space = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>> {
-auto __jakt_enum_value = (on_new_line);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::indent(formatted_token.indent));
-}else {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(" "sv));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+ByteString const space = [&]() -> ByteString { auto __jakt_enum_value = next_char;
+if ((__jakt_enum_value == static_cast<u8>(u8' '))||(__jakt_enum_value == static_cast<u8>(u8'\t'))||(__jakt_enum_value == static_cast<u8>(u8'/'))) {return ByteString::from_utf8_without_validation(""sv);}else {return ByteString::from_utf8_without_validation(" "sv);} 
+}();
+ByteString const lhs_space = [&]() -> ByteString { auto __jakt_enum_value = on_new_line;
+if (__jakt_enum_value) {return Jakt::indent(formatted_token.indent);}else {return ByteString::from_utf8_without_validation(" "sv);} 
+}();
 formatted_file.appendff(ByteString::from_utf8_without_validation("{}//{}{}"sv),lhs_space,space,comment.value());
 }
 on_new_line = true;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_207;};/*case end*/
 case 114 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;JaktInternal::Optional<ByteString> const& consumed = __jakt_match_value.consumed;
 {
@@ -1886,8 +1776,7 @@ if (consumed.has_value()){
 formatted_file.appendff(ByteString::from_utf8_without_validation("{}"sv),consumed.value());
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_207;};/*case end*/
 default:{
 if (on_new_line){
 formatted_file.appendff(ByteString::from_utf8_without_validation("{}"sv),Jakt::indent(formatted_token.indent));
@@ -1895,18 +1784,8 @@ formatted_file.appendff(ByteString::from_utf8_without_validation("{}"sv),Jakt::i
 formatted_file.appendff(ByteString::from_utf8_without_validation("{}"sv),TRY((formatted_token.token_text())));
 on_new_line = false;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_207;}/*switch end*/
+break;}goto __jakt_label_207; __jakt_label_207:;;
 {
 JaktInternal::ArrayIterator<u8> _magic = formatted_token.trailing_trivia.iterator();
 for (;;){

--- a/bootstrap/stage0/parser.cpp
+++ b/bootstrap/stage0/parser.cpp
@@ -90,9 +90,7 @@ void Jakt::parser::ParsedModuleImport::merge_import_list(Jakt::parser::ImportLis
 {
 JaktInternal::Set<ByteString> name_set = Set<ByteString>::create_with_values({});
 bool everything = false;
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, void>{
-auto&& __jakt_match_variant = this->import_list;
+{auto&& __jakt_match_variant = this->import_list;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* List */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.List;JaktInternal::DynamicArray<Jakt::parser::ImportName> const& names = __jakt_match_value.value;
@@ -113,23 +111,14 @@ name_set.add(name.literal_name());
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_7;};/*case end*/
 case 1 /* All */:{
 everything = true;
 }
-return JaktInternal::ExplicitValue<void>();
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_7;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_7; __jakt_label_7:;;
 if (!everything){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, void>{
-auto&& __jakt_match_variant = list;
+{auto&& __jakt_match_variant = list;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* List */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.List;JaktInternal::DynamicArray<Jakt::parser::ImportName> const& names = __jakt_match_value.value;
@@ -152,19 +141,12 @@ this->import_list.add(name);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_8;};/*case end*/
 case 1 /* All */:{
 everything = true;
 }
-return JaktInternal::ExplicitValue<void>();
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_8;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_8; __jakt_label_8:;;
 }
 if (everything){
 this->import_list = Jakt::parser::ImportList::All();
@@ -541,7 +523,7 @@ break;
 }
 size_t param_index = _magic_value.value();
 {
-if (!this->params.operator[](param_index).equals(other.params.operator[](param_index))){
+if (!this->params[param_index].equals(other.params[param_index])){
 return false;
 }
 }
@@ -669,7 +651,7 @@ break;
 }
 size_t x = _magic_value.value();
 {
-if (!this->stmts.operator[](x)->equals(rhs_block.stmts.operator[](x))){
+if (!this->stmts[x]->equals(rhs_block.stmts[x])){
 return false;
 }
 }
@@ -850,7 +832,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (!this->patterns.operator[](i).is_equal_pattern(rhs_match_case.patterns.operator[](i))){
+if (!this->patterns[i].is_equal_pattern(rhs_match_case.patterns[i])){
 return false;
 }
 }
@@ -879,7 +861,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (!this->patterns.operator[](i).equals(rhs_match_case.patterns.operator[](i))){
+if (!this->patterns[i].equals(rhs_match_case.patterns[i])){
 return false;
 }
 }
@@ -1011,12 +993,12 @@ break;
 }
 size_t i = _magic_value.value();
 {
-JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const lhs_str___lhs_expr_ = this->args.operator[](i);
+JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const lhs_str___lhs_expr_ = this->args[i];
 ByteString const lhs_str = lhs_str___lhs_expr_.template get<0>();
 Jakt::utility::Span const _ = lhs_str___lhs_expr_.template get<1>();
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const lhs_expr = lhs_str___lhs_expr_.template get<2>();
 
-JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const rhs_str____rhs_expr_ = rhs_parsed_call.args.operator[](i);
+JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const rhs_str____rhs_expr_ = rhs_parsed_call.args[i];
 ByteString const rhs_str = rhs_str____rhs_expr_.template get<0>();
 Jakt::utility::Span const __ = rhs_str____rhs_expr_.template get<1>();
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const rhs_expr = rhs_str____rhs_expr_.template get<2>();
@@ -1157,7 +1139,7 @@ return this->index >= JaktInternal::checked_sub(this->tokens.size(),static_cast<
 
 bool Jakt::parser::Parser::eol() const {
 {
-return this->eof() || (this->tokens.operator[](this->index).__jakt_init_index() == 55 /* Eol */);
+return this->eof() || (this->tokens[this->index].__jakt_init_index() == 55 /* Eol */);
 }
 }
 
@@ -1166,7 +1148,7 @@ Jakt::lexer::Token Jakt::parser::Parser::peek(size_t const steps) const {
 if (this->eof() || (JaktInternal::checked_add(steps,this->index) >= this->tokens.size())){
 return this->tokens.last().value();
 }
-return this->tokens.operator[](JaktInternal::checked_add(this->index,steps));
+return this->tokens[JaktInternal::checked_add(this->index,steps)];
 }
 }
 
@@ -1175,7 +1157,7 @@ Jakt::lexer::Token Jakt::parser::Parser::previous() const {
 if ((this->index == static_cast<size_t>(0ULL)) || (this->index > this->tokens.size())){
 return Jakt::lexer::Token::Eof(this->span(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL)));
 }
-return this->tokens.operator[](JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL)));
+return this->tokens[JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL))];
 }
 }
 
@@ -1208,93 +1190,72 @@ while (!this->eof()){
 if (process_only_one_entity && saw_an_entity){
 break;
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, Jakt::parser::ParsedNamespace>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 113 /* Trait */:{
 if (!active_attributes.is_empty()){
-this->error(ByteString::from_utf8_without_validation("Cannot apply attributes to trait declarations"sv),active_attributes.operator[](static_cast<i64>(0LL)).span);
+this->error(ByteString::from_utf8_without_validation("Cannot apply attributes to trait declarations"sv),active_attributes[static_cast<i64>(0LL)].span);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 }
 this->index++;
 parsed_namespace.traits.push(this->parse_trait());
 saw_an_entity = true;
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* Identifier */: {
+goto __jakt_label_9;case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
-return ({({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,Jakt::parser::ParsedNamespace> {
-auto __jakt_enum_value = (name);
+{auto __jakt_enum_value = name;
 if (__jakt_enum_value == ByteString::from_utf8_without_validation("type"sv)) {{
 if (!active_attributes.is_empty()){
-this->error(ByteString::from_utf8_without_validation("Cannot apply attributes to external trait declarations"sv),active_attributes.operator[](static_cast<i64>(0LL)).span);
+this->error(ByteString::from_utf8_without_validation("Cannot apply attributes to external trait declarations"sv),active_attributes[static_cast<i64>(0LL)].span);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 }
 this->index++;
 parsed_namespace.external_trait_implementations.push(this->parse_external_trait_implementation());
 saw_an_entity = true;
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("use"sv)) {{
+goto __jakt_label_10;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("use"sv)) {{
 if (!active_attributes.is_empty()){
-this->error(ByteString::from_utf8_without_validation("Cannot apply attributes to use declarations"sv),active_attributes.operator[](static_cast<i64>(0LL)).span);
+this->error(ByteString::from_utf8_without_validation("Cannot apply attributes to use declarations"sv),active_attributes[static_cast<i64>(0LL)].span);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 }
 this->index++;
 parsed_namespace.aliases.push(this->parse_using());
 saw_an_entity = true;
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("forall"sv)) {{
+goto __jakt_label_10;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("forall"sv)) {{
 if (!active_attributes.is_empty()){
-this->error(ByteString::from_utf8_without_validation("Cannot apply attributes to forall declarations"sv),active_attributes.operator[](static_cast<i64>(0LL)).span);
+this->error(ByteString::from_utf8_without_validation("Cannot apply attributes to forall declarations"sv),active_attributes[static_cast<i64>(0LL)].span);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 }
 this->index++;
 parsed_namespace.forall_chunks.push(this->parse_forall());
 saw_an_entity = true;
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_10;}else {{
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 this->error(ByteString::from_utf8_without_validation("Unexpected token (expected keyword)"sv),this->current().span());
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_10;}}goto __jakt_label_10; __jakt_label_10:;;goto __jakt_label_9;};/*case end*/
 case 73 /* Export */:{
 if (!active_attributes.is_empty()){
-this->error(ByteString::from_utf8_without_validation("Cannot apply attributes to exports"sv),active_attributes.operator[](static_cast<i64>(0LL)).span);
+this->error(ByteString::from_utf8_without_validation("Cannot apply attributes to exports"sv),active_attributes[static_cast<i64>(0LL)].span);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 }
 this->index++;
 this->parse_export(parsed_namespace);
 saw_an_entity = true;
 }
-return JaktInternal::ExplicitValue<void>();
-case 79 /* Import */:{
+goto __jakt_label_9;case 79 /* Import */:{
 if (!active_attributes.is_empty()){
-this->error(ByteString::from_utf8_without_validation("Cannot apply attributes to imports"sv),active_attributes.operator[](static_cast<i64>(0LL)).span);
+this->error(ByteString::from_utf8_without_validation("Cannot apply attributes to imports"sv),active_attributes[static_cast<i64>(0LL)].span);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 }
 this->index++;
 this->parse_import(parsed_namespace);
 saw_an_entity = true;
 }
-return JaktInternal::ExplicitValue<void>();
-case 11 /* LSquare */:{
+goto __jakt_label_9;case 11 /* LSquare */:{
 if (this->peek(static_cast<size_t>(1ULL)).__jakt_init_index() == 11 /* LSquare */){
 this->index += static_cast<size_t>(2ULL);
 this->parse_attribute_list(active_attributes);
@@ -1305,8 +1266,7 @@ this->index += static_cast<size_t>(1ULL);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-case 105 /* Unsafe */:{
+goto __jakt_label_9;case 105 /* Unsafe */:{
 this->index++;
 if (this->current().__jakt_init_index() == 76 /* Fn */){
 Jakt::parser::ParsedFunction parsed_function = this->parse_function(Jakt::parser::FunctionLinkage::Internal(),Jakt::parser::Visibility::Public(),this->current().__jakt_init_index() == 77 /* Comptime */,false,true,false);
@@ -1320,50 +1280,36 @@ this->error(ByteString::from_utf8_without_validation("Expected 'fn' after 'unsaf
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-case 76 /* Fn */:case 77 /* Comptime */:{
+goto __jakt_label_9;case 76 /* Fn */:case 77 /* Comptime */:{
 Jakt::parser::ParsedFunction parsed_function = this->parse_function(Jakt::parser::FunctionLinkage::Internal(),Jakt::parser::Visibility::Public(),this->current().__jakt_init_index() == 77 /* Comptime */,false,false,false);
 this->apply_attributes(parsed_function,active_attributes);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 parsed_namespace.functions.push(parsed_function);
 saw_an_entity = true;
 }
-return JaktInternal::ExplicitValue<void>();
-case 99 /* Struct */:case 65 /* Class */:case 71 /* Enum */:case 62 /* Boxed */:{
+goto __jakt_label_9;case 99 /* Struct */:case 65 /* Class */:case 71 /* Enum */:case 62 /* Boxed */:{
 Jakt::parser::ParsedRecord parsed_record = this->parse_record(Jakt::parser::DefinitionLinkage::Internal());
 this->apply_attributes(parsed_record,active_attributes);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 parsed_namespace.records.push(parsed_record);
 saw_an_entity = true;
 }
-return JaktInternal::ExplicitValue<void>();
-case 88 /* Namespace */:{
+goto __jakt_label_9;case 88 /* Namespace */:{
 this->index++;
-JaktInternal::Optional<JaktInternal::Tuple<ByteString,Jakt::utility::Span>> const name = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>, Jakt::parser::ParsedNamespace>{
-auto&& __jakt_match_variant = this->current();
+JaktInternal::Optional<JaktInternal::Tuple<ByteString,Jakt::utility::Span>> const name = [&]() -> JaktInternal::Optional<JaktInternal::Tuple<ByteString,Jakt::utility::Span>> { auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->index++;
-return JaktInternal::ExplicitValue<JaktInternal::Optional<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>(static_cast<JaktInternal::Optional<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>(Tuple{name, span}));
+return static_cast<JaktInternal::Optional<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>(Tuple{name, span});
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+default:return JaktInternal::OptionalNone();}/*switch end*/
+ 
+}();
 this->skip_newlines();
 if (this->current().__jakt_init_index() == 9 /* LCurly */){
 this->index++;
@@ -1389,12 +1335,9 @@ active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({})
 parsed_namespace.add_child_namespace(namespace_);
 saw_an_entity = true;
 }
-return JaktInternal::ExplicitValue<void>();
-case 72 /* Extern */:{
+goto __jakt_label_9;case 72 /* Extern */:{
 this->index++;
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, Jakt::parser::ParsedNamespace>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 105 /* Unsafe */:{
 this->index++;
@@ -1410,81 +1353,53 @@ this->error(ByteString::from_utf8_without_validation("Expected 'fn' after 'unsaf
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-case 76 /* Fn */:{
+goto __jakt_label_11;case 76 /* Fn */:{
 Jakt::parser::ParsedFunction parsed_function = this->parse_function(Jakt::parser::FunctionLinkage::External(),Jakt::parser::Visibility::Public(),false,false,false,false);
 this->apply_attributes(parsed_function,active_attributes);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 parsed_namespace.functions.push(parsed_function);
 saw_an_entity = true;
 }
-return JaktInternal::ExplicitValue<void>();
-case 99 /* Struct */:{
+goto __jakt_label_11;case 99 /* Struct */:{
 Jakt::parser::ParsedRecord parsed_struct = this->parse_struct(Jakt::parser::DefinitionLinkage::External());
 this->apply_attributes(parsed_struct,active_attributes);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 parsed_namespace.records.push(parsed_struct);
 saw_an_entity = true;
 }
-return JaktInternal::ExplicitValue<void>();
-case 65 /* Class */:{
+goto __jakt_label_11;case 65 /* Class */:{
 Jakt::parser::ParsedRecord parsed_class = this->parse_class(Jakt::parser::DefinitionLinkage::External());
 this->apply_attributes(parsed_class,active_attributes);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 parsed_namespace.records.push(parsed_class);
 saw_an_entity = true;
 }
-return JaktInternal::ExplicitValue<void>();
-case 71 /* Enum */:{
+goto __jakt_label_11;case 71 /* Enum */:{
 Jakt::parser::ParsedRecord parsed_enum = this->parse_enum(Jakt::parser::DefinitionLinkage::External(),false);
 this->apply_attributes(parsed_enum,active_attributes);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 parsed_namespace.records.push(parsed_enum);
 saw_an_entity = true;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_11;default:{
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 this->error(ByteString::from_utf8_without_validation("Unexpected keyword"sv),this->current().span());
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+goto __jakt_label_11;}/*switch end*/
+break;}goto __jakt_label_11; __jakt_label_11:;;
 }
-return JaktInternal::ExplicitValue<void>();
-case 55 /* Eol */:{
+goto __jakt_label_9;case 55 /* Eol */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 10 /* RCurly */:{
-return JaktInternal::LoopBreak{};
+goto __jakt_label_9;case 10 /* RCurly */:{
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_9;default:{
 this->error(ByteString::from_utf8_without_validation("Unexpected token (expected keyword)"sv),this->current().span());
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_9;}/*switch end*/
+break;}goto __jakt_label_9; __jakt_label_9:;;
 }
 return parsed_namespace;
 }
@@ -1501,9 +1416,7 @@ break;
 }
 Jakt::parser::ParsedAttribute attribute = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,void> {
-auto __jakt_enum_value = (attribute.name);
+{auto __jakt_enum_value = attribute.name;
 if (__jakt_enum_value == ByteString::from_utf8_without_validation("extern_import"sv)) {{
 if (!attribute.assigned_value.has_value()){
 {
@@ -1515,22 +1428,19 @@ break;
 }
 Jakt::parser::ParsedAttributeArgument argument = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,void> {
-auto __jakt_enum_value = (argument.name);
+{auto __jakt_enum_value = argument.name;
 if (__jakt_enum_value == ByteString::from_utf8_without_validation("from"sv)) {{
 namespace_.import_path_if_extern = argument.assigned_value;
 }
-return JaktInternal::ExplicitValue<void>();
-}else if ((__jakt_enum_value == ByteString::from_utf8_without_validation("define_before"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("undefine_before"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("define_after"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("undefine_after"sv))) {{
+goto __jakt_label_13;}else if ((__jakt_enum_value == ByteString::from_utf8_without_validation("define_before"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("undefine_before"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("define_after"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("undefine_after"sv))) {{
 if (argument.assigned_value.has_value()){
 if (argument.name.starts_with(ByteString::from_utf8_without_validation("define"sv))){
 JaktInternal::DynamicArray<ByteString> const parts = argument.assigned_value.value().split('=');
 if (parts.size() != static_cast<size_t>(2ULL)){
 this->error(__jakt_format(StringView::from_string_literal("The argument '{}' expects a value in the form 'name=value'"sv),argument.name),argument.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
-Jakt::parser::IncludeAction const action = Jakt::parser::IncludeAction::Define(parts.operator[](static_cast<i64>(0LL)),attribute.span,parts.operator[](static_cast<i64>(1LL)));
+Jakt::parser::IncludeAction const action = Jakt::parser::IncludeAction::Define(parts[static_cast<i64>(0LL)],attribute.span,parts[static_cast<i64>(1LL)]);
 if (argument.name.ends_with(ByteString::from_utf8_without_validation("before"sv))){
 namespace_.generating_import_extern_before_include.push(action);
 }
@@ -1553,25 +1463,14 @@ namespace_.generating_import_extern_after_include.push(action);
 }
 else {
 this->error(__jakt_format(StringView::from_string_literal("The argument '{}' expects a value"sv),argument.name),argument.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_13;}else {{
 this->error(__jakt_format(StringView::from_string_literal("Invalid argument for attribute '{}'"sv),attribute.name),argument.span);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return {};
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_13;}}goto __jakt_label_13; __jakt_label_13:;;
 }
 
 }
@@ -1580,36 +1479,24 @@ return JaktInternal::ExplicitValue<void>();
 }
 else {
 this->error(__jakt_format(StringView::from_string_literal("The attribute '{}' does not take a value"sv),attribute.name),attribute.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("generated"sv)) {{
+goto __jakt_label_12;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("generated"sv)) {{
 if (!attribute.assigned_value.has_value()){
 namespace_.is_generated_code = true;
 }
 else {
 this->error(__jakt_format(StringView::from_string_literal("The attribute '{}' does not take a value"sv),attribute.name),attribute.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_12;}else {{
 this->error(__jakt_format(StringView::from_string_literal("The attribute '{}' does not apply to namespaces"sv),attribute.name),attribute.span);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_12;}}goto __jakt_label_12; __jakt_label_12:;;
 }
 
 }
@@ -1629,14 +1516,12 @@ break;
 }
 Jakt::parser::ParsedAttribute attribute = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,void> {
-auto __jakt_enum_value = (attribute.name);
+{auto __jakt_enum_value = attribute.name;
 if (__jakt_enum_value == ByteString::from_utf8_without_validation("name"sv)) {{
 if (attribute.assigned_value.has_value()){
 if (field.var_decl.external_name.has_value()){
 this->error(__jakt_format(StringView::from_string_literal("The attribute '{}' cannot be applied more than once"sv),attribute.name),attribute.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
 if (attribute.assigned_value.value().starts_with(ByteString::from_utf8_without_validation("operator("sv)) && attribute.assigned_value.value().ends_with(ByteString::from_utf8_without_validation(")"sv))){
 ByteString const operator_name = attribute.assigned_value.value().substring(static_cast<size_t>(9ULL),JaktInternal::checked_sub(attribute.assigned_value.value().length(),static_cast<size_t>(10ULL)));
@@ -1653,25 +1538,14 @@ field.var_decl.external_name = Jakt::parser::ExternalName::Plain(attribute.assig
 }
 else {
 this->error(__jakt_format(StringView::from_string_literal("The attribute '{}' requires a value"sv),attribute.name),attribute.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_14;}else {{
 this->error(__jakt_format(StringView::from_string_literal("The attribute '{}' does not apply to fields"sv),attribute.name),attribute.span);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_14;}}goto __jakt_label_14; __jakt_label_14:;;
 }
 
 }
@@ -1691,14 +1565,12 @@ break;
 }
 Jakt::parser::ParsedAttribute attribute = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,void> {
-auto __jakt_enum_value = (attribute.name);
+{auto __jakt_enum_value = attribute.name;
 if (__jakt_enum_value == ByteString::from_utf8_without_validation("name"sv)) {{
 if (attribute.assigned_value.has_value()){
 if (parsed_function.external_name.has_value()){
 this->error(__jakt_format(StringView::from_string_literal("The attribute '{}' cannot be applied more than once"sv),attribute.name),attribute.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
 if (!parsed_function.is_raw_constructor){
 if (attribute.assigned_value.value().starts_with(ByteString::from_utf8_without_validation("operator("sv)) && attribute.assigned_value.value().ends_with(ByteString::from_utf8_without_validation(")"sv))){
@@ -1716,34 +1588,32 @@ parsed_function.external_name = Jakt::parser::ExternalName::Plain(attribute.assi
 }
 else {
 this->error(ByteString::from_utf8_without_validation("A raw constructor cannot have an external name"sv),attribute.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
 
 }
 else {
 this->error(__jakt_format(StringView::from_string_literal("The attribute '{}' requires a value"sv),attribute.name),attribute.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("deprecated"sv)) {{
+goto __jakt_label_15;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("deprecated"sv)) {{
 if (parsed_function.deprecated_message.has_value()){
 this->error(__jakt_format(StringView::from_string_literal("The attribute '{}' cannot be applied more than once"sv),attribute.name),attribute.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
 ByteString const message = attribute.arguments.first().map([](auto& _value) { return _value.name; }).value_or_lazy_evaluated([&] { return __jakt_format(StringView::from_string_literal("The function '{}' is marked as deprecated"sv),parsed_function.name); });
 parsed_function.deprecated_message = message;
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("inline"sv)) {{
+goto __jakt_label_15;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("inline"sv)) {{
 if (!(parsed_function.force_inline.__jakt_init_index() == 0 /* Default */)){
 this->error(__jakt_format(StringView::from_string_literal("The attribute '{}' cannot be applied more than once"sv),attribute.name),attribute.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
 Jakt::parser::InlineState const inline_state = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::InlineState,void> {
-auto __jakt_enum_value = (attribute.arguments.first().map([](auto& _value) { return _value.name; }).value_or_lazy_evaluated([&] { return ByteString::from_utf8_without_validation(""sv); }));
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::InlineState, void>{
+auto __jakt_enum_value = attribute.arguments.first().map([](auto& _value) { return _value.name; }).value_or_lazy_evaluated([&] { return ByteString::from_utf8_without_validation(""sv); });
 if (__jakt_enum_value == ByteString::from_utf8_without_validation("never"sv)) {return JaktInternal::ExplicitValue(Jakt::parser::InlineState::Default());
 }else if ((__jakt_enum_value == ByteString::from_utf8_without_validation(""sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("always"sv))) {return JaktInternal::ExplicitValue(Jakt::parser::InlineState::ForceInline());
 }else if (__jakt_enum_value == ByteString::from_utf8_without_validation("make_available"sv)) {return JaktInternal::ExplicitValue(Jakt::parser::InlineState::MakeDefinitionAvailable());
@@ -1751,19 +1621,19 @@ if (__jakt_enum_value == ByteString::from_utf8_without_validation("never"sv)) {r
 this->error(__jakt_format(StringView::from_string_literal("Invalid argument for attribute '{}'"sv),attribute.name),attribute.span);
 return JaktInternal::LoopContinue{};
 }
-}}());
+}}()
+);
     if (_jakt_value.is_return())
-        return {};
+        return _jakt_value.release_return();
     if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
+        break;
     if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
+        continue;
     _jakt_value.release_value();
 });
 parsed_function.force_inline = inline_state;
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("stores_arguments"sv)) {{
+goto __jakt_label_15;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("stores_arguments"sv)) {{
 JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,Jakt::parser::ArgumentStoreLevel>> stores_arguments = DynamicArray<JaktInternal::Tuple<size_t,Jakt::parser::ArgumentStoreLevel>>::create_with({});
 {
 JaktInternal::ArrayIterator<Jakt::parser::ParsedAttributeArgument> _magic = attribute.arguments.iterator();
@@ -1816,21 +1686,10 @@ continue;
 }
 JaktInternal::Tuple<size_t,Jakt::parser::ArgumentStoreLevel> entry = Tuple{name_index.value(), Jakt::parser::ArgumentStoreLevel::InStaticStorage()};
 if (target.has_value()){
-entry.template get<1>() = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::ArgumentStoreLevel,void> {
-auto __jakt_enum_value = (targets_return);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::parser::ArgumentStoreLevel::InReturnValue());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::parser::ArgumentStoreLevel::InObject(target_index.value()));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return {};
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+entry.template get<1>() = [&]() -> Jakt::parser::ArgumentStoreLevel { auto __jakt_enum_value = targets_return;
+if (__jakt_enum_value) {return Jakt::parser::ArgumentStoreLevel::InReturnValue();}else if (!__jakt_enum_value) {return Jakt::parser::ArgumentStoreLevel::InObject(target_index.value());}VERIFY_NOT_REACHED();
+ 
+}();
 }
 stores_arguments.push(entry);
 }
@@ -1846,33 +1705,21 @@ parsed_function.stores_arguments = stores_arguments;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("raw_constructor"sv)) {{
+goto __jakt_label_15;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("raw_constructor"sv)) {{
 if (parsed_function.is_raw_constructor){
 this->error(__jakt_format(StringView::from_string_literal("The attribute '{}' cannot be applied more than once"sv),attribute.name),attribute.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
 if (parsed_function.external_name.has_value()){
 this->error(ByteString::from_utf8_without_validation("A raw constructor cannot have an external name"sv),attribute.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
 parsed_function.is_raw_constructor = true;
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_15;}else {{
 this->error(__jakt_format(StringView::from_string_literal("The attribute '{}' does not apply to functions"sv),attribute.name),attribute.span);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_15;}}goto __jakt_label_15; __jakt_label_15:;;
 }
 
 }
@@ -1898,57 +1745,43 @@ break;
 }
 Jakt::parser::ParsedAttribute attribute = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,void> {
-auto __jakt_enum_value = (attribute.name);
+{auto __jakt_enum_value = attribute.name;
 if (__jakt_enum_value == ByteString::from_utf8_without_validation("name"sv)) {{
 if (attribute.assigned_value.has_value()){
 if (parsed_record.external_name.has_value()){
 this->error(__jakt_format(StringView::from_string_literal("The attribute '{}' cannot be applied more than once"sv),attribute.name),attribute.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
 if (attribute.assigned_value.value().starts_with(ByteString::from_utf8_without_validation("operator("sv)) && attribute.assigned_value.value().ends_with(ByteString::from_utf8_without_validation(")"sv))){
 this->error(ByteString::from_utf8_without_validation("A record cannot be renamed to an operator"sv),attribute.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
 parsed_record.external_name = Jakt::parser::ExternalName::Plain(attribute.assigned_value.value());
 }
 else {
 this->error(__jakt_format(StringView::from_string_literal("The attribute '{}' requires a value"sv),attribute.name),attribute.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("create_function"sv)) {{
+goto __jakt_label_16;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("create_function"sv)) {{
 if (attribute.assigned_value.has_value()){
 if (parsed_record.create_function_name.has_value()){
 this->error(__jakt_format(StringView::from_string_literal("The attribute '{}' cannot be applied more than once"sv),attribute.name),attribute.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
 parsed_record.create_function_name = attribute.assigned_value.value();
 }
 else {
 this->error(__jakt_format(StringView::from_string_literal("The attribute '{}' requires a value"sv),attribute.name),attribute.span);
-return JaktInternal::LoopContinue{};
+continue;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_16;}else {{
 this->error(__jakt_format(StringView::from_string_literal("The attribute '{}' does not apply to records"sv),attribute.name),attribute.span);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_16;}}goto __jakt_label_16; __jakt_label_16:;;
 }
 
 }
@@ -2116,43 +1949,37 @@ this->error(ByteString::from_utf8_without_validation("Expected ‘)’"sv),this-
 JaktInternal::Optional<ByteString> assigned_value = JaktInternal::OptionalNone();
 if (this->current().__jakt_init_index() == 16 /* Equal */){
 this->index++;
-assigned_value = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>, JaktInternal::Optional<Jakt::parser::ParsedAttribute>>{
-auto&& __jakt_match_variant = this->current();
+assigned_value = [&]() -> JaktInternal::Optional<ByteString> { auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
 {
 this->index++;
-return JaktInternal::ExplicitValue<JaktInternal::Optional<ByteString>>(static_cast<JaktInternal::Optional<ByteString>>(name));
+return static_cast<JaktInternal::Optional<ByteString>>(name);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 100 /* This */:{
 this->index++;
-return JaktInternal::ExplicitValue<JaktInternal::Optional<ByteString>>(ByteString::from_utf8_without_validation("this"sv));
+return ByteString::from_utf8_without_validation("this"sv);
 }
 VERIFY_NOT_REACHED();
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;ByteString const& quote = __jakt_match_value.quote;
 {
 this->index++;
-return JaktInternal::ExplicitValue<JaktInternal::Optional<ByteString>>(static_cast<JaktInternal::Optional<ByteString>>(quote));
+return static_cast<JaktInternal::Optional<ByteString>>(quote);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
 this->error(ByteString::from_utf8_without_validation("Expected identifier or string literal"sv),this->current().span());
-return JaktInternal::ExplicitValue<JaktInternal::Optional<ByteString>>(JaktInternal::OptionalNone());
+return JaktInternal::OptionalNone();
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 }
 return Jakt::parser::ParsedAttribute(name,span,assigned_value,arguments);
 }
@@ -2162,20 +1989,16 @@ Jakt::parser::ParsedAlias Jakt::parser::Parser::parse_using() {
 {
 Jakt::parser::ParsedAlias alias = Jakt::parser::ParsedAlias(JaktInternal::OptionalNone(),DynamicArray<Jakt::parser::ParsedNameWithGenericParameters>::create_with({}));
 for (;;){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, Jakt::parser::ParsedAlias>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 55 /* Eol */:case 61 /* As */:case 56 /* Eof */:{
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 6 /* ColonColon */:{
+goto __jakt_label_17;case 6 /* ColonColon */:{
 this->index++;
-return JaktInternal::LoopContinue{};
+continue;
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* Identifier */: {
+goto __jakt_label_17;case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
@@ -2184,943 +2007,808 @@ this->index++;
 if (this->current().__jakt_init_index() == 28 /* LessThan */){
 this->index++;
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, Jakt::parser::ParsedAlias>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 26 /* GreaterThan */:{
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 52 /* Comma */:case 55 /* Eol */:{
+goto __jakt_label_18;case 52 /* Comma */:case 55 /* Eol */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 33 /* RightShift */:{
+goto __jakt_label_18;case 33 /* RightShift */:{
 this->inject_token(Jakt::lexer::Token::GreaterThan(this->current().span()));
 this->index += static_cast<size_t>(1ULL);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_18;default:{
 size_t const index_before = this->index;
 NonnullRefPtr<typename Jakt::parser::ParsedType> const inner_type = this->parse_typename();
 if (index_before == this->index){
 this->error(ByteString::from_utf8_without_validation("Expected type name"sv),this->current().span());
-return JaktInternal::LoopBreak{};
+break;
 }
 parsed_name.generic_parameters.push(inner_type);
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_18;}/*switch end*/
+break;}goto __jakt_label_18; __jakt_label_18:;;
 }
 }
 alias.target.push(parsed_name);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 4 /* Semicolon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Semicolon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 5 /* Colon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Colon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 7 /* LParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LParen;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 8 /* RParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RParen;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 9 /* LCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LCurly;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 10 /* RCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RCurly;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 11 /* LSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LSquare;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 12 /* RSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RSquare;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 13 /* PercentSign */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSign;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 14 /* Plus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Plus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 15 /* Minus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Minus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 16 /* Equal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Equal;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 17 /* PlusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 18 /* PlusPlus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusPlus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 19 /* MinusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 20 /* MinusMinus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusMinus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 21 /* AsteriskEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AsteriskEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 22 /* ForwardSlashEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlashEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 23 /* PercentSignEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSignEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 24 /* NotEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NotEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 25 /* DoubleEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DoubleEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 26 /* GreaterThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThan;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 27 /* GreaterThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThanOrEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 28 /* LessThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThan;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 29 /* LessThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThanOrEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 30 /* LeftArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftArithmeticShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 31 /* LeftShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 32 /* LeftShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShiftEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 33 /* RightShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 34 /* RightArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightArithmeticShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 35 /* RightShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShiftEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 36 /* Asterisk */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Asterisk;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 37 /* Ampersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Ampersand;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 38 /* AmpersandEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 39 /* AmpersandAmpersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandAmpersand;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 40 /* Pipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Pipe;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 41 /* PipeEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipeEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 42 /* PipePipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipePipe;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 43 /* Caret */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Caret;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 44 /* CaretEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CaretEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 45 /* Dollar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dollar;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 46 /* Tilde */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Tilde;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 47 /* ForwardSlash */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlash;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 48 /* ExclamationPoint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ExclamationPoint;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 49 /* QuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMark;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 50 /* QuestionMarkQuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMark;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 51 /* QuestionMarkQuestionMarkEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMarkEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 52 /* Comma */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comma;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 54 /* DotDot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DotDot;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 57 /* FatArrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.FatArrow;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 58 /* Arrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Arrow;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 59 /* And */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.And;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 60 /* Anon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Anon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 62 /* Boxed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boxed;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 63 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 64 /* Catch */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Catch;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 65 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 66 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 67 /* Cpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Cpp;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 68 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 69 /* Destructor */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Destructor;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 70 /* Else */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Else;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 71 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 72 /* Extern */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Extern;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 73 /* Export */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Export;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 74 /* False */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.False;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 75 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 76 /* Fn */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Fn;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 77 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 78 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 79 /* Import */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Import;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 80 /* Relative */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Relative;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 81 /* In */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.In;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 82 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 83 /* Let */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Let;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 84 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 85 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 86 /* Must */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Must;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 87 /* Mut */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Mut;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 88 /* Namespace */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Namespace;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 89 /* Not */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Not;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 90 /* Or */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Or;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 91 /* Override */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Override;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 92 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 93 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 94 /* Raw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Raw;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 95 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 96 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 97 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 98 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 99 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 100 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 101 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 102 /* Throws */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throws;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 103 /* True */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.True;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 104 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 105 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 106 /* Virtual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Virtual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 107 /* Weak */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Weak;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 108 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 109 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 110 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 111 /* Implements */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Implements;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 112 /* Requires */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Requires;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 113 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 case 114 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias target name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_17;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+break;}goto __jakt_label_17; __jakt_label_17:;;
 }
 Jakt::lexer::Token __jakt_tmp8 = this->previous();
 if (__jakt_tmp8.__jakt_init_index() == 6 /* ColonColon */){
@@ -3129,9 +2817,7 @@ this->error(ByteString::from_utf8_without_validation("Expected alias target name
 }
 if (this->current().__jakt_init_index() == 61 /* As */){
 this->index++;
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, Jakt::parser::ParsedAlias>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
@@ -3140,813 +2826,693 @@ Jakt::utility::Span const& span = __jakt_match_value.span;
 alias.alias_name = Jakt::parser::ParsedName(name,span);
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 4 /* Semicolon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Semicolon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 5 /* Colon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Colon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 6 /* ColonColon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ColonColon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 7 /* LParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LParen;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 8 /* RParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RParen;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 9 /* LCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LCurly;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 10 /* RCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RCurly;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 11 /* LSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LSquare;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 12 /* RSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RSquare;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 13 /* PercentSign */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSign;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 14 /* Plus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Plus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 15 /* Minus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Minus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 16 /* Equal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Equal;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 17 /* PlusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 18 /* PlusPlus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusPlus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 19 /* MinusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 20 /* MinusMinus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusMinus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 21 /* AsteriskEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AsteriskEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 22 /* ForwardSlashEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlashEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 23 /* PercentSignEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSignEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 24 /* NotEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NotEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 25 /* DoubleEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DoubleEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 26 /* GreaterThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThan;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 27 /* GreaterThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThanOrEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 28 /* LessThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThan;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 29 /* LessThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThanOrEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 30 /* LeftArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftArithmeticShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 31 /* LeftShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 32 /* LeftShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShiftEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 33 /* RightShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 34 /* RightArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightArithmeticShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 35 /* RightShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShiftEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 36 /* Asterisk */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Asterisk;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 37 /* Ampersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Ampersand;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 38 /* AmpersandEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 39 /* AmpersandAmpersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandAmpersand;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 40 /* Pipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Pipe;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 41 /* PipeEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipeEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 42 /* PipePipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipePipe;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 43 /* Caret */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Caret;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 44 /* CaretEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CaretEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 45 /* Dollar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dollar;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 46 /* Tilde */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Tilde;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 47 /* ForwardSlash */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlash;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 48 /* ExclamationPoint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ExclamationPoint;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 49 /* QuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMark;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 50 /* QuestionMarkQuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMark;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 51 /* QuestionMarkQuestionMarkEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMarkEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 52 /* Comma */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comma;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 54 /* DotDot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DotDot;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 55 /* Eol */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eol;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 56 /* Eof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eof;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 57 /* FatArrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.FatArrow;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 58 /* Arrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Arrow;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 59 /* And */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.And;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 60 /* Anon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Anon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 61 /* As */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.As;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 62 /* Boxed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boxed;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 63 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 64 /* Catch */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Catch;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 65 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 66 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 67 /* Cpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Cpp;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 68 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 69 /* Destructor */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Destructor;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 70 /* Else */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Else;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 71 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 72 /* Extern */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Extern;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 73 /* Export */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Export;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 74 /* False */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.False;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 75 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 76 /* Fn */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Fn;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 77 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 78 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 79 /* Import */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Import;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 80 /* Relative */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Relative;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 81 /* In */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.In;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 82 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 83 /* Let */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Let;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 84 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 85 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 86 /* Must */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Must;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 87 /* Mut */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Mut;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 88 /* Namespace */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Namespace;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 89 /* Not */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Not;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 90 /* Or */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Or;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 91 /* Override */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Override;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 92 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 93 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 94 /* Raw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Raw;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 95 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 96 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 97 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 98 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 99 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 100 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 101 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 102 /* Throws */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throws;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 103 /* True */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.True;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 104 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 105 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 106 /* Virtual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Virtual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 107 /* Weak */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Weak;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 108 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 109 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 110 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 111 /* Implements */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Implements;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 112 /* Requires */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Requires;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 113 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 case 114 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error(ByteString::from_utf8_without_validation("Expected alias name"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_19;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}goto __jakt_label_19; __jakt_label_19:;;
 }
 return alias;
 }
@@ -3976,10 +3542,10 @@ JaktInternal::DynamicArray<Jakt::parser::ParsedMethod> const methods = fields_me
 JaktInternal::DynamicArray<Jakt::parser::ParsedRecord> const records = fields_methods_records_.template get<2>();
 
 if (!records.is_empty()){
-this->error(ByteString::from_utf8_without_validation("External trait implementations cannot have nested records"sv),records.operator[](static_cast<i64>(0LL)).name_span);
+this->error(ByteString::from_utf8_without_validation("External trait implementations cannot have nested records"sv),records[static_cast<i64>(0LL)].name_span);
 }
 if (!fields.is_empty()){
-this->error(ByteString::from_utf8_without_validation("External trait implementations cannot have fields"sv),fields.operator[](static_cast<i64>(0LL)).var_decl.span);
+this->error(ByteString::from_utf8_without_validation("External trait implementations cannot have fields"sv),fields[static_cast<i64>(0LL)].var_decl.span);
 }
 return Jakt::parser::ParsedExternalTraitImplementation(type_name,trait_list.value(),methods);
 }
@@ -4004,31 +3570,25 @@ this->index++;
 if (this->current().__jakt_init_index() == 28 /* LessThan */){
 parsed_trait.generic_parameters = this->parse_generic_parameters();
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, Jakt::parser::ParsedTrait>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* LCurly */:{
 this->index++;
 JaktInternal::DynamicArray<Jakt::parser::ParsedFunction> methods = DynamicArray<Jakt::parser::ParsedFunction>::create_with({});
 JaktInternal::DynamicArray<Jakt::parser::ParsedAttribute> active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 for (;;){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, Jakt::parser::ParsedTrait>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* RCurly */:{
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 56 /* Eof */: {
+goto __jakt_label_21;case 56 /* Eof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eof;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected '}' to close the trait body"sv),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 11 /* LSquare */:{
 if (this->peek(static_cast<size_t>(1ULL)).__jakt_init_index() == 11 /* LSquare */){
 this->index += static_cast<size_t>(2ULL);
@@ -4040,13 +3600,11 @@ this->index += static_cast<size_t>(1ULL);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-case 55 /* Eol */:{
+goto __jakt_label_21;case 55 /* Eol */:{
 this->index++;
-return JaktInternal::LoopContinue{};
+continue;
 }
-return JaktInternal::ExplicitValue<void>();
-case 76 /* Fn */:{
+goto __jakt_label_21;case 76 /* Fn */:{
 Jakt::parser::ParsedFunction method = this->parse_function(Jakt::parser::FunctionLinkage::Internal(),Jakt::parser::Visibility::Public(),false,false,false,true);
 if (method.block.stmts.is_empty()){
 method.linkage = Jakt::parser::FunctionLinkage::External();
@@ -4055,920 +3613,792 @@ this->apply_attributes(method,active_attributes);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 methods.push(method);
 }
-return JaktInternal::ExplicitValue<void>();
-case 0 /* SingleQuotedString */: {
+goto __jakt_label_21;case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 4 /* Semicolon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Semicolon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 5 /* Colon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Colon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 6 /* ColonColon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ColonColon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 7 /* LParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LParen;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 8 /* RParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RParen;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 9 /* LCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LCurly;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 12 /* RSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RSquare;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 13 /* PercentSign */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSign;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 14 /* Plus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Plus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 15 /* Minus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Minus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 16 /* Equal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Equal;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 17 /* PlusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 18 /* PlusPlus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusPlus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 19 /* MinusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 20 /* MinusMinus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusMinus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 21 /* AsteriskEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AsteriskEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 22 /* ForwardSlashEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlashEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 23 /* PercentSignEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSignEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 24 /* NotEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NotEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 25 /* DoubleEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DoubleEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 26 /* GreaterThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThan;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 27 /* GreaterThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThanOrEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 28 /* LessThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThan;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 29 /* LessThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThanOrEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 30 /* LeftArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftArithmeticShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 31 /* LeftShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 32 /* LeftShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShiftEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 33 /* RightShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 34 /* RightArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightArithmeticShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 35 /* RightShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShiftEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 36 /* Asterisk */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Asterisk;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 37 /* Ampersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Ampersand;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 38 /* AmpersandEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 39 /* AmpersandAmpersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandAmpersand;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 40 /* Pipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Pipe;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 41 /* PipeEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipeEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 42 /* PipePipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipePipe;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 43 /* Caret */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Caret;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 44 /* CaretEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CaretEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 45 /* Dollar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dollar;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 46 /* Tilde */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Tilde;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 47 /* ForwardSlash */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlash;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 48 /* ExclamationPoint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ExclamationPoint;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 49 /* QuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMark;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 50 /* QuestionMarkQuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMark;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 51 /* QuestionMarkQuestionMarkEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMarkEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 52 /* Comma */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comma;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 54 /* DotDot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DotDot;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 57 /* FatArrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.FatArrow;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 58 /* Arrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Arrow;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 59 /* And */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.And;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 60 /* Anon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Anon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 61 /* As */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.As;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 62 /* Boxed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boxed;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 63 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 64 /* Catch */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Catch;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 65 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 66 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 67 /* Cpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Cpp;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 68 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 69 /* Destructor */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Destructor;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 70 /* Else */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Else;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 71 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 72 /* Extern */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Extern;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 73 /* Export */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Export;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 74 /* False */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.False;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 75 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 77 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 78 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 79 /* Import */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Import;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 80 /* Relative */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Relative;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 81 /* In */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.In;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 82 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 83 /* Let */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Let;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 84 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 85 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 86 /* Must */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Must;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 87 /* Mut */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Mut;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 88 /* Namespace */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Namespace;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 89 /* Not */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Not;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 90 /* Or */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Or;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 91 /* Override */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Override;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 92 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 93 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 94 /* Raw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Raw;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 95 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 96 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 97 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 98 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 99 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 100 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 101 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 102 /* Throws */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throws;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 103 /* True */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.True;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 104 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 105 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 106 /* Virtual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Virtual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 107 /* Weak */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Weak;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 108 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 109 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 110 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 111 /* Implements */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Implements;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 112 /* Requires */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Requires;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 113 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 case 114 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv),span,__jakt_format(StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv),parsed_trait.name),parsed_trait.name_span);
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_21;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+break;}goto __jakt_label_21; __jakt_label_21:;;
 parsed_trait.requirements = Jakt::parser::ParsedTraitRequirements::Methods(methods);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-case 16 /* Equal */:{
+goto __jakt_label_20;case 16 /* Equal */:{
 this->index += static_cast<size_t>(1ULL);
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expression = this->parse_expression(false,true);
 parsed_trait.requirements = Jakt::parser::ParsedTraitRequirements::ComptimeExpression(expression);
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_20;default:{
 this->error(ByteString::from_utf8_without_validation("Expected '{' to enter the body of the trait, or '=' to specify trait requirements"sv),this->current().span());
 return parsed_trait;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_20;}/*switch end*/
+}goto __jakt_label_20; __jakt_label_20:;;
 return parsed_trait;
 }
 else {
@@ -4981,60 +4411,37 @@ return parsed_trait;
 
 Jakt::parser::ParsedRecord Jakt::parser::Parser::parse_record(Jakt::parser::DefinitionLinkage const definition_linkage) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::ParsedRecord, Jakt::parser::ParsedRecord>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 99 /* Struct */:return JaktInternal::ExplicitValue(this->parse_struct(definition_linkage));
-case 65 /* Class */:return JaktInternal::ExplicitValue(this->parse_class(definition_linkage));
-case 71 /* Enum */:return JaktInternal::ExplicitValue(this->parse_enum(definition_linkage,false));
-case 62 /* Boxed */:{
+case 99 /* Struct */:return this->parse_struct(definition_linkage);case 65 /* Class */:return this->parse_class(definition_linkage);case 71 /* Enum */:return this->parse_enum(definition_linkage,false);case 62 /* Boxed */:{
 this->index++;
-return JaktInternal::ExplicitValue<Jakt::parser::ParsedRecord>(this->parse_enum(definition_linkage,true));
+return this->parse_enum(definition_linkage,true);
 }
 VERIFY_NOT_REACHED();
 default:{
 this->error(ByteString::from_utf8_without_validation("Expected `struct`, `class`, `enum`, or `boxed`"sv),this->current().span());
-return JaktInternal::ExplicitValue<Jakt::parser::ParsedRecord>(Jakt::parser::ParsedRecord(ByteString::from_utf8_without_validation(""sv),this->empty_span(),DynamicArray<Jakt::parser::ParsedGenericParameter>::create_with({}),definition_linkage,JaktInternal::OptionalNone(),DynamicArray<Jakt::parser::ParsedMethod>::create_with({}),Jakt::parser::RecordType::Garbage(),DynamicArray<Jakt::parser::ParsedRecord>::create_with({}),JaktInternal::OptionalNone(),JaktInternal::OptionalNone()));
+return Jakt::parser::ParsedRecord(ByteString::from_utf8_without_validation(""sv),this->empty_span(),DynamicArray<Jakt::parser::ParsedGenericParameter>::create_with({}),definition_linkage,JaktInternal::OptionalNone(),DynamicArray<Jakt::parser::ParsedMethod>::create_with({}),Jakt::parser::RecordType::Garbage(),DynamicArray<Jakt::parser::ParsedRecord>::create_with({}),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 void Jakt::parser::Parser::escape_toplevel() {
 {
 for (;;){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, void>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 56 /* Eof */:case 72 /* Extern */:case 73 /* Export */:case 79 /* Import */:case 88 /* Namespace */:case 99 /* Struct */:case 71 /* Enum */:case 113 /* Trait */:case 76 /* Fn */:case 77 /* Comptime */:{
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_22;default:{
 this->index++;
-return JaktInternal::LoopContinue{};
+continue;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_22;}/*switch end*/
+break;}goto __jakt_label_22; __jakt_label_22:;;
 }
 }
 }
@@ -5052,21 +4459,17 @@ this->index++;
 bool has_doublecolon = false;
 JaktInternal::DynamicArray<Jakt::parser::ParsedName> current_ns = DynamicArray<Jakt::parser::ParsedName>::create_with({});
 for (;;){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, void>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 55 /* Eol */:{
 this->index++;
-return JaktInternal::LoopContinue{};
+continue;
 }
-return JaktInternal::ExplicitValue<void>();
-case 10 /* RCurly */:{
+goto __jakt_label_23;case 10 /* RCurly */:{
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* Identifier */: {
+goto __jakt_label_23;case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
@@ -5078,10 +4481,9 @@ current_ns = DynamicArray<Jakt::parser::ParsedName>::create_with({});
 current_ns.push(Jakt::parser::ParsedName(name,span));
 has_doublecolon = false;
 this->index++;
-return JaktInternal::LoopContinue{};
+continue;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 6 /* ColonColon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ColonColon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
@@ -5090,10 +4492,9 @@ this->error(ByteString::from_utf8_without_validation("Expected name before '::'"
 }
 has_doublecolon = true;
 this->index++;
-return JaktInternal::LoopContinue{};
+continue;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 52 /* Comma */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comma;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
@@ -5106,1011 +4507,891 @@ current_ns = DynamicArray<Jakt::parser::ParsedName>::create_with({});
 }
 
 this->index++;
-return JaktInternal::LoopContinue{};
+continue;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 4 /* Semicolon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Semicolon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 5 /* Colon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Colon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 7 /* LParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LParen;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 8 /* RParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RParen;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 9 /* LCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LCurly;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 11 /* LSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LSquare;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 12 /* RSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RSquare;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 13 /* PercentSign */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSign;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 14 /* Plus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Plus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 15 /* Minus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Minus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 16 /* Equal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Equal;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 17 /* PlusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 18 /* PlusPlus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusPlus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 19 /* MinusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 20 /* MinusMinus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusMinus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 21 /* AsteriskEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AsteriskEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 22 /* ForwardSlashEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlashEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 23 /* PercentSignEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSignEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 24 /* NotEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NotEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 25 /* DoubleEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DoubleEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 26 /* GreaterThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThan;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 27 /* GreaterThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThanOrEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 28 /* LessThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThan;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 29 /* LessThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThanOrEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 30 /* LeftArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftArithmeticShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 31 /* LeftShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 32 /* LeftShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShiftEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 33 /* RightShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 34 /* RightArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightArithmeticShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 35 /* RightShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShiftEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 36 /* Asterisk */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Asterisk;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 37 /* Ampersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Ampersand;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 38 /* AmpersandEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 39 /* AmpersandAmpersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandAmpersand;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 40 /* Pipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Pipe;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 41 /* PipeEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipeEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 42 /* PipePipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipePipe;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 43 /* Caret */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Caret;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 44 /* CaretEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CaretEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 45 /* Dollar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dollar;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 46 /* Tilde */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Tilde;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 47 /* ForwardSlash */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlash;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 48 /* ExclamationPoint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ExclamationPoint;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 49 /* QuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMark;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 50 /* QuestionMarkQuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMark;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 51 /* QuestionMarkQuestionMarkEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMarkEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 54 /* DotDot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DotDot;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 56 /* Eof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eof;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 57 /* FatArrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.FatArrow;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 58 /* Arrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Arrow;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 59 /* And */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.And;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 60 /* Anon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Anon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 61 /* As */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.As;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 62 /* Boxed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boxed;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 63 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 64 /* Catch */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Catch;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 65 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 66 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 67 /* Cpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Cpp;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 68 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 69 /* Destructor */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Destructor;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 70 /* Else */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Else;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 71 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 72 /* Extern */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Extern;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 73 /* Export */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Export;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 74 /* False */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.False;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 75 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 76 /* Fn */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Fn;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 77 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 78 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 79 /* Import */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Import;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 80 /* Relative */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Relative;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 81 /* In */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.In;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 82 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 83 /* Let */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Let;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 84 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 85 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 86 /* Must */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Must;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 87 /* Mut */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Mut;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 88 /* Namespace */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Namespace;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 89 /* Not */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Not;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 90 /* Or */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Or;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 91 /* Override */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Override;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 92 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 93 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 94 /* Raw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Raw;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 95 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 96 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 97 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 98 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 99 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 100 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 101 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 102 /* Throws */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throws;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 103 /* True */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.True;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 104 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 105 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 106 /* Virtual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Virtual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 107 /* Weak */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Weak;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 108 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 109 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 110 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 111 /* Implements */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Implements;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 112 /* Requires */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Requires;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 113 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 case 114 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error(ByteString::from_utf8_without_validation("Expected exported name, ',' or '}'"sv),span);
 this->escape_toplevel();
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_23;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+break;}goto __jakt_label_23; __jakt_label_23:;;
 }
 if (!current_ns.is_empty()){
 result.names.push(current_ns);
@@ -6164,30 +5445,24 @@ this->error(ByteString::from_utf8_without_validation("Expected 'c' or path after
 
 }
 parsed_import.assigned_namespace.name_span = this->current().span();
-ByteString const import_path = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, Jakt::parser::ParsedExternImport>{
-auto&& __jakt_match_variant = this->current();
+ByteString const import_path = [&]() -> ByteString { auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;ByteString const& quote = __jakt_match_value.quote;
 {
 this->index++;
-return JaktInternal::ExplicitValue<ByteString>(quote);
+return quote;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
 this->error(ByteString::from_utf8_without_validation("Expected path after `import extern`"sv),this->current().span());
-return JaktInternal::ExplicitValue<ByteString>(ByteString::from_utf8_without_validation(""sv));
+return ByteString::from_utf8_without_validation(""sv);
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 if (this->current().__jakt_init_index() == 61 /* As */){
 this->index++;
 Jakt::lexer::Token __jakt_tmp12 = this->current();
@@ -6230,9 +5505,7 @@ for (;;){
 Jakt::lexer::Token __jakt_tmp13 = this->current();
 if (__jakt_tmp13.__jakt_init_index() == 3 /* Identifier */){
 ByteString const name = __jakt_tmp13.as.Identifier.name;
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,Jakt::parser::ParsedExternImport> {
-auto __jakt_enum_value = (name);
+{auto __jakt_enum_value = name;
 if (__jakt_enum_value == ByteString::from_utf8_without_validation("before_include"sv)) {{
 this->index++;
 JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::parser::IncludeAction>> const actions = this->parse_include_action();
@@ -6240,29 +5513,17 @@ if (actions.has_value()){
 parsed_import.before_include.push_values(actions.value());
 }
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("after_include"sv)) {{
+goto __jakt_label_24;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("after_include"sv)) {{
 this->index++;
 JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::parser::IncludeAction>> const actions = this->parse_include_action();
 if (actions.has_value()){
 parsed_import.after_include.push_values(actions.value());
 }
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
-return JaktInternal::LoopBreak{};
+goto __jakt_label_24;}else {{
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_24;}}goto __jakt_label_24; __jakt_label_24:;;
 }
 else {
 break;
@@ -6279,9 +5540,7 @@ this->skip_newlines();
 Jakt::lexer::Token __jakt_tmp14 = this->current();
 if (__jakt_tmp14.__jakt_init_index() == 3 /* Identifier */){
 ByteString const name = __jakt_tmp14.as.Identifier.name;
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::parser::IncludeAction>>> {
-auto __jakt_enum_value = (name);
+{auto __jakt_enum_value = name;
 if (__jakt_enum_value == ByteString::from_utf8_without_validation("define"sv)) {{
 this->index++;
 this->skip_newlines();
@@ -6310,34 +5569,24 @@ this->error(ByteString::from_utf8_without_validation("Expected '=' to assign val
 continue;
 }
 
-ByteString const value = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::parser::IncludeAction>>>{
-auto&& __jakt_match_variant = this->current();
+ByteString const value = [&]() -> ByteString { auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;ByteString const& quote = __jakt_match_value.quote;
 {
 this->index++;
-return JaktInternal::ExplicitValue<ByteString>(quote);
+return quote;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
 this->error(ByteString::from_utf8_without_validation("Expected quoted string to assign value to defined symbols"sv),this->current().span());
-return JaktInternal::ExplicitValue<ByteString>(ByteString::from_utf8_without_validation(""sv));
+return ByteString::from_utf8_without_validation(""sv);
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}();
 defines.push(Jakt::parser::IncludeAction::Define(name,span,value));
 this->skip_newlines();
 if (this->current().__jakt_init_index() == 52 /* Comma */){
@@ -6359,8 +5608,7 @@ this->error(ByteString::from_utf8_without_validation("Expected '}' to end define
 
 return static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::parser::IncludeAction>>>(defines);
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("undefine"sv)) {{
+goto __jakt_label_25;}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("undefine"sv)) {{
 this->index++;
 this->skip_newlines();
 if (this->current().__jakt_init_index() == 9 /* LCurly */){
@@ -6400,16 +5648,9 @@ this->error(ByteString::from_utf8_without_validation("Expected '}' to end undefi
 
 return static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::parser::IncludeAction>>>(defines);
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_25;}else {{
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_25;}}goto __jakt_label_25; __jakt_label_25:;;
 this->error(ByteString::from_utf8_without_validation("Expected 'define' or 'undefine' in include action"sv),this->current().span());
 return JaktInternal::OptionalNone();
 }
@@ -6435,9 +5676,7 @@ this->index++;
 parsed_import.parent_path_count++;
 while (this->current().__jakt_init_index() == 6 /* ColonColon */){
 this->index++;
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, Jakt::parser::ParsedModuleImport>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
@@ -6447,42 +5686,28 @@ return !(self == rhs);
 }
 }
 (name,ByteString::from_utf8_without_validation("parent"sv))){
-return JaktInternal::LoopBreak{};
+break;
 }
 this->index++;
 parsed_import.parent_path_count++;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_26;};/*case end*/
 default:{
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_26;}/*switch end*/
+break;}goto __jakt_label_26; __jakt_label_26:;;
 }
 if (this->current().__jakt_init_index() == 7 /* LParen */){
 this->index++;
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, Jakt::parser::ParsedModuleImport>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* RParen */:{
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* Number */: {
+goto __jakt_label_27;case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;Jakt::lexer::LiteralPrefix const& prefix = __jakt_match_value.prefix;
 ByteString const& number = __jakt_match_value.number;
 Jakt::lexer::LiteralSuffix const& suffix = __jakt_match_value.suffix;
@@ -6496,28 +5721,17 @@ parsed_import.parent_path_count = val.to_usize();
 }
 else {
 this->error(ByteString::from_utf8_without_validation("Invalid Numeric Constant"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_27;};/*case end*/
 default:{
 this->error(__jakt_format(StringView::from_string_literal("Incomplete relative import defintion, `)`; got ‘{}’"sv),this->current()),this->current().span());
 return parsed_import;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_27;}/*switch end*/
+break;}goto __jakt_label_27; __jakt_label_27:;;
 }
 if (this->current().__jakt_init_index() == 6 /* ColonColon */){
 this->index++;
@@ -6538,9 +5752,7 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::ImportName, Jakt::parser::ParsedModuleImport>{
-auto&& __jakt_match_variant = this->peek(static_cast<size_t>(1ULL));
+return JaktInternal::ExplicitValue([&]() -> Jakt::parser::ImportName { auto&& __jakt_match_variant = this->peek(static_cast<size_t>(1ULL));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* LParen */:{
 bool const previous_can_have_trailing_closure = this->can_have_trailing_closure;
@@ -6548,17 +5760,12 @@ this->can_have_trailing_closure = false;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expression = Jakt::parser::ParsedExpression::Call(this->parse_call().value(),span);
 this->can_have_trailing_closure = previous_can_have_trailing_closure;
 this->index--;
-return JaktInternal::ExplicitValue<Jakt::parser::ImportName>(Jakt::parser::ImportName::Comptime(expression));
+return Jakt::parser::ImportName::Comptime(expression);
 }
 VERIFY_NOT_REACHED();
-default:return JaktInternal::ExplicitValue(Jakt::parser::ImportName::Literal(name,span));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+default:return Jakt::parser::ImportName::Literal(name,span);}/*switch end*/
+ 
+}());
 };/*case end*/
 default:{
 this->error(ByteString::from_utf8_without_validation("Expected module name"sv),this->current().span());
@@ -6585,9 +5792,7 @@ self = (self + rhs);
 }
 }
 (module_name,ByteString::from_utf8_without_validation("::"sv));
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, Jakt::parser::ParsedModuleImport>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
@@ -6601,28 +5806,16 @@ self = (self + rhs);
 module_span = Jakt::parser::merge_spans(module_span,span);
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_28;};/*case end*/
 case 61 /* As */:case 9 /* LCurly */:{
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_28;default:{
 this->error(ByteString::from_utf8_without_validation("Expected module name fragment"sv),this->current().span());
 return parsed_import;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_28;}/*switch end*/
+break;}goto __jakt_label_28; __jakt_label_28:;;
 }
 parsed_import.module_name = Jakt::parser::ImportName::Literal(module_name,module_span);
 }
@@ -6649,9 +5842,7 @@ this->error(ByteString::from_utf8_without_validation("Expected '{'"sv),this->cur
 }
 this->index++;
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, Jakt::parser::ParsedModuleImport>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
@@ -6669,8 +5860,7 @@ this->error_with_hint(__jakt_format(StringView::from_string_literal("Already imp
 
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_29;};/*case end*/
 case 36 /* Asterisk */:{
 Jakt::parser::ImportList __jakt_tmp21 = parsed_import.import_list;
 if (__jakt_tmp21.__jakt_init_index() == 0 /* List */){
@@ -6701,32 +5891,19 @@ this->error(__jakt_format(StringView::from_string_literal("Cannot mix '*' and sp
 
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 52 /* Comma */:case 55 /* Eol */:{
+goto __jakt_label_29;case 52 /* Comma */:case 55 /* Eol */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 10 /* RCurly */:{
+goto __jakt_label_29;case 10 /* RCurly */:{
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_29;default:{
 this->error(ByteString::from_utf8_without_validation("Expected import symbol"sv),this->current().span());
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_29;}/*switch end*/
+break;}goto __jakt_label_29; __jakt_label_29:;;
 }
 return parsed_import;
 }
@@ -6751,9 +5928,7 @@ return Tuple{variants, methods};
 JaktInternal::Optional<Jakt::parser::Visibility> last_visibility = JaktInternal::OptionalNone();
 JaktInternal::Optional<Jakt::utility::Span> last_visibility_span = JaktInternal::OptionalNone();
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::parser::ValueEnumVariant>,JaktInternal::DynamicArray<Jakt::parser::ParsedMethod>>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
@@ -6770,17 +5945,14 @@ variants.push(Jakt::parser::ValueEnumVariant(name,span,JaktInternal::OptionalNon
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_30;};/*case end*/
 case 10 /* RCurly */:{
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 52 /* Comma */:case 55 /* Eol */:{
+goto __jakt_label_30;case 52 /* Comma */:case 55 /* Eol */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 92 /* Private */: {
+goto __jakt_label_30;case 92 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 if (last_visibility.has_value()){
@@ -6790,8 +5962,7 @@ last_visibility = Jakt::parser::Visibility::Private();
 last_visibility_span = span;
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_30;};/*case end*/
 case 93 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
@@ -6802,27 +5973,14 @@ last_visibility = Jakt::parser::Visibility::Public();
 last_visibility_span = span;
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_30;};/*case end*/
 case 76 /* Fn */:case 77 /* Comptime */:{
 bool const is_comptime = this->current().__jakt_init_index() == 77 /* Comptime */;
-Jakt::parser::FunctionLinkage const function_linkage = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::FunctionLinkage, JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::parser::ValueEnumVariant>,JaktInternal::DynamicArray<Jakt::parser::ParsedMethod>>>{
-auto&& __jakt_match_variant = definition_linkage;
+Jakt::parser::FunctionLinkage const function_linkage = [&]() -> Jakt::parser::FunctionLinkage { auto&& __jakt_match_variant = definition_linkage;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Internal */:return JaktInternal::ExplicitValue(Jakt::parser::FunctionLinkage::Internal());
-case 1 /* External */:return JaktInternal::ExplicitValue(Jakt::parser::FunctionLinkage::External());
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+case 0 /* Internal */:return Jakt::parser::FunctionLinkage::Internal();case 1 /* External */:return Jakt::parser::FunctionLinkage::External();default: VERIFY_NOT_REACHED();}/*switch end*/
+ 
+}();
 if ((function_linkage.__jakt_init_index() == 1 /* External */) && is_comptime){
 this->error(ByteString::from_utf8_without_validation("External functions cannot be comptime"sv),this->current().span());
 }
@@ -6832,23 +5990,12 @@ last_visibility_span = JaktInternal::OptionalNone();
 Jakt::parser::ParsedMethod const parsed_method = this->parse_method(function_linkage,visibility,false,false,is_comptime,false,false);
 methods.push(parsed_method);
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_30;default:{
 this->error(ByteString::from_utf8_without_validation("Expected identifier or the end of enum block"sv),this->current().span());
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_30;}/*switch end*/
+break;}goto __jakt_label_30; __jakt_label_30:;;
 }
 if (!(this->current().__jakt_init_index() == 10 /* RCurly */)){
 this->error(ByteString::from_utf8_without_validation("Invalid enum definition, expected `}`"sv),this->current().span());
@@ -6886,9 +6033,7 @@ JaktInternal::Optional<Jakt::utility::Span> last_visibility_span = JaktInternal:
 bool last_extern = false;
 JaktInternal::DynamicArray<Jakt::parser::ParsedAttribute> active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::parser::SumEnumVariant>,JaktInternal::DynamicArray<Jakt::parser::ParsedField>,JaktInternal::DynamicArray<Jakt::parser::ParsedMethod>,JaktInternal::DynamicArray<Jakt::parser::ParsedRecord>>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 72 /* Extern */:{
 if (last_extern){
@@ -6897,8 +6042,7 @@ this->error(ByteString::from_utf8_without_validation("Multiple extern modifiers 
 last_extern = true;
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* Identifier */: {
+goto __jakt_label_31;case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
@@ -6919,13 +6063,13 @@ else {
 fields.push(field);
 }
 
-return JaktInternal::LoopContinue{};
+continue;
 }
 seen_a_variant = true;
 if (!(this->peek(static_cast<size_t>(1ULL)).__jakt_init_index() == 7 /* LParen */)){
 this->index++;
 variants.push(Jakt::parser::SumEnumVariant(name,span,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()));
-return JaktInternal::LoopContinue{};
+continue;
 }
 this->index += static_cast<size_t>(2ULL);
 JaktInternal::DynamicArray<Jakt::parser::ParsedVarDecl> var_decls = DynamicArray<Jakt::parser::ParsedVarDecl>::create_with({});
@@ -6953,96 +6097,53 @@ continue;
 }
 
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::parser::SumEnumVariant>,JaktInternal::DynamicArray<Jakt::parser::ParsedField>,JaktInternal::DynamicArray<Jakt::parser::ParsedMethod>,JaktInternal::DynamicArray<Jakt::parser::ParsedRecord>>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Identifier */:case 11 /* LSquare */:case 9 /* LCurly */:{
 var_decls.push(Jakt::parser::ParsedVarDecl(ByteString::from_utf8_without_validation(""sv),this->parse_typename(),false,JaktInternal::OptionalNone(),this->current().span(),JaktInternal::OptionalNone()));
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_32;default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::parser::SumEnumVariant>,JaktInternal::DynamicArray<Jakt::parser::ParsedField>,JaktInternal::DynamicArray<Jakt::parser::ParsedMethod>,JaktInternal::DynamicArray<Jakt::parser::ParsedRecord>>>{
-auto&& __jakt_match_variant = this->current();
+goto __jakt_label_32;}/*switch end*/
+break;}goto __jakt_label_32; __jakt_label_32:;;
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 16 /* Equal */:{
 this->index++;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const default_value = this->parse_expression(false,false);
 default_values.push(static_cast<JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>>(default_value));
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_33;default:{
 default_values.push(JaktInternal::OptionalNone());
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::parser::SumEnumVariant>,JaktInternal::DynamicArray<Jakt::parser::ParsedField>,JaktInternal::DynamicArray<Jakt::parser::ParsedMethod>,JaktInternal::DynamicArray<Jakt::parser::ParsedRecord>>>{
-auto&& __jakt_match_variant = this->current();
+goto __jakt_label_33;}/*switch end*/
+break;}goto __jakt_label_33; __jakt_label_33:;;
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* RParen */:{
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 52 /* Comma */:case 55 /* Eol */:{
+goto __jakt_label_34;case 52 /* Comma */:case 55 /* Eol */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_34;default:{
 this->error(__jakt_format(StringView::from_string_literal("Incomplete enum variant definition, expected `,` or `)`; got ‘{}’"sv),this->current()),this->current().span());
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_34;}/*switch end*/
+break;}goto __jakt_label_34; __jakt_label_34:;;
 }
 variants.push(Jakt::parser::SumEnumVariant(name,span,var_decls,default_values));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_31;};/*case end*/
 case 10 /* RCurly */:{
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 52 /* Comma */:case 55 /* Eol */:{
+goto __jakt_label_31;case 52 /* Comma */:case 55 /* Eol */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 11 /* LSquare */:{
+goto __jakt_label_31;case 11 /* LSquare */:{
 if (this->peek(static_cast<size_t>(1ULL)).__jakt_init_index() == 11 /* LSquare */){
 this->index += static_cast<size_t>(2ULL);
 this->parse_attribute_list(active_attributes);
@@ -7053,8 +6154,7 @@ this->index += static_cast<size_t>(1ULL);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-case 92 /* Private */: {
+goto __jakt_label_31;case 92 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 if (last_visibility.has_value()){
@@ -7064,8 +6164,7 @@ last_visibility = Jakt::parser::Visibility::Private();
 last_visibility_span = span;
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_31;};/*case end*/
 case 93 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
@@ -7076,41 +6175,16 @@ last_visibility = Jakt::parser::Visibility::Public();
 last_visibility_span = span;
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_31;};/*case end*/
 case 76 /* Fn */:case 77 /* Comptime */:{
 bool const is_comptime = this->current().__jakt_init_index() == 77 /* Comptime */;
-Jakt::parser::FunctionLinkage const function_linkage = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::FunctionLinkage,JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::parser::SumEnumVariant>,JaktInternal::DynamicArray<Jakt::parser::ParsedField>,JaktInternal::DynamicArray<Jakt::parser::ParsedMethod>,JaktInternal::DynamicArray<Jakt::parser::ParsedRecord>>> {
-auto __jakt_enum_value = (last_extern);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::parser::FunctionLinkage::External());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::FunctionLinkage, JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::parser::SumEnumVariant>,JaktInternal::DynamicArray<Jakt::parser::ParsedField>,JaktInternal::DynamicArray<Jakt::parser::ParsedMethod>,JaktInternal::DynamicArray<Jakt::parser::ParsedRecord>>>{
-auto&& __jakt_match_variant = definition_linkage;
+Jakt::parser::FunctionLinkage const function_linkage = [&]() -> Jakt::parser::FunctionLinkage { auto __jakt_enum_value = last_extern;
+if (__jakt_enum_value) {return Jakt::parser::FunctionLinkage::External();}else if (!__jakt_enum_value) {{auto&& __jakt_match_variant = definition_linkage;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Internal */:return JaktInternal::ExplicitValue(Jakt::parser::FunctionLinkage::Internal());
-case 1 /* External */:return JaktInternal::ExplicitValue(Jakt::parser::FunctionLinkage::External());
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+case 0 /* Internal */:return Jakt::parser::FunctionLinkage::Internal();case 1 /* External */:return Jakt::parser::FunctionLinkage::External();default: VERIFY_NOT_REACHED();}/*switch end*/
+}}VERIFY_NOT_REACHED();
+ 
+}();
 if ((function_linkage.__jakt_init_index() == 1 /* External */) && is_comptime){
 this->error(ByteString::from_utf8_without_validation("External functions cannot be comptime"sv),this->current().span());
 }
@@ -7122,48 +6196,25 @@ this->apply_attributes(parsed_method,active_attributes);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 methods.push(parsed_method);
 }
-return JaktInternal::ExplicitValue<void>();
-case 99 /* Struct */:case 71 /* Enum */:case 62 /* Boxed */:case 65 /* Class */:{
+goto __jakt_label_31;case 99 /* Struct */:case 71 /* Enum */:case 62 /* Boxed */:case 65 /* Class */:{
 if (last_visibility.has_value()){
 this->error(ByteString::from_utf8_without_validation("Nested types cannot have visibility modifiers"sv),this->current().span());
 last_visibility = JaktInternal::OptionalNone();
 }
-Jakt::parser::ParsedRecord parsed_record = this->parse_record(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::DefinitionLinkage,JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::parser::SumEnumVariant>,JaktInternal::DynamicArray<Jakt::parser::ParsedField>,JaktInternal::DynamicArray<Jakt::parser::ParsedMethod>,JaktInternal::DynamicArray<Jakt::parser::ParsedRecord>>> {
-auto __jakt_enum_value = (last_extern);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::parser::DefinitionLinkage::External());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(definition_linkage);
-}VERIFY_NOT_REACHED();
+Jakt::parser::ParsedRecord parsed_record = this->parse_record([&]() -> Jakt::parser::DefinitionLinkage { auto __jakt_enum_value = last_extern;
+if (__jakt_enum_value) {return Jakt::parser::DefinitionLinkage::External();}else if (!__jakt_enum_value) {return definition_linkage;}VERIFY_NOT_REACHED();
+ 
 }());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
 this->apply_attributes(parsed_record,active_attributes);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 records.push(parsed_record);
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_31;default:{
 this->error(ByteString::from_utf8_without_validation("Expected identifier or the end of enum block"sv),this->current().span());
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_31;}/*switch end*/
+break;}goto __jakt_label_31; __jakt_label_31:;;
 }
 if (!(this->current().__jakt_init_index() == 10 /* RCurly */)){
 this->error(ByteString::from_utf8_without_validation("Invalid enum definition, expected `}`"sv),this->current().span());
@@ -7277,9 +6328,7 @@ bool error = false;
 JaktInternal::DynamicArray<Jakt::parser::ParsedAttribute> active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 while (!this->eof()){
 Jakt::lexer::Token const token = this->current();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::parser::ParsedField>,JaktInternal::DynamicArray<Jakt::parser::ParsedMethod>,JaktInternal::DynamicArray<Jakt::parser::ParsedRecord>>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* RCurly */:{
 if (last_visibility.has_value()){
@@ -7291,17 +6340,14 @@ this->error(ByteString::from_utf8_without_validation("Expected function after at
 this->index++;
 return Tuple{fields, methods, records};
 }
-return JaktInternal::ExplicitValue<void>();
-case 52 /* Comma */:case 55 /* Eol */:{
+goto __jakt_label_35;case 52 /* Comma */:case 55 /* Eol */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 72 /* Extern */:{
+goto __jakt_label_35;case 72 /* Extern */:{
 last_extern = true;
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 93 /* Public */: {
+goto __jakt_label_35;case 93 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 if (last_visibility.has_value()){
@@ -7311,8 +6357,7 @@ last_visibility = Jakt::parser::Visibility::Public();
 last_visibility_span = span;
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_35;};/*case end*/
 case 92 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
@@ -7323,8 +6368,7 @@ last_visibility = Jakt::parser::Visibility::Private();
 last_visibility_span = span;
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_35;};/*case end*/
 case 97 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
@@ -7334,8 +6378,7 @@ this->error_with_hint(ByteString::from_utf8_without_validation("Multiple visibil
 last_visibility = this->parse_restricted_visibility_modifier();
 last_visibility_span = span;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_35;};/*case end*/
 case 11 /* LSquare */:{
 if (this->peek(static_cast<size_t>(1ULL)).__jakt_init_index() == 11 /* LSquare */){
 this->index += static_cast<size_t>(2ULL);
@@ -7347,8 +6390,7 @@ this->index += static_cast<size_t>(1ULL);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* Identifier */:{
+goto __jakt_label_35;case 3 /* Identifier */:{
 Jakt::parser::Visibility const visibility = last_visibility.value_or_lazy_evaluated([&] { return default_visibility; });
 last_visibility = JaktInternal::OptionalNone();
 last_visibility_span = JaktInternal::OptionalNone();
@@ -7366,41 +6408,16 @@ this->apply_attributes(field,active_attributes);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 fields.push(field);
 }
-return JaktInternal::ExplicitValue<void>();
-case 76 /* Fn */:case 77 /* Comptime */:case 69 /* Destructor */:{
+goto __jakt_label_35;case 76 /* Fn */:case 77 /* Comptime */:case 69 /* Destructor */:{
 bool const is_comptime = this->current().__jakt_init_index() == 77 /* Comptime */;
 bool const is_destructor = this->current().__jakt_init_index() == 69 /* Destructor */;
-Jakt::parser::FunctionLinkage const function_linkage = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::FunctionLinkage, JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::parser::ParsedField>,JaktInternal::DynamicArray<Jakt::parser::ParsedMethod>,JaktInternal::DynamicArray<Jakt::parser::ParsedRecord>>>{
-auto&& __jakt_match_variant = definition_linkage;
+Jakt::parser::FunctionLinkage const function_linkage = [&]() -> Jakt::parser::FunctionLinkage { auto&& __jakt_match_variant = definition_linkage;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Internal */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::FunctionLinkage,JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::parser::ParsedField>,JaktInternal::DynamicArray<Jakt::parser::ParsedMethod>,JaktInternal::DynamicArray<Jakt::parser::ParsedRecord>>> {
-auto __jakt_enum_value = (last_extern);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::parser::FunctionLinkage::External());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::parser::FunctionLinkage::Internal());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
-case 1 /* External */:return JaktInternal::ExplicitValue(Jakt::parser::FunctionLinkage::External());
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+case 0 /* Internal */:{auto __jakt_enum_value = last_extern;
+if (__jakt_enum_value) {return Jakt::parser::FunctionLinkage::External();}else if (!__jakt_enum_value) {return Jakt::parser::FunctionLinkage::Internal();}VERIFY_NOT_REACHED();
+}case 1 /* External */:return Jakt::parser::FunctionLinkage::External();default: VERIFY_NOT_REACHED();}/*switch end*/
+ 
+}();
 last_extern = false;
 if ((function_linkage.__jakt_init_index() == 1 /* External */) && is_comptime){
 this->error(ByteString::from_utf8_without_validation("External functions cannot be comptime"sv),this->current().span());
@@ -7417,18 +6434,15 @@ this->apply_attributes(parsed_method,active_attributes);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 methods.push(parsed_method);
 }
-return JaktInternal::ExplicitValue<void>();
-case 106 /* Virtual */:{
+goto __jakt_label_35;case 106 /* Virtual */:{
 last_virtual = true;
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 91 /* Override */:{
+goto __jakt_label_35;case 91 /* Override */:{
 last_override = true;
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 99 /* Struct */:case 71 /* Enum */:case 62 /* Boxed */:case 65 /* Class */:{
+goto __jakt_label_35;case 99 /* Struct */:case 71 /* Enum */:case 62 /* Boxed */:case 65 /* Class */:{
 if (last_virtual || last_override){
 this->error(ByteString::from_utf8_without_validation("Nested types cannot be ‘virtual’ or ‘override’"sv),this->current().span());
 last_virtual = false;
@@ -7438,27 +6452,15 @@ if (last_visibility.has_value()){
 this->error(ByteString::from_utf8_without_validation("Nested types cannot have visibility modifiers"sv),this->current().span());
 last_visibility = JaktInternal::OptionalNone();
 }
-Jakt::parser::ParsedRecord parsed_record = this->parse_record(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::DefinitionLinkage,JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::parser::ParsedField>,JaktInternal::DynamicArray<Jakt::parser::ParsedMethod>,JaktInternal::DynamicArray<Jakt::parser::ParsedRecord>>> {
-auto __jakt_enum_value = (last_extern);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::parser::DefinitionLinkage::External());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(definition_linkage);
-}VERIFY_NOT_REACHED();
+Jakt::parser::ParsedRecord parsed_record = this->parse_record([&]() -> Jakt::parser::DefinitionLinkage { auto __jakt_enum_value = last_extern;
+if (__jakt_enum_value) {return Jakt::parser::DefinitionLinkage::External();}else if (!__jakt_enum_value) {return definition_linkage;}VERIFY_NOT_REACHED();
+ 
 }());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
 this->apply_attributes(parsed_record,active_attributes);
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 records.push(parsed_record);
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_35;default:{
 active_attributes = DynamicArray<Jakt::parser::ParsedAttribute>::create_with({});
 if (!error){
 this->error(__jakt_format(StringView::from_string_literal("Invalid member, did not expect a {} here"sv),token),token.span());
@@ -7466,18 +6468,8 @@ error = true;
 }
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_35;}/*switch end*/
+break;}goto __jakt_label_35; __jakt_label_35:;;
 }
 if (is_class){
 this->error(ByteString::from_utf8_without_validation("Incomplete class body, expected ‘}’"sv),this->current().span());
@@ -7619,17 +6611,10 @@ else if (for_trailing_closure && (this->current().__jakt_init_index() == 40 /* P
 this->index++;
 }
 else {
-this->error(__jakt_format(StringView::from_string_literal("Expected '{:c}'"sv),({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<u32,Jakt::parser::ParsedFunctionParameters> {
-auto __jakt_enum_value = (for_trailing_closure);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(static_cast<u32>(U'|'));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(static_cast<u32>(U')'));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-})),this->current().span());
+this->error(__jakt_format(StringView::from_string_literal("Expected '{:c}'"sv),[&]() -> u32 { auto __jakt_enum_value = for_trailing_closure;
+if (__jakt_enum_value) {return static_cast<u32>(U'|');}else if (!__jakt_enum_value) {return static_cast<u32>(U')');}VERIFY_NOT_REACHED();
+ 
+}()),this->current().span());
 }
 
 this->skip_newlines();
@@ -7639,14 +6624,12 @@ bool current_param_is_mutable = false;
 bool error = false;
 bool parameter_complete = false;
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, Jakt::parser::ParsedFunctionParameters>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* RParen */:{
 if (!for_trailing_closure){
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
 if ((!error) && (!result.has_varargs)){
 this->error(ByteString::from_utf8_without_validation("Expected parameter"sv),this->current().span());
@@ -7654,11 +6637,10 @@ error = true;
 }
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 40 /* Pipe */:{
+goto __jakt_label_36;case 40 /* Pipe */:{
 if (for_trailing_closure){
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
 if (!error){
 this->error(ByteString::from_utf8_without_validation("Expected parameter"sv),this->current().span());
@@ -7666,8 +6648,7 @@ error = true;
 }
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 52 /* Comma */:case 55 /* Eol */:{
+goto __jakt_label_36;case 52 /* Comma */:case 55 /* Eol */:{
 if ((!parameter_complete) && (!error)){
 this->error(ByteString::from_utf8_without_validation("Expected parameter"sv),this->current().span());
 error = true;
@@ -7677,8 +6658,7 @@ current_param_requires_label = true;
 current_param_is_mutable = false;
 parameter_complete = false;
 }
-return JaktInternal::ExplicitValue<void>();
-case 54 /* DotDot */:{
+goto __jakt_label_36;case 54 /* DotDot */:{
 if (result.has_varargs){
 this->error(ByteString::from_utf8_without_validation("Multiple varargs cannot be present in one parameter list"sv),this->current().span());
 error = true;
@@ -7697,8 +6677,7 @@ parameter_complete = false;
 current_param_requires_label = true;
 current_param_is_mutable = false;
 }
-return JaktInternal::ExplicitValue<void>();
-case 60 /* Anon */:{
+goto __jakt_label_36;case 60 /* Anon */:{
 if (result.has_varargs){
 this->error(ByteString::from_utf8_without_validation("A variadic argument may only appear at the end of a parameter list"sv),this->current().span());
 error = true;
@@ -7718,8 +6697,7 @@ error = true;
 this->index++;
 current_param_requires_label = false;
 }
-return JaktInternal::ExplicitValue<void>();
-case 87 /* Mut */:{
+goto __jakt_label_36;case 87 /* Mut */:{
 if (result.has_varargs){
 this->error(ByteString::from_utf8_without_validation("A variadic argument may only appear at the end of a parameter list"sv),this->current().span());
 error = true;
@@ -7735,8 +6713,7 @@ error = true;
 this->index++;
 current_param_is_mutable = true;
 }
-return JaktInternal::ExplicitValue<void>();
-case 100 /* This */:{
+goto __jakt_label_36;case 100 /* This */:{
 if (result.has_varargs){
 this->error(ByteString::from_utf8_without_validation("A variadic argument may only appear at the end of a parameter list"sv),this->current().span());
 error = true;
@@ -7745,8 +6722,7 @@ result.parameters.push(Jakt::parser::ParsedParameter(false,Jakt::parser::ParsedV
 this->index++;
 parameter_complete = true;
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* Identifier */: {
+goto __jakt_label_36;case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
@@ -7763,8 +6739,7 @@ default_argument = this->parse_expression(false,true);
 result.parameters.push(Jakt::parser::ParsedParameter(current_param_requires_label,Jakt::parser::ParsedVariable(var_decl.name,var_decl.parsed_type,var_decl.is_mutable,this->previous().span()),default_argument,this->previous().span()));
 parameter_complete = true;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_36;};/*case end*/
 default:{
 if (!error){
 this->error(ByteString::from_utf8_without_validation("Expected parameter"sv),this->current().span());
@@ -7772,18 +6747,8 @@ error = true;
 }
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_36;}/*switch end*/
+break;}goto __jakt_label_36; __jakt_label_36:;;
 }
 return result;
 }
@@ -7925,46 +6890,32 @@ if (this->current().__jakt_init_index() == 28 /* LessThan */){
 this->index++;
 bool saw_ending_bracket = false;
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 26 /* GreaterThan */:{
 this->index++;
 saw_ending_bracket = true;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 33 /* RightShift */:{
+goto __jakt_label_37;case 33 /* RightShift */:{
 this->inject_token(Jakt::lexer::Token::GreaterThan(this->current().span()));
 this->index++;
 saw_ending_bracket = true;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_37;default:{
 size_t index_before = this->index;
 params.push(this->parse_typename());
 if (this->index == index_before){
 this->error(ByteString::from_utf8_without_validation("Expected type parameter"sv),this->current().span());
-return JaktInternal::LoopBreak{};
+break;
 }
 if (this->current().__jakt_init_index() == 52 /* Comma */){
 this->index++;
 }
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_37;}/*switch end*/
+break;}goto __jakt_label_37; __jakt_label_37:;;
 }
 if (!saw_ending_bracket){
 this->error(ByteString::from_utf8_without_validation("Expected `>` after type parameters"sv),this->current().span());
@@ -7980,9 +6931,7 @@ NonnullRefPtr<typename Jakt::parser::ParsedType> const base = this->parse_typena
 NonnullRefPtr<typename Jakt::parser::ParsedType> result = base;
 bool done = false;
 while (!done){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, NonnullRefPtr<typename Jakt::parser::ParsedType>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* ColonColon */:{
 this->index++;
@@ -7999,22 +6948,11 @@ done = true;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_38;default:{
 done = true;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_38;}/*switch end*/
+break;}goto __jakt_label_38; __jakt_label_38:;;
 }
 return result;
 }
@@ -8080,31 +7018,20 @@ return parsed_type;
 
 NonnullRefPtr<typename Jakt::parser::ParsedType> Jakt::parser::Parser::parse_type_longhand(Jakt::parser::ParsedTypeQualifiers const qualifiers) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedType>, NonnullRefPtr<typename Jakt::parser::ParsedType>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 94 /* Raw */:{
 Jakt::utility::Span const start = this->current().span();
 this->index++;
 NonnullRefPtr<typename Jakt::parser::ParsedType> const inner = this->parse_typename();
 Jakt::utility::Span const span = Jakt::parser::merge_spans(start,this->current().span());
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedType>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedType>, NonnullRefPtr<typename Jakt::parser::ParsedType>>{
-auto&& __jakt_match_variant = *inner;
+{auto&& __jakt_match_variant = *inner;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* Optional */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Optional;NonnullRefPtr<typename Jakt::parser::ParsedType> const& inner = __jakt_match_value.inner;
-return JaktInternal::ExplicitValue(Jakt::parser::ParsedType::Optional(qualifiers,Jakt::parser::ParsedType::RawPtr(JaktInternal::OptionalNone(),inner,span),span));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(Jakt::parser::ParsedType::RawPtr(qualifiers,inner,span));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+return Jakt::parser::ParsedType::Optional(qualifiers,Jakt::parser::ParsedType::RawPtr(JaktInternal::OptionalNone(),inner,span),span);};/*case end*/
+default:return Jakt::parser::ParsedType::RawPtr(qualifiers,inner,span);}/*switch end*/
+}
 }
 VERIFY_NOT_REACHED();
 case 107 /* Weak */:{
@@ -8112,7 +7039,7 @@ Jakt::utility::Span const start = this->current().span();
 this->index++;
 NonnullRefPtr<typename Jakt::parser::ParsedType> const inner = this->parse_typename();
 Jakt::utility::Span const span = Jakt::parser::merge_spans(start,this->current().span());
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedType>>(Jakt::parser::ParsedType::WeakPtr(qualifiers,inner,span));
+return Jakt::parser::ParsedType::WeakPtr(qualifiers,inner,span);
 }
 VERIFY_NOT_REACHED();
 case 3 /* Identifier */: {
@@ -8129,9 +7056,7 @@ if (this->current().__jakt_init_index() == 6 /* ColonColon */){
 this->index++;
 JaktInternal::DynamicArray<ByteString> namespaces = DynamicArray<ByteString>::create_with({name});
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, NonnullRefPtr<typename Jakt::parser::ParsedType>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& namespace_name = __jakt_match_value.name;
@@ -8142,44 +7067,32 @@ this->index++;
 }
 else {
 this->error(ByteString::from_utf8_without_validation("Expected ‘::’ here"sv),Jakt::utility::Span(span.file_id,span.start,span.start));
-return JaktInternal::LoopBreak{};
+break;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_39;};/*case end*/
 case 6 /* ColonColon */:{
 if (this->previous().__jakt_init_index() == 3 /* Identifier */){
 this->index++;
 }
 else {
 this->error(ByteString::from_utf8_without_validation("Expected name after"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
-return JaktInternal::LoopBreak{};
+goto __jakt_label_39;default:{
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_39;}/*switch end*/
+break;}goto __jakt_label_39; __jakt_label_39:;;
 }
 ByteString const type_name = namespaces.pop().value();
 JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>> params = this->parse_type_parameter_list();
 parsed_type = Jakt::parser::ParsedType::NamespacedName(JaktInternal::OptionalNone(),type_name,namespaces,params,this->previous().span());
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedType>>(parsed_type);
+return parsed_type;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -8203,21 +7116,16 @@ else {
 this->error(ByteString::from_utf8_without_validation("Expected '->'"sv),this->current().span());
 }
 
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedType>>(Jakt::parser::ParsedType::Function(qualifiers,fn_parameters.parameters,can_throw,return_type,Jakt::parser::merge_spans(start,return_type->span())));
+return Jakt::parser::ParsedType::Function(qualifiers,fn_parameters.parameters,can_throw,return_type,Jakt::parser::merge_spans(start,return_type->span()));
 }
 VERIFY_NOT_REACHED();
 default:{
 this->error(ByteString::from_utf8_without_validation("Expected type name"sv),this->current().span());
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedType>>(Jakt::parser::ParsedType::Empty(qualifiers));
+return Jakt::parser::ParsedType::Empty(qualifiers);
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -8227,40 +7135,25 @@ Jakt::utility::Span const start = this->current().span();
 this->index++;
 JaktInternal::DynamicArray<Jakt::parser::ParsedVarDecl> var_declarations = DynamicArray<Jakt::parser::ParsedVarDecl>::create_with({});
 for (;;){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, Jakt::parser::ParsedVarDeclTuple>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Identifier */:{
 var_declarations.push(this->parse_variable_declaration(is_mutable));
 }
-return JaktInternal::ExplicitValue<void>();
-case 52 /* Comma */:{
+goto __jakt_label_40;case 52 /* Comma */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 8 /* RParen */:{
+goto __jakt_label_40;case 8 /* RParen */:{
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_40;default:{
 this->error(ByteString::from_utf8_without_validation("Expected close of destructuring assignment block"sv),this->current().span());
 var_declarations = DynamicArray<Jakt::parser::ParsedVarDecl>::create_with({});
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_40;}/*switch end*/
+break;}goto __jakt_label_40; __jakt_label_40:;;
 }
 return Jakt::parser::ParsedVarDeclTuple(var_declarations,Jakt::parser::merge_spans(start,this->previous().span()));
 }
@@ -8295,21 +7188,10 @@ return Jakt::parser::ParsedVarDecl(ByteString::from_utf8_without_validation(""sv
 
 NonnullRefPtr<typename Jakt::parser::ParsedType> Jakt::parser::Parser::parse_type_shorthand(Jakt::parser::ParsedTypeQualifiers const qualifiers) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedType>, NonnullRefPtr<typename Jakt::parser::ParsedType>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 11 /* LSquare */:return JaktInternal::ExplicitValue(this->parse_type_shorthand_array_or_dictionary(qualifiers));
-case 9 /* LCurly */:return JaktInternal::ExplicitValue(this->parse_type_shorthand_set(qualifiers));
-case 7 /* LParen */:return JaktInternal::ExplicitValue(this->parse_type_shorthand_tuple(qualifiers));
-default:return JaktInternal::ExplicitValue(Jakt::parser::ParsedType::Empty(qualifiers));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 11 /* LSquare */:return this->parse_type_shorthand_array_or_dictionary(qualifiers);case 9 /* LCurly */:return this->parse_type_shorthand_set(qualifiers);case 7 /* LParen */:return this->parse_type_shorthand_tuple(qualifiers);default:return Jakt::parser::ParsedType::Empty(qualifiers);}/*switch end*/
+}
 }
 }
 
@@ -8398,34 +7280,20 @@ this->error(ByteString::from_utf8_without_validation("Expected '{'"sv),start);
 }
 
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, Jakt::parser::ParsedBlock>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* RCurly */:{
 this->index++;
 return block;
 }
-return JaktInternal::ExplicitValue<void>();
-case 4 /* Semicolon */:case 55 /* Eol */:{
+goto __jakt_label_41;case 4 /* Semicolon */:case 55 /* Eol */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_41;default:{
 block.stmts.push(this->parse_statement(true));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_41;}/*switch end*/
+break;}goto __jakt_label_41; __jakt_label_41:;;
 }
 this->error(ByteString::from_utf8_without_validation("Expected complete block"sv),this->current().span());
 return block;
@@ -8435,63 +7303,53 @@ return block;
 NonnullRefPtr<typename Jakt::parser::ParsedStatement> Jakt::parser::Parser::parse_statement(bool const inside_block) {
 {
 Jakt::utility::Span const start = this->current().span();
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedStatement>, NonnullRefPtr<typename Jakt::parser::ParsedStatement>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 67 /* Cpp */:{
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>(Jakt::parser::ParsedStatement::InlineCpp(this->parse_block(),Jakt::parser::merge_spans(start,this->previous().span())));
+return Jakt::parser::ParsedStatement::InlineCpp(this->parse_block(),Jakt::parser::merge_spans(start,this->previous().span()));
 }
 VERIFY_NOT_REACHED();
 case 68 /* Defer */:{
 this->index++;
 NonnullRefPtr<typename Jakt::parser::ParsedStatement> const statement = this->parse_statement(false);
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>(Jakt::parser::ParsedStatement::Defer(statement,Jakt::parser::merge_spans(start,this->previous().span())));
+return Jakt::parser::ParsedStatement::Defer(statement,Jakt::parser::merge_spans(start,this->previous().span()));
 }
 VERIFY_NOT_REACHED();
-case 105 /* Unsafe */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedStatement>, NonnullRefPtr<typename Jakt::parser::ParsedStatement>>{
-auto&& __jakt_match_variant = this->peek(static_cast<size_t>(1ULL));
+case 105 /* Unsafe */:{auto&& __jakt_match_variant = this->peek(static_cast<size_t>(1ULL));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* LCurly */:{
 this->index++;
 Jakt::parser::ParsedBlock const block = this->parse_block();
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>(Jakt::parser::ParsedStatement::UnsafeBlock(block,Jakt::parser::merge_spans(start,this->previous().span())));
+return Jakt::parser::ParsedStatement::UnsafeBlock(block,Jakt::parser::merge_spans(start,this->previous().span()));
 }
 VERIFY_NOT_REACHED();
 default:{
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = this->parse_expression(true,false);
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>(Jakt::parser::ParsedStatement::Expression(expr,Jakt::parser::merge_spans(start,this->previous().span())));
+return Jakt::parser::ParsedStatement::Expression(expr,Jakt::parser::merge_spans(start,this->previous().span()));
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 63 /* Break */:{
+}case 63 /* Break */:{
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>(Jakt::parser::ParsedStatement::Break(start));
+return Jakt::parser::ParsedStatement::Break(start);
 }
 VERIFY_NOT_REACHED();
 case 66 /* Continue */:{
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>(Jakt::parser::ParsedStatement::Continue(start));
+return Jakt::parser::ParsedStatement::Continue(start);
 }
 VERIFY_NOT_REACHED();
 case 84 /* Loop */:{
 this->index++;
 Jakt::parser::ParsedBlock const block = this->parse_block();
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>(Jakt::parser::ParsedStatement::Loop(block,Jakt::parser::merge_spans(start,this->previous().span())));
+return Jakt::parser::ParsedStatement::Loop(block,Jakt::parser::merge_spans(start,this->previous().span()));
 }
 VERIFY_NOT_REACHED();
 case 101 /* Throw */:{
 this->index++;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = this->parse_expression(false,false);
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>(Jakt::parser::ParsedStatement::Throw(expr,Jakt::parser::merge_spans(start,this->previous().span())));
+return Jakt::parser::ParsedStatement::Throw(expr,Jakt::parser::merge_spans(start,this->previous().span()));
 }
 VERIFY_NOT_REACHED();
 case 108 /* While */:{
@@ -8501,20 +7359,18 @@ this->can_have_trailing_closure = false;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const condition = this->parse_expression(false,true);
 this->can_have_trailing_closure = previous_can_have_trailing_closure;
 Jakt::parser::ParsedBlock const block = this->parse_block();
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>(Jakt::parser::ParsedStatement::While(condition,block,Jakt::parser::merge_spans(start,this->previous().span())));
+return Jakt::parser::ParsedStatement::While(condition,block,Jakt::parser::merge_spans(start,this->previous().span()));
 }
 VERIFY_NOT_REACHED();
 case 109 /* Yield */:{
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedStatement>, NonnullRefPtr<typename Jakt::parser::ParsedStatement>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 55 /* Eol */:case 56 /* Eof */:case 10 /* RCurly */:{
 if (!inside_block){
 this->error(ByteString::from_utf8_without_validation("‘yield’ can only be used inside a block"sv),start);
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>(Jakt::parser::ParsedStatement::Yield(JaktInternal::OptionalNone(),start));
+return Jakt::parser::ParsedStatement::Yield(JaktInternal::OptionalNone(),start);
 }
 VERIFY_NOT_REACHED();
 default:{
@@ -8522,33 +7378,19 @@ NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = this->parse_
 if (!inside_block){
 this->error(ByteString::from_utf8_without_validation("‘yield’ can only be used inside a block"sv),Jakt::parser::merge_spans(start,expr->span()));
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>(Jakt::parser::ParsedStatement::Yield(expr,Jakt::parser::merge_spans(start,this->previous().span())));
+return Jakt::parser::ParsedStatement::Yield(expr,Jakt::parser::merge_spans(start,this->previous().span()));
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}
 }
 VERIFY_NOT_REACHED();
 case 96 /* Return */:{
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedStatement>, NonnullRefPtr<typename Jakt::parser::ParsedStatement>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 55 /* Eol */:case 56 /* Eof */:case 10 /* RCurly */:return JaktInternal::ExplicitValue(Jakt::parser::ParsedStatement::Return(JaktInternal::OptionalNone(),start));
-default:return JaktInternal::ExplicitValue(Jakt::parser::ParsedStatement::Return(this->parse_expression(false,false),Jakt::parser::merge_spans(start,this->previous().span())));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+case 55 /* Eol */:case 56 /* Eof */:case 10 /* RCurly */:return Jakt::parser::ParsedStatement::Return(JaktInternal::OptionalNone(),start);default:return Jakt::parser::ParsedStatement::Return(this->parse_expression(false,false),Jakt::parser::merge_spans(start,this->previous().span()));}/*switch end*/
+}
 }
 VERIFY_NOT_REACHED();
 case 83 /* Let */:case 87 /* Mut */:{
@@ -8591,55 +7433,41 @@ else {
 tuple_var_decl = this->parse_variable_declaration(is_mutable);
 }
 
-NonnullRefPtr<typename Jakt::parser::ParsedExpression> const init = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedExpression>, NonnullRefPtr<typename Jakt::parser::ParsedStatement>>{
-auto&& __jakt_match_variant = this->current();
+NonnullRefPtr<typename Jakt::parser::ParsedExpression> const init = [&]() -> NonnullRefPtr<typename Jakt::parser::ParsedExpression> { auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 16 /* Equal */:{
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(this->parse_expression(false,false));
+return this->parse_expression(false,false);
 }
 VERIFY_NOT_REACHED();
 default:{
 this->error(ByteString::from_utf8_without_validation("Expected initializer"sv),this->current().span());
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::Garbage(this->current().span()));
+return Jakt::parser::ParsedExpression::Garbage(this->current().span());
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 NonnullRefPtr<typename Jakt::parser::ParsedStatement> return_statement = Jakt::parser::ParsedStatement::VarDecl(tuple_var_decl,init,Jakt::parser::merge_spans(start,this->previous().span()));
 if (is_destructuring_assingment){
 NonnullRefPtr<typename Jakt::parser::ParsedStatement> const old_return_statement = return_statement;
 return_statement = Jakt::parser::ParsedStatement::DestructuringAssignment(vars,old_return_statement,Jakt::parser::merge_spans(start,this->previous().span()));
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>(return_statement);
+return return_statement;
 }
 VERIFY_NOT_REACHED();
-case 78 /* If */:return JaktInternal::ExplicitValue(this->parse_if_statement());
-case 75 /* For */:return JaktInternal::ExplicitValue(this->parse_for_statement());
-case 9 /* LCurly */:{
+case 78 /* If */:return this->parse_if_statement();case 75 /* For */:return this->parse_for_statement();case 9 /* LCurly */:{
 Jakt::parser::ParsedBlock const block = this->parse_block();
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>(Jakt::parser::ParsedStatement::Block(block,Jakt::parser::merge_spans(start,this->previous().span())));
+return Jakt::parser::ParsedStatement::Block(block,Jakt::parser::merge_spans(start,this->previous().span()));
 }
 VERIFY_NOT_REACHED();
-case 110 /* Guard */:return JaktInternal::ExplicitValue(this->parse_guard_statement());
-default:{
+case 110 /* Guard */:return this->parse_guard_statement();default:{
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = this->parse_expression(true,false);
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>(Jakt::parser::ParsedStatement::Expression(expr,Jakt::parser::merge_spans(start,this->previous().span())));
+return Jakt::parser::ParsedStatement::Expression(expr,Jakt::parser::merge_spans(start,this->previous().span()));
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -8661,33 +7489,19 @@ this->error(ByteString::from_utf8_without_validation("Expected `else` keyword"sv
 Jakt::parser::ParsedBlock const else_block = this->parse_block();
 Jakt::parser::ParsedBlock remaining_code = Jakt::parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>::create_with({}));
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, NonnullRefPtr<typename Jakt::parser::ParsedStatement>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* RCurly */:{
 return Jakt::parser::ParsedStatement::Guard(expr,else_block,remaining_code,span);
 }
-return JaktInternal::ExplicitValue<void>();
-case 4 /* Semicolon */:case 55 /* Eol */:{
+goto __jakt_label_42;case 4 /* Semicolon */:case 55 /* Eol */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_42;default:{
 remaining_code.stmts.push(this->parse_statement(true));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_42;}/*switch end*/
+break;}goto __jakt_label_42; __jakt_label_42:;;
 }
 return Jakt::parser::ParsedStatement::Guard(expr,else_block,remaining_code,span);
 }
@@ -8725,9 +7539,7 @@ this->index++;
 ByteString iterator_name = ByteString::from_utf8_without_validation(""sv);
 JaktInternal::DynamicArray<Jakt::parser::ParsedVarDecl> destructured_var_decls = DynamicArray<Jakt::parser::ParsedVarDecl>::create_with({});
 Jakt::utility::Span name_span = this->current().span();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, NonnullRefPtr<typename Jakt::parser::ParsedStatement>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
@@ -8735,8 +7547,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const&
 iterator_name = name;
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_43;};/*case end*/
 case 7 /* LParen */:{
 Jakt::parser::ParsedVarDeclTuple const destructured_assignment = this->parse_destructuring_assignment(false);
 destructured_var_decls = destructured_assignment.var_decls;
@@ -8768,19 +7579,12 @@ self = (self + rhs);
 name_span = destructured_assignment.span;
 iterator_name = tuple_var_name;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_43;default:{
 this->error(ByteString::from_utf8_without_validation("Expected iterator name or destructuring pattern"sv),this->current().span());
 return Jakt::parser::ParsedStatement::Garbage(Jakt::parser::merge_spans(start_span,this->current().span()));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_43;}/*switch end*/
+}goto __jakt_label_43; __jakt_label_43:;;
 if (this->current().__jakt_init_index() == 81 /* In */){
 this->index++;
 }
@@ -8834,33 +7638,23 @@ this->skip_newlines();
 if (this->current().__jakt_init_index() == 70 /* Else */){
 this->index++;
 this->skip_newlines();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, NonnullRefPtr<typename Jakt::parser::ParsedStatement>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 78 /* If */:{
 else_statement = this->parse_if_statement();
 }
-return JaktInternal::ExplicitValue<void>();
-case 9 /* LCurly */:{
+goto __jakt_label_44;case 9 /* LCurly */:{
 Jakt::parser::ParsedBlock const block = this->parse_block();
 if (then_block.equals(block)){
 this->error(ByteString::from_utf8_without_validation("if and else have identical blocks"sv),this->current().span());
 }
 else_statement = Jakt::parser::ParsedStatement::Block(block,Jakt::parser::merge_spans(start_span,this->previous().span()));
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_44;default:{
 this->error(ByteString::from_utf8_without_validation("‘else’ missing ‘if’ or block"sv),this->previous().span());
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_44;}/*switch end*/
+}goto __jakt_label_44; __jakt_label_44:;;
 }
 return Jakt::parser::ParsedStatement::If(condition,then_block,else_statement,Jakt::parser::merge_spans(start_span,this->previous().span()));
 }
@@ -8902,9 +7696,7 @@ expr_stack.push(rhs);
 break;
 }
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const lhs = expr_stack.pop().value();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = *op;
+{auto&& __jakt_match_variant = *op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* Operator */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Operator;Jakt::parser::BinaryOperator const& op = __jakt_match_value.op;
@@ -8913,23 +7705,12 @@ Jakt::utility::Span const& span = __jakt_match_value.span;
 Jakt::utility::Span const new_span = Jakt::parser::merge_spans(lhs->span(),rhs->span());
 expr_stack.push(Jakt::parser::ParsedExpression::BinaryOp(lhs,op,rhs,new_span));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_45;};/*case end*/
 default:{
 this->compiler->panic(ByteString::from_utf8_without_validation("operator is not an operator"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_45;}/*switch end*/
+break;}goto __jakt_label_45; __jakt_label_45:;;
 }
 expr_stack.push(parsed_operator);
 expr_stack.push(rhs);
@@ -8939,9 +7720,7 @@ while (expr_stack.size() > static_cast<size_t>(1ULL)){
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const rhs = expr_stack.pop().value();
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const parsed_operator = expr_stack.pop().value();
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const lhs = expr_stack.pop().value();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = *parsed_operator;
+{auto&& __jakt_match_variant = *parsed_operator;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* Operator */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Operator;Jakt::parser::BinaryOperator const& op = __jakt_match_value.op;
@@ -8950,38 +7729,25 @@ Jakt::utility::Span const& span = __jakt_match_value.span;
 Jakt::utility::Span const new_span = Jakt::parser::merge_spans(lhs->span(),rhs->span());
 expr_stack.push(Jakt::parser::ParsedExpression::BinaryOp(lhs,op,rhs,new_span));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_46;};/*case end*/
 default:{
 this->compiler->panic(ByteString::from_utf8_without_validation("operator is not an operator"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_46;}/*switch end*/
+break;}goto __jakt_label_46; __jakt_label_46:;;
 }
-return expr_stack.operator[](static_cast<i64>(0LL));
+return expr_stack[static_cast<i64>(0LL)];
 }
 }
 
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> Jakt::parser::Parser::parse_operand_base() {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedExpression>, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::Var(ByteString::from_utf8_without_validation("this"sv),span));
+return Jakt::parser::ParsedExpression::Var(ByteString::from_utf8_without_validation("this"sv),span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -8992,7 +7758,7 @@ Jakt::utility::Span const start = this->current().span();
 this->index++;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = this->parse_operand();
 Jakt::utility::Span const span = Jakt::parser::merge_spans(start,expr->span());
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::Must(expr,span));
+return Jakt::parser::ParsedExpression::Must(expr,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -9000,12 +7766,9 @@ case 104 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedExpression>, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 9 /* LCurly */:return JaktInternal::ExplicitValue(this->parse_try_block());
-default:{
+case 9 /* LCurly */:return this->parse_try_block();default:{
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expression = this->parse_expression(true,true);
 JaktInternal::Optional<Jakt::parser::ParsedBlock> catch_block = JaktInternal::OptionalNone();
 JaktInternal::Optional<ByteString> catch_name = JaktInternal::OptionalNone();
@@ -9021,16 +7784,11 @@ this->index++;
 }
 catch_block = this->parse_block();
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::Try(expression,catch_block,catch_span,catch_name,span));
+return Jakt::parser::ParsedExpression::Try(expression,catch_block,catch_span,catch_name,span);
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -9039,7 +7797,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;ByteString cons
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::QuotedString(quote,span));
+return Jakt::parser::ParsedExpression::QuotedString(quote,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -9049,7 +7807,7 @@ JaktInternal::Optional<ByteString> const& prefix = __jakt_match_value.prefix;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::SingleQuotedString(quote,prefix,span));
+return Jakt::parser::ParsedExpression::SingleQuotedString(quote,prefix,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -9058,13 +7816,12 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Number;Jakt::lexer::LiteralP
 ByteString const& number = __jakt_match_value.number;
 Jakt::lexer::LiteralSuffix const& suffix = __jakt_match_value.suffix;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(this->parse_number(prefix,number,suffix,span));
-};/*case end*/
+return this->parse_number(prefix,number,suffix,span);};/*case end*/
 case 103 /* True */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.True;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::Boolean(true,span));
+return Jakt::parser::ParsedExpression::Boolean(true,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -9072,7 +7829,7 @@ case 74 /* False */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.False;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::Boolean(false,span));
+return Jakt::parser::ParsedExpression::Boolean(false,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -9080,7 +7837,7 @@ case 100 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::Var(ByteString::from_utf8_without_validation("this"sv),span));
+return Jakt::parser::ParsedExpression::Var(ByteString::from_utf8_without_validation("this"sv),span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -9091,7 +7848,7 @@ Jakt::utility::Span const start = this->current().span();
 this->index++;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = this->parse_operand();
 Jakt::utility::Span const span = Jakt::parser::merge_spans(start,expr->span());
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::UnaryOp(expr,Jakt::parser::UnaryOperator::LogicalNot(),span));
+return Jakt::parser::ParsedExpression::UnaryOp(expr,Jakt::parser::UnaryOperator::LogicalNot(),span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -9102,7 +7859,7 @@ Jakt::utility::Span const start = this->current().span();
 this->index++;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = this->parse_operand();
 Jakt::utility::Span const span = Jakt::parser::merge_spans(start,expr->span());
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::UnaryOp(expr,Jakt::parser::UnaryOperator::BitwiseNot(),span));
+return Jakt::parser::ParsedExpression::UnaryOp(expr,Jakt::parser::UnaryOperator::BitwiseNot(),span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -9113,7 +7870,7 @@ Jakt::utility::Span const start = this->current().span();
 this->index++;
 NonnullRefPtr<typename Jakt::parser::ParsedType> const parsed_type = this->parse_typename();
 Jakt::utility::Span const span = Jakt::parser::merge_spans(start,parsed_type->span());
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::UnaryOp(Jakt::parser::ParsedExpression::Garbage(span),Jakt::parser::UnaryOperator::Sizeof(parsed_type),span));
+return Jakt::parser::ParsedExpression::UnaryOp(Jakt::parser::ParsedExpression::Garbage(span),Jakt::parser::UnaryOperator::Sizeof(parsed_type),span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -9124,7 +7881,7 @@ Jakt::utility::Span const start = this->current().span();
 this->index++;
 NonnullRefPtr<typename Jakt::parser::ParsedType> const type = this->parse_typename();
 Jakt::utility::Span const span = Jakt::parser::merge_spans(start,type->span());
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::Reflect(type,span));
+return Jakt::parser::ParsedExpression::Reflect(type,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -9146,16 +7903,8 @@ this->compiler->ignore_parser_errors = true;
 JaktInternal::Optional<Jakt::parser::ParsedCall> const call = this->parse_call();
 this->compiler->ignore_parser_errors = false;
 if (!call.has_value()){
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,NonnullRefPtr<typename Jakt::parser::ParsedExpression>> {
-auto __jakt_enum_value = (name);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("None"sv)) {return JaktInternal::ExplicitValue(Jakt::parser::ParsedExpression::OptionalNone(span));
-}else {return JaktInternal::ExplicitValue(Jakt::parser::ParsedExpression::Var(name,span));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = name;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("None"sv)) {return Jakt::parser::ParsedExpression::OptionalNone(span);}else {return Jakt::parser::ParsedExpression::Var(name,span);}}
 }
 return Jakt::parser::ParsedExpression::Call(call.value(),span);
 }
@@ -9163,7 +7912,7 @@ this->index++;
 if (name == ByteString::from_utf8_without_validation("None"sv)){
 return Jakt::parser::ParsedExpression::OptionalNone(span);
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::Var(name,span));
+return Jakt::parser::ParsedExpression::Var(name,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -9174,186 +7923,125 @@ Jakt::utility::Span const start_span = this->current().span();
 this->index++;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> expr = this->parse_expression(false,false);
 this->skip_newlines();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* RParen */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 52 /* Comma */:{
+goto __jakt_label_47;case 52 /* Comma */:{
 this->index++;
 JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> tuple_exprs = DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>::create_with({expr});
 Jakt::utility::Span end_span = start_span;
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 55 /* Eol */:case 52 /* Comma */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 8 /* RParen */:{
+goto __jakt_label_48;case 8 /* RParen */:{
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_48;default:{
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = this->parse_expression(false,false);
 end_span = expr->span();
 tuple_exprs.push(expr);
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_48;}/*switch end*/
+break;}goto __jakt_label_48; __jakt_label_48:;;
 }
 if (this->eof()){
 this->error(ByteString::from_utf8_without_validation("Expected ')'"sv),this->current().span());
 }
 expr = Jakt::parser::ParsedExpression::JaktTuple(tuple_exprs,Jakt::parser::merge_spans(start_span,end_span));
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_47;default:{
 this->error(ByteString::from_utf8_without_validation("Expected ')'"sv),this->current().span());
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(expr);
+goto __jakt_label_47;}/*switch end*/
+}goto __jakt_label_47; __jakt_label_47:;;
+return expr;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 18 /* PlusPlus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusPlus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
-Jakt::parser::UnaryOperator const op = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::UnaryOperator, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = this->current();
+Jakt::parser::UnaryOperator const op = [&]() -> Jakt::parser::UnaryOperator { auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 18 /* PlusPlus */:return JaktInternal::ExplicitValue(Jakt::parser::UnaryOperator::PreIncrement());
-case 20 /* MinusMinus */:return JaktInternal::ExplicitValue(Jakt::parser::UnaryOperator::PreDecrement());
-case 15 /* Minus */:return JaktInternal::ExplicitValue(Jakt::parser::UnaryOperator::Negate());
-default:{
+case 18 /* PlusPlus */:return Jakt::parser::UnaryOperator::PreIncrement();case 20 /* MinusMinus */:return Jakt::parser::UnaryOperator::PreDecrement();case 15 /* Minus */:return Jakt::parser::UnaryOperator::Negate();default:{
 this->compiler->panic(ByteString::from_utf8_without_validation("unreachable"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 Jakt::utility::Span const start = this->current().span();
 this->index++;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = this->parse_operand();
 Jakt::utility::Span const span = Jakt::parser::merge_spans(start,expr->span());
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::UnaryOp(expr,op,span));
+return Jakt::parser::ParsedExpression::UnaryOp(expr,op,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 20 /* MinusMinus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusMinus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
-Jakt::parser::UnaryOperator const op = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::UnaryOperator, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = this->current();
+Jakt::parser::UnaryOperator const op = [&]() -> Jakt::parser::UnaryOperator { auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 18 /* PlusPlus */:return JaktInternal::ExplicitValue(Jakt::parser::UnaryOperator::PreIncrement());
-case 20 /* MinusMinus */:return JaktInternal::ExplicitValue(Jakt::parser::UnaryOperator::PreDecrement());
-case 15 /* Minus */:return JaktInternal::ExplicitValue(Jakt::parser::UnaryOperator::Negate());
-default:{
+case 18 /* PlusPlus */:return Jakt::parser::UnaryOperator::PreIncrement();case 20 /* MinusMinus */:return Jakt::parser::UnaryOperator::PreDecrement();case 15 /* Minus */:return Jakt::parser::UnaryOperator::Negate();default:{
 this->compiler->panic(ByteString::from_utf8_without_validation("unreachable"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 Jakt::utility::Span const start = this->current().span();
 this->index++;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = this->parse_operand();
 Jakt::utility::Span const span = Jakt::parser::merge_spans(start,expr->span());
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::UnaryOp(expr,op,span));
+return Jakt::parser::ParsedExpression::UnaryOp(expr,op,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 15 /* Minus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Minus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
-Jakt::parser::UnaryOperator const op = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::UnaryOperator, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = this->current();
+Jakt::parser::UnaryOperator const op = [&]() -> Jakt::parser::UnaryOperator { auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 18 /* PlusPlus */:return JaktInternal::ExplicitValue(Jakt::parser::UnaryOperator::PreIncrement());
-case 20 /* MinusMinus */:return JaktInternal::ExplicitValue(Jakt::parser::UnaryOperator::PreDecrement());
-case 15 /* Minus */:return JaktInternal::ExplicitValue(Jakt::parser::UnaryOperator::Negate());
-default:{
+case 18 /* PlusPlus */:return Jakt::parser::UnaryOperator::PreIncrement();case 20 /* MinusMinus */:return Jakt::parser::UnaryOperator::PreDecrement();case 15 /* Minus */:return Jakt::parser::UnaryOperator::Negate();default:{
 this->compiler->panic(ByteString::from_utf8_without_validation("unreachable"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 Jakt::utility::Span const start = this->current().span();
 this->index++;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = this->parse_operand();
 Jakt::utility::Span const span = Jakt::parser::merge_spans(start,expr->span());
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::UnaryOp(expr,op,span));
+return Jakt::parser::ParsedExpression::UnaryOp(expr,op,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 11 /* LSquare */:{
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(this->parse_array_or_dictionary_literal());
+return this->parse_array_or_dictionary_literal();
 }
 VERIFY_NOT_REACHED();
 case 85 /* Match */:{
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(this->parse_match_expression());
+return this->parse_match_expression();
 }
 VERIFY_NOT_REACHED();
 case 9 /* LCurly */:{
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(this->parse_set_literal());
+return this->parse_set_literal();
 }
 VERIFY_NOT_REACHED();
-case 37 /* Ampersand */:return JaktInternal::ExplicitValue(this->parse_ampersand());
-case 36 /* Asterisk */:return JaktInternal::ExplicitValue(this->parse_asterisk());
-case 76 /* Fn */:return JaktInternal::ExplicitValue(this->parse_lambda());
-case 54 /* DotDot */:return JaktInternal::ExplicitValue(this->parse_range());
-case 105 /* Unsafe */:return JaktInternal::ExplicitValue(this->parse_unsafe_expr());
-default:{
+case 37 /* Ampersand */:return this->parse_ampersand();case 36 /* Asterisk */:return this->parse_asterisk();case 76 /* Fn */:return this->parse_lambda();case 54 /* DotDot */:return this->parse_range();case 105 /* Unsafe */:return this->parse_unsafe_expr();default:{
 Jakt::utility::Span const span = this->current().span();
 this->index++;
 this->error(ByteString::from_utf8_without_validation("Unsupported expression"sv),span);
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::Garbage(span));
+return Jakt::parser::ParsedExpression::Garbage(span);
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -9362,9 +8050,7 @@ NonnullRefPtr<typename Jakt::parser::ParsedExpression> Jakt::parser::Parser::par
 this->index++;
 u64 total = static_cast<u64>(0ULL);
 if (!(prefix.__jakt_init_index() == 0 /* None */)){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = prefix;
+{auto&& __jakt_match_variant = prefix;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Hexadecimal */:{
 if (number.length() == static_cast<size_t>(0ULL)){
@@ -9399,8 +8085,7 @@ total = JaktInternal::checked_add(JaktInternal::checked_mul(total,static_cast<u6
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* Octal */:{
+goto __jakt_label_49;case 2 /* Octal */:{
 if (number.length() == static_cast<size_t>(0ULL)){
 this->error(__jakt_format(StringView::from_string_literal("Could not parse octal number due to no digits"sv)),span);
 return Jakt::parser::ParsedExpression::Garbage(span);
@@ -9425,8 +8110,7 @@ total = JaktInternal::checked_add(JaktInternal::checked_mul(total,static_cast<u6
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* Binary */:{
+goto __jakt_label_49;case 3 /* Binary */:{
 if (number.length() == static_cast<size_t>(0ULL)){
 this->error(__jakt_format(StringView::from_string_literal("Could not parse binary number due to no digits"sv)),span);
 return Jakt::parser::ParsedExpression::Garbage(span);
@@ -9451,17 +8135,10 @@ total = JaktInternal::checked_add(JaktInternal::checked_mul(total,static_cast<u6
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-case 0 /* None */:{
+goto __jakt_label_49;case 0 /* None */:{
 }
-return JaktInternal::ExplicitValue<void>();
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_49;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_49; __jakt_label_49:;;
 JaktInternal::Optional<Jakt::parser::NumericConstant> const constant_value = this->make_integer_numeric_constant(total,suffix,span);
 if (constant_value.has_value()){
 return Jakt::parser::ParsedExpression::NumericConstant(constant_value.value(),span);
@@ -9517,39 +8194,24 @@ return Jakt::parser::ParsedExpression::Garbage(span);
 if (floating && (suffix.__jakt_init_index() == 0 /* None */)){
 suffix = Jakt::lexer::LiteralSuffix::F64();
 }
-bool const is_float_suffix = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = suffix;
+bool const is_float_suffix = [&]() -> bool { auto&& __jakt_match_variant = suffix;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 10 /* F32 */:case 11 /* F64 */:return JaktInternal::ExplicitValue(true);
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 10 /* F32 */:case 11 /* F64 */:return true;default:return false;}/*switch end*/
+ 
+}();
 if (floating && (!is_float_suffix)){
 return Jakt::parser::ParsedExpression::Garbage(span);
 }
-JaktInternal::Optional<Jakt::parser::NumericConstant> const constant_value = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::parser::NumericConstant>, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = suffix;
+JaktInternal::Optional<Jakt::parser::NumericConstant> const constant_value = [&]() -> JaktInternal::Optional<Jakt::parser::NumericConstant> { auto&& __jakt_match_variant = suffix;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* F32 */:case 11 /* F64 */:{
 f64 const number = Jakt::parser::u64_to_float<f64>(total) + Jakt::parser::u64_to_float<f64>(fraction_nominator) / Jakt::parser::u64_to_float<f64>(fraction_denominator);
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::parser::NumericConstant>>(this->make_float_numeric_constant(number,suffix,span));
+return this->make_float_numeric_constant(number,suffix,span);
 }
 VERIFY_NOT_REACHED();
-default:return JaktInternal::ExplicitValue(this->make_integer_numeric_constant(total,suffix,span));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return this->make_integer_numeric_constant(total,suffix,span);}/*switch end*/
+ 
+}();
 if (constant_value.has_value()){
 return Jakt::parser::ParsedExpression::NumericConstant(constant_value.value(),span);
 }
@@ -9559,9 +8221,7 @@ return Jakt::parser::ParsedExpression::Garbage(span);
 
 JaktInternal::Optional<Jakt::parser::NumericConstant> Jakt::parser::Parser::make_integer_numeric_constant(u64 const number,Jakt::lexer::LiteralSuffix const suffix,Jakt::utility::Span const span) {
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, JaktInternal::Optional<Jakt::parser::NumericConstant>>{
-auto&& __jakt_match_variant = suffix;
+{auto&& __jakt_match_variant = suffix;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* None */:{
 JaktInternal::Optional<i64> const n = fallible_integer_cast<i64>(number);
@@ -9570,8 +8230,7 @@ return Jakt::parser::NumericConstant::UnknownSigned(n.value());
 }
 return Jakt::parser::NumericConstant::UnknownUnsigned(number);
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* U8 */:{
+goto __jakt_label_50;case 2 /* U8 */:{
 JaktInternal::Optional<u8> const n = fallible_integer_cast<u8>(number);
 if (!n.has_value()){
 this->error(__jakt_format(StringView::from_string_literal("Number {} cannot fit in integer type {}"sv),number,suffix),span);
@@ -9579,8 +8238,7 @@ return Jakt::parser::NumericConstant::U64(number);
 }
 return Jakt::parser::NumericConstant::U8(n.value());
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* U16 */:{
+goto __jakt_label_50;case 3 /* U16 */:{
 JaktInternal::Optional<u16> const n = fallible_integer_cast<u16>(number);
 if (!n.has_value()){
 this->error(__jakt_format(StringView::from_string_literal("Number {} cannot fit in integer type {}"sv),number,suffix),span);
@@ -9588,8 +8246,7 @@ return Jakt::parser::NumericConstant::U64(number);
 }
 return Jakt::parser::NumericConstant::U16(n.value());
 }
-return JaktInternal::ExplicitValue<void>();
-case 4 /* U32 */:{
+goto __jakt_label_50;case 4 /* U32 */:{
 JaktInternal::Optional<u32> const n = fallible_integer_cast<u32>(number);
 if (!n.has_value()){
 this->error(__jakt_format(StringView::from_string_literal("Number {} cannot fit in integer type {}"sv),number,suffix),span);
@@ -9597,8 +8254,7 @@ return Jakt::parser::NumericConstant::U64(number);
 }
 return Jakt::parser::NumericConstant::U32(n.value());
 }
-return JaktInternal::ExplicitValue<void>();
-case 5 /* U64 */:{
+goto __jakt_label_50;case 5 /* U64 */:{
 JaktInternal::Optional<u64> const n = fallible_integer_cast<u64>(number);
 if (!n.has_value()){
 this->error(__jakt_format(StringView::from_string_literal("Number {} cannot fit in integer type {}"sv),number,suffix),span);
@@ -9606,8 +8262,7 @@ return Jakt::parser::NumericConstant::U64(number);
 }
 return Jakt::parser::NumericConstant::U64(n.value());
 }
-return JaktInternal::ExplicitValue<void>();
-case 1 /* UZ */:{
+goto __jakt_label_50;case 1 /* UZ */:{
 JaktInternal::Optional<size_t> const n = fallible_integer_cast<size_t>(number);
 if (!n.has_value()){
 this->error(__jakt_format(StringView::from_string_literal("Number {} cannot fit in integer type {}"sv),number,suffix),span);
@@ -9615,8 +8270,7 @@ return Jakt::parser::NumericConstant::U64(number);
 }
 return Jakt::parser::NumericConstant::USize(infallible_integer_cast<u64>(n.value()));
 }
-return JaktInternal::ExplicitValue<void>();
-case 6 /* I8 */:{
+goto __jakt_label_50;case 6 /* I8 */:{
 JaktInternal::Optional<i8> const n = fallible_integer_cast<i8>(number);
 if (!n.has_value()){
 this->error(__jakt_format(StringView::from_string_literal("Number {} cannot fit in integer type {}"sv),number,suffix),span);
@@ -9624,8 +8278,7 @@ return Jakt::parser::NumericConstant::U64(number);
 }
 return Jakt::parser::NumericConstant::I8(n.value());
 }
-return JaktInternal::ExplicitValue<void>();
-case 7 /* I16 */:{
+goto __jakt_label_50;case 7 /* I16 */:{
 JaktInternal::Optional<i16> const n = fallible_integer_cast<i16>(number);
 if (!n.has_value()){
 this->error(__jakt_format(StringView::from_string_literal("Number {} cannot fit in integer type {}"sv),number,suffix),span);
@@ -9633,8 +8286,7 @@ return Jakt::parser::NumericConstant::U64(number);
 }
 return Jakt::parser::NumericConstant::I16(n.value());
 }
-return JaktInternal::ExplicitValue<void>();
-case 8 /* I32 */:{
+goto __jakt_label_50;case 8 /* I32 */:{
 JaktInternal::Optional<i32> const n = fallible_integer_cast<i32>(number);
 if (!n.has_value()){
 this->error(__jakt_format(StringView::from_string_literal("Number {} cannot fit in integer type {}"sv),number,suffix),span);
@@ -9642,8 +8294,7 @@ return Jakt::parser::NumericConstant::U64(number);
 }
 return Jakt::parser::NumericConstant::I32(n.value());
 }
-return JaktInternal::ExplicitValue<void>();
-case 9 /* I64 */:{
+goto __jakt_label_50;case 9 /* I64 */:{
 JaktInternal::Optional<i64> const n = fallible_integer_cast<i64>(number);
 if (!n.has_value()){
 this->error(__jakt_format(StringView::from_string_literal("Number {} cannot fit in integer type {}"sv),number,suffix),span);
@@ -9651,37 +8302,20 @@ return Jakt::parser::NumericConstant::U64(number);
 }
 return Jakt::parser::NumericConstant::I64(n.value());
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_50;default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_50;}/*switch end*/
+}goto __jakt_label_50; __jakt_label_50:;;
 return JaktInternal::OptionalNone();
 }
 }
 
 JaktInternal::Optional<Jakt::parser::NumericConstant> Jakt::parser::Parser::make_float_numeric_constant(f64 const number,Jakt::lexer::LiteralSuffix const suffix,Jakt::utility::Span const span) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::parser::NumericConstant>, JaktInternal::Optional<Jakt::parser::NumericConstant>>{
-auto&& __jakt_match_variant = suffix;
+{auto&& __jakt_match_variant = suffix;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 10 /* F32 */:return JaktInternal::ExplicitValue(Jakt::parser::NumericConstant::F32(Jakt::parser::f64_to_f32(number)));
-case 11 /* F64 */:return JaktInternal::ExplicitValue(Jakt::parser::NumericConstant::F64(number));
-default:return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 10 /* F32 */:return Jakt::parser::NumericConstant::F32(Jakt::parser::f64_to_f32(number));case 11 /* F64 */:return Jakt::parser::NumericConstant::F64(number);default:return JaktInternal::OptionalNone();}/*switch end*/
+}
 }
 }
 
@@ -9691,20 +8325,15 @@ JaktInternal::DynamicArray<Jakt::parser::ParsedCapture> captures = DynamicArray<
 if (this->current().__jakt_init_index() == 11 /* LSquare */){
 this->index++;
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, JaktInternal::DynamicArray<Jakt::parser::ParsedCapture>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* RSquare */:{
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 37 /* Ampersand */:{
+goto __jakt_label_51;case 37 /* Ampersand */:{
 this->index++;
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, JaktInternal::DynamicArray<Jakt::parser::ParsedCapture>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 87 /* Mut */:{
 this->index++;
@@ -9720,34 +8349,21 @@ this->index++;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* Identifier */: {
+goto __jakt_label_52;case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
 {
 captures.push(Jakt::parser::ParsedCapture::ByReference(name,this->current().span()));
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_52;};/*case end*/
 default:{
 this->error(__jakt_format(StringView::from_string_literal("Expected identifier or mut, got '{}'"sv),this->current()),this->current().span());
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+goto __jakt_label_52;}/*switch end*/
+break;}goto __jakt_label_52; __jakt_label_52:;;
 }
-return JaktInternal::ExplicitValue<void>();
-case 77 /* Comptime */:{
+goto __jakt_label_51;case 77 /* Comptime */:{
 this->index++;
 Jakt::lexer::Token __jakt_tmp33 = this->current();
 if (__jakt_tmp33.__jakt_init_index() == 3 /* Identifier */){
@@ -9761,40 +8377,26 @@ this->index++;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* Identifier */: {
+goto __jakt_label_51;case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
 {
 captures.push(Jakt::parser::ParsedCapture::ByValue(name,this->current().span()));
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_51;};/*case end*/
 case 100 /* This */:{
 captures.push(Jakt::parser::ParsedCapture::ByValue(ByteString::from_utf8_without_validation("this"sv),this->current().span()));
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 52 /* Comma */:case 55 /* Eol */:{
+goto __jakt_label_51;case 52 /* Comma */:case 55 /* Eol */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_51;default:{
 this->error(__jakt_format(StringView::from_string_literal("Unexpected token '{}' in captures list"sv),this->current()),this->current().span());
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_51;}/*switch end*/
+break;}goto __jakt_label_51; __jakt_label_51:;;
 }
 return captures;
 }
@@ -9818,44 +8420,30 @@ this->index++;
 if (fn_parameters.has_varargs){
 this->error(ByteString::from_utf8_without_validation("Anonymous functions cannot have varargs"sv),this->current().span());
 }
-NonnullRefPtr<typename Jakt::parser::ParsedType> return_type = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedType>, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = this->current();
+NonnullRefPtr<typename Jakt::parser::ParsedType> return_type = [&]() -> NonnullRefPtr<typename Jakt::parser::ParsedType> { auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 58 /* Arrow */:{
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedType>>(this->parse_typename());
+return this->parse_typename();
 }
 VERIFY_NOT_REACHED();
-default:return JaktInternal::ExplicitValue(Jakt::parser::ParsedType::Empty(JaktInternal::OptionalNone()));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return Jakt::parser::ParsedType::Empty(JaktInternal::OptionalNone());}/*switch end*/
+ 
+}();
 bool is_fat_arrow = false;
-Jakt::parser::ParsedBlock const block = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::ParsedBlock, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = this->current();
+Jakt::parser::ParsedBlock const block = [&]() -> Jakt::parser::ParsedBlock { auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 57 /* FatArrow */:{
 is_fat_arrow = true;
 this->index++;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = this->parse_expression(true,false);
 Jakt::utility::Span const span = expr->span();
-return JaktInternal::ExplicitValue<Jakt::parser::ParsedBlock>(Jakt::parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>::create_with({Jakt::parser::ParsedStatement::Return(expr,span)})));
+return Jakt::parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>::create_with({Jakt::parser::ParsedStatement::Return(expr,span)}));
 }
 VERIFY_NOT_REACHED();
-default:return JaktInternal::ExplicitValue(this->parse_block());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return this->parse_block();}/*switch end*/
+ 
+}();
 return Jakt::parser::ParsedExpression::Function(captures,fn_parameters.parameters,can_throw,is_fat_arrow,return_type,block,Jakt::parser::merge_spans(start,this->current().span()));
 }
 }
@@ -9893,24 +8481,15 @@ NonnullRefPtr<typename Jakt::parser::ParsedExpression> Jakt::parser::Parser::par
 Jakt::utility::Span const start = this->current().span();
 this->index++;
 JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> to = JaktInternal::OptionalNone();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* RSquare */:case 55 /* Eol */:case 52 /* Comma */:case 8 /* RParen */:{
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_53;default:{
 to = this->parse_operand();
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_53;}/*switch end*/
+}goto __jakt_label_53; __jakt_label_53:;;
 return Jakt::parser::ParsedExpression::Range(JaktInternal::OptionalNone(),to,Jakt::parser::merge_spans(start,this->current().span()));
 }
 }
@@ -9934,44 +8513,30 @@ return Jakt::parser::ParsedExpression::Garbage(this->current().span());
 this->index++;
 JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> output = DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>::create_with({});
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* RCurly */:{
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 52 /* Comma */:case 55 /* Eol */:{
+goto __jakt_label_54;case 52 /* Comma */:case 55 /* Eol */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_54;default:{
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = this->parse_expression(false,false);
 if (expr->__jakt_init_index() == 30 /* Garbage */){
-return JaktInternal::LoopBreak{};
+break;
 }
 output.push(expr);
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_54;}/*switch end*/
+break;}goto __jakt_label_54; __jakt_label_54:;;
 }
 size_t const end = JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL));
-if ((end >= this->tokens.size()) || (!(this->tokens.operator[](end).__jakt_init_index() == 10 /* RCurly */))){
-this->error(ByteString::from_utf8_without_validation("Expected ‘}’ to close the set"sv),this->tokens.operator[](end).span());
+if ((end >= this->tokens.size()) || (!(this->tokens[end].__jakt_init_index() == 10 /* RCurly */))){
+this->error(ByteString::from_utf8_without_validation("Expected ‘}’ to close the set"sv),this->tokens[end].span());
 }
-return Jakt::parser::ParsedExpression::Set(output,Jakt::parser::merge_spans(start,this->tokens.operator[](end).span()));
+return Jakt::parser::ParsedExpression::Set(output,Jakt::parser::merge_spans(start,this->tokens[end].span()));
 }
 }
 
@@ -9997,29 +8562,16 @@ case 54 /* DotDot */:{
 this->index++;
 JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> to = JaktInternal::OptionalNone();
 Jakt::utility::Span span_end = this->current().span();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* RSquare */:case 55 /* Eol */:case 52 /* Comma */:case 8 /* RParen */:{
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_55;default:{
 to = this->parse_operand();
 span_end = to.value()->span();
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+goto __jakt_label_55;}/*switch end*/
+return JaktInternal::LoopBreak{};}goto __jakt_label_55; __jakt_label_55:;;
 return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::Range(result,to,Jakt::parser::merge_spans(start,span_end)));
 }
 VERIFY_NOT_REACHED();
@@ -10041,36 +8593,26 @@ VERIFY_NOT_REACHED();
 case 61 /* As */:{
 this->index++;
 Jakt::utility::Span const cast_span = Jakt::parser::merge_spans(this->previous().span(),this->current().span());
-Jakt::parser::TypeCast const cast = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::TypeCast, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = this->current();
+Jakt::parser::TypeCast const cast = [&]() -> Jakt::parser::TypeCast { auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 48 /* ExclamationPoint */:{
 this->index++;
-return JaktInternal::ExplicitValue<Jakt::parser::TypeCast>(Jakt::parser::TypeCast::Infallible(this->parse_typename()));
+return Jakt::parser::TypeCast::Infallible(this->parse_typename());
 }
 VERIFY_NOT_REACHED();
 case 49 /* QuestionMark */:{
 this->index++;
-return JaktInternal::ExplicitValue<Jakt::parser::TypeCast>(Jakt::parser::TypeCast::Fallible(this->parse_typename()));
+return Jakt::parser::TypeCast::Fallible(this->parse_typename());
 }
 VERIFY_NOT_REACHED();
 default:{
 this->error_with_hint(ByteString::from_utf8_without_validation("Invalid cast syntax"sv),cast_span,ByteString::from_utf8_without_validation("Use `as!` for an infallible cast, or `as?` for a fallible cast"sv),this->previous().span());
-return JaktInternal::ExplicitValue<Jakt::parser::TypeCast>(Jakt::parser::TypeCast::Fallible(this->parse_typename()));
+return Jakt::parser::TypeCast::Fallible(this->parse_typename());
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+ 
+}();
 Jakt::utility::Span const span = Jakt::parser::merge_spans(start,Jakt::parser::merge_spans(cast_span,this->current().span()));
 return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::UnaryOp(result,Jakt::parser::UnaryOperator::TypeCast(cast),span));
 }
@@ -10102,9 +8644,7 @@ this->error(ByteString::from_utf8_without_validation("Expected ‘.’ after ‘
 }
 }
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedExpression>, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = this->current();
+return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>([&]() -> NonnullRefPtr<typename Jakt::parser::ParsedExpression> { auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;Jakt::lexer::LiteralPrefix const& prefix = __jakt_match_value.prefix;
@@ -10113,29 +8653,19 @@ Jakt::lexer::LiteralSuffix const& suffix = __jakt_match_value.suffix;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const numeric_constant = this->parse_number(prefix,number,suffix,span);
-NonnullRefPtr<typename Jakt::parser::ParsedExpression> __jakt_tmp35 = numeric_constant;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,NonnullRefPtr<typename Jakt::parser::ParsedExpression>> {
-auto __jakt_enum_value = (__jakt_tmp35->__jakt_init_index() == 1 /* NumericConstant */);
+NonnullRefPtr<typename Jakt::parser::ParsedExpression> __jakt_tmp34 = numeric_constant;
+{auto __jakt_enum_value = __jakt_tmp34->__jakt_init_index() == 1 /* NumericConstant */;
 if (__jakt_enum_value) {{
-Jakt::parser::NumericConstant const val = __jakt_tmp35->as.NumericConstant.val;
+Jakt::parser::NumericConstant const val = __jakt_tmp34->as.NumericConstant.val;
 size_t const num = val.to_usize();
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::IndexedTuple(result,num,is_optional,Jakt::parser::merge_spans(start,this->previous().span())));
+return Jakt::parser::ParsedExpression::IndexedTuple(result,num,is_optional,Jakt::parser::merge_spans(start,this->previous().span()));
 }
 VERIFY_NOT_REACHED();
 }else {{
 this->error(ByteString::from_utf8_without_validation("Invalid Numeric Constant"sv),span);
 return expr;
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
+}}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -10143,54 +8673,31 @@ case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
 {
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedExpression>, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 28 /* LessThan */:{
 size_t const original_index = this->index;
-JaktInternal::DynamicArray<Jakt::error::JaktError> const existing_errors = this->compiler->errors.operator[](JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}).to_array();
+JaktInternal::DynamicArray<Jakt::error::JaktError> const existing_errors = this->compiler->errors[JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}].to_array();
 this->index--;
 JaktInternal::Optional<Jakt::parser::ParsedCall> const call = this->parse_call();
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,NonnullRefPtr<typename Jakt::parser::ParsedExpression>> {
-auto __jakt_enum_value = (call.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::parser::ParsedExpression::MethodCall(result,call.value(),is_optional,Jakt::parser::merge_spans(start,this->previous().span())));
-}else {{
+{auto __jakt_enum_value = call.has_value();
+if (__jakt_enum_value) {return Jakt::parser::ParsedExpression::MethodCall(result,call.value(),is_optional,Jakt::parser::merge_spans(start,this->previous().span()));}else {{
 this->index = original_index;
 this->compiler->errors = existing_errors;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::IndexedStruct(result,name,is_optional,Jakt::parser::merge_spans(start,this->current().span())));
+return Jakt::parser::ParsedExpression::IndexedStruct(result,name,is_optional,Jakt::parser::merge_spans(start,this->current().span()));
 }
 VERIFY_NOT_REACHED();
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
+}}
 }
 VERIFY_NOT_REACHED();
 case 7 /* LParen */:{
 this->index--;
 JaktInternal::Optional<Jakt::parser::ParsedCall> const call = this->parse_call();
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::MethodCall(result,call.value(),is_optional,Jakt::parser::merge_spans(start,this->previous().span())));
+return Jakt::parser::ParsedExpression::MethodCall(result,call.value(),is_optional,Jakt::parser::merge_spans(start,this->previous().span()));
 }
 VERIFY_NOT_REACHED();
-default:return JaktInternal::ExplicitValue(Jakt::parser::ParsedExpression::IndexedStruct(result,name,is_optional,Jakt::parser::merge_spans(start,this->current().span())));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
+default:return Jakt::parser::ParsedExpression::IndexedStruct(result,name,is_optional,Jakt::parser::merge_spans(start,this->current().span()));}/*switch end*/
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -10201,26 +8708,18 @@ if (!(this->current().__jakt_init_index() == 12 /* RSquare */)){
 this->error(ByteString::from_utf8_without_validation("Expected ‘]’ to close the index"sv),this->current().span());
 }
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::ComptimeIndex(result,index,is_optional,Jakt::parser::merge_spans(start,this->previous().span())));
+return Jakt::parser::ParsedExpression::ComptimeIndex(result,index,is_optional,Jakt::parser::merge_spans(start,this->previous().span()));
 }
 VERIFY_NOT_REACHED();
 default:{
 this->error(ByteString::from_utf8_without_validation("Unsupported dot operation"sv),this->current().span());
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
+ 
+}());
 }
 VERIFY_NOT_REACHED();
 case 11 /* LSquare */:{
@@ -10234,7 +8733,7 @@ this->error(ByteString::from_utf8_without_validation("Expected ']'"sv),this->cur
 }
 
 size_t const end = JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL));
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::IndexedExpression(result,index_expr,Jakt::parser::merge_spans(start,this->tokens.operator[](end).span())));
+return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::IndexedExpression(result,index_expr,Jakt::parser::merge_spans(start,this->tokens[end].span())));
 }
 VERIFY_NOT_REACHED();
 default:{
@@ -10260,9 +8759,9 @@ NonnullRefPtr<typename Jakt::parser::ParsedExpression> Jakt::parser::Parser::par
 {
 this->index++;
 JaktInternal::DynamicArray<ByteString> namespace_ = DynamicArray<ByteString>::create_with({});
-NonnullRefPtr<typename Jakt::parser::ParsedExpression> __jakt_tmp36 = expr;
-if (__jakt_tmp36->__jakt_init_index() == 9 /* Var */){
-ByteString const name = __jakt_tmp36->as.Var.name;
+NonnullRefPtr<typename Jakt::parser::ParsedExpression> __jakt_tmp35 = expr;
+if (__jakt_tmp35->__jakt_init_index() == 9 /* Var */){
+ByteString const name = __jakt_tmp35->as.Var.name;
 namespace_.push(name);
 }
 else {
@@ -10270,9 +8769,9 @@ this->error(ByteString::from_utf8_without_validation("Expected namespace"sv),exp
 }
 
 while (!this->eof()){
-Jakt::lexer::Token __jakt_tmp37 = this->current();
-if (__jakt_tmp37.__jakt_init_index() == 3 /* Identifier */){
-ByteString const current_name = __jakt_tmp37.as.Identifier.name;
+Jakt::lexer::Token __jakt_tmp36 = this->current();
+if (__jakt_tmp36.__jakt_init_index() == 3 /* Identifier */){
+ByteString const current_name = __jakt_tmp36.as.Identifier.name;
 this->index++;
 if (this->current().__jakt_init_index() == 7 /* LParen */){
 this->index--;
@@ -10291,9 +8790,9 @@ return Jakt::parser::ParsedExpression::Call(call,Jakt::parser::merge_spans(expr-
 return Jakt::parser::ParsedExpression::Garbage(this->current().span());
 }
 if (this->current().__jakt_init_index() == 6 /* ColonColon */){
-Jakt::lexer::Token __jakt_tmp38 = this->previous();
-if (__jakt_tmp38.__jakt_init_index() == 3 /* Identifier */){
-ByteString const name = __jakt_tmp38.as.Identifier.name;
+Jakt::lexer::Token __jakt_tmp37 = this->previous();
+if (__jakt_tmp37.__jakt_init_index() == 3 /* Identifier */){
+ByteString const name = __jakt_tmp37.as.Identifier.name;
 namespace_.push(name);
 }
 else {
@@ -10415,8 +8914,8 @@ break;
 }
 size_t k = _magic_value.value();
 {
-if (cases.operator[](i).has_equal_pattern(cases.operator[](k))){
-this->error_with_hint(ByteString::from_utf8_without_validation("Duplicated match pattern"sv),cases.operator[](k).marker_span,ByteString::from_utf8_without_validation("Original pattern here"sv),cases.operator[](i).marker_span);
+if (cases[i].has_equal_pattern(cases[k])){
+this->error_with_hint(ByteString::from_utf8_without_validation("Duplicated match pattern"sv),cases[k].marker_span,ByteString::from_utf8_without_validation("Original pattern here"sv),cases[i].marker_span);
 }
 }
 
@@ -10456,23 +8955,11 @@ this->error(ByteString::from_utf8_without_validation("Expected ‘=>’"sv),this
 }
 
 this->skip_newlines();
-Jakt::parser::ParsedMatchBody const body = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::ParsedMatchBody, JaktInternal::DynamicArray<Jakt::parser::ParsedMatchCase>>{
-auto&& __jakt_match_variant = this->current();
+Jakt::parser::ParsedMatchBody const body = [&]() -> Jakt::parser::ParsedMatchBody { auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 9 /* LCurly */:return JaktInternal::ExplicitValue(Jakt::parser::ParsedMatchBody::Block(this->parse_block()));
-default:return JaktInternal::ExplicitValue(Jakt::parser::ParsedMatchBody::Expression(this->parse_expression(false,true)));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+case 9 /* LCurly */:return Jakt::parser::ParsedMatchBody::Block(this->parse_block());default:return Jakt::parser::ParsedMatchBody::Expression(this->parse_expression(false,true));}/*switch end*/
+ 
+}();
 cases.push(Jakt::parser::ParsedMatchCase(patterns,marker_span,body));
 if (this->index == pattern_start_index){
 break;
@@ -10502,9 +8989,9 @@ patterns.push(pattern);
 });
 JaktInternal::Dictionary<ByteString,Jakt::parser::ParsedPatternDefault> defaults = pattern.common.init_common.defaults;
 this->skip_newlines();
-Jakt::lexer::Token __jakt_tmp39 = this->current();
-if (__jakt_tmp39.__jakt_init_index() == 3 /* Identifier */){
-ByteString const name = __jakt_tmp39.as.Identifier.name;
+Jakt::lexer::Token __jakt_tmp38 = this->current();
+if (__jakt_tmp38.__jakt_init_index() == 3 /* Identifier */){
+ByteString const name = __jakt_tmp38.as.Identifier.name;
 if (name == ByteString::from_utf8_without_validation("default"sv)){
 JaktInternal::Dictionary<ByteString,Jakt::parser::ParsedPatternDefault> defaults = pattern.common.init_common.defaults;
 this->index += static_cast<size_t>(1ULL);
@@ -10519,31 +9006,21 @@ if (is_mutable){
 this->index++;
 }
 Jakt::parser::ParsedVarDecl const declaration = this->parse_variable_declaration(is_mutable);
-NonnullRefPtr<typename Jakt::parser::ParsedExpression> const value = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedExpression>, JaktInternal::DynamicArray<Jakt::parser::ParsedMatchPattern>>{
-auto&& __jakt_match_variant = this->current();
+NonnullRefPtr<typename Jakt::parser::ParsedExpression> const value = [&]() -> NonnullRefPtr<typename Jakt::parser::ParsedExpression> { auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 16 /* Equal */:{
 this->index++;
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(this->parse_expression(false,false));
+return this->parse_expression(false,false);
 }
 VERIFY_NOT_REACHED();
 default:{
 this->error(ByteString::from_utf8_without_validation("Expected initializer"sv),this->current().span());
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>(Jakt::parser::ParsedExpression::Garbage(this->current().span()));
+return Jakt::parser::ParsedExpression::Garbage(this->current().span());
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}();
 defaults.set(declaration.name,Jakt::parser::ParsedPatternDefault(declaration,value));
 }
 if (this->current().__jakt_init_index() == 8 /* RParen */){
@@ -10568,18 +9045,15 @@ return patterns;
 
 Jakt::parser::ParsedMatchPattern Jakt::parser::Parser::parse_match_pattern() {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::ParsedMatchPattern, Jakt::parser::ParsedMatchPattern>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 103 /* True */:case 74 /* False */:case 2 /* Number */:case 1 /* QuotedString */:case 0 /* SingleQuotedString */:case 7 /* LParen */:return JaktInternal::ExplicitValue(Jakt::parser::ParsedMatchPattern::Expression(Dictionary<ByteString, Jakt::parser::ParsedPatternDefault>::create_with_entries({}),this->parse_operand()));
-case 70 /* Else */:{
+case 103 /* True */:case 74 /* False */:case 2 /* Number */:case 1 /* QuotedString */:case 0 /* SingleQuotedString */:case 7 /* LParen */:return Jakt::parser::ParsedMatchPattern::Expression(Dictionary<ByteString, Jakt::parser::ParsedPatternDefault>::create_with_entries({}),this->parse_operand());case 70 /* Else */:{
 this->index++;
 JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> variant_arguments = this->parse_variant_arguments();
 Jakt::utility::Span const arguments_start = this->current().span();
 Jakt::utility::Span const arguments_end = this->previous().span();
 Jakt::utility::Span const arguments_span = Jakt::parser::merge_spans(arguments_start,arguments_end);
-return JaktInternal::ExplicitValue<Jakt::parser::ParsedMatchPattern>(Jakt::parser::ParsedMatchPattern::CatchAll(Dictionary<ByteString, Jakt::parser::ParsedPatternDefault>::create_with_entries({}),variant_arguments,arguments_span));
+return Jakt::parser::ParsedMatchPattern::CatchAll(Dictionary<ByteString, Jakt::parser::ParsedPatternDefault>::create_with_entries({}),variant_arguments,arguments_span);
 }
 VERIFY_NOT_REACHED();
 case 3 /* Identifier */:{
@@ -10587,62 +9061,43 @@ JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>> 
 bool just_saw_name = false;
 while (!this->eof()){
 this->skip_newlines();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, Jakt::parser::ParsedMatchPattern>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
 {
 if (just_saw_name){
-return JaktInternal::LoopBreak{};
+break;
 }
 just_saw_name = true;
 this->index++;
 variant_names.push(Tuple{name, this->current().span()});
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_56;};/*case end*/
 case 6 /* ColonColon */:{
 this->index++;
 just_saw_name = false;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
-return JaktInternal::LoopBreak{};
+goto __jakt_label_56;default:{
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_56;}/*switch end*/
+break;}goto __jakt_label_56; __jakt_label_56:;;
 }
 JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> variant_arguments = this->parse_variant_arguments();
 Jakt::utility::Span const arguments_start = this->current().span();
 Jakt::utility::Span const arguments_end = this->previous().span();
 Jakt::utility::Span const arguments_span = Jakt::parser::merge_spans(arguments_start,arguments_end);
-return JaktInternal::ExplicitValue<Jakt::parser::ParsedMatchPattern>(Jakt::parser::ParsedMatchPattern::EnumVariant(Dictionary<ByteString, Jakt::parser::ParsedPatternDefault>::create_with_entries({}),variant_names,variant_arguments,arguments_span));
+return Jakt::parser::ParsedMatchPattern::EnumVariant(Dictionary<ByteString, Jakt::parser::ParsedPatternDefault>::create_with_entries({}),variant_names,variant_arguments,arguments_span);
 }
 VERIFY_NOT_REACHED();
 default:{
 this->error(ByteString::from_utf8_without_validation("Expected pattern or ‘else’"sv),this->current().span());
-return JaktInternal::ExplicitValue<Jakt::parser::ParsedMatchPattern>(Jakt::parser::ParsedMatchPattern::Invalid(Dictionary<ByteString, Jakt::parser::ParsedPatternDefault>::create_with_entries({})));
+return Jakt::parser::ParsedMatchPattern::Invalid(Dictionary<ByteString, Jakt::parser::ParsedPatternDefault>::create_with_entries({}));
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -10657,29 +9112,25 @@ bool is_reference = false;
 bool is_mutable = false;
 while (!this->eof()){
 this->skip_newlines();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 37 /* Ampersand */:{
 is_reference = true;
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 87 /* Mut */:{
+goto __jakt_label_57;case 87 /* Mut */:{
 is_mutable = true;
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* Identifier */: {
+goto __jakt_label_57;case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& arg_name = __jakt_match_value.name;
 {
 Jakt::utility::Span const arg_name_span = this->current().span();
 if (this->peek(static_cast<size_t>(1ULL)).__jakt_init_index() == 5 /* Colon */){
 this->index += static_cast<size_t>(2ULL);
-Jakt::lexer::Token __jakt_tmp40 = this->current();
-if (__jakt_tmp40.__jakt_init_index() == 3 /* Identifier */){
-ByteString const arg_binding = __jakt_tmp40.as.Identifier.name;
+Jakt::lexer::Token __jakt_tmp39 = this->current();
+if (__jakt_tmp39.__jakt_init_index() == 3 /* Identifier */){
+ByteString const arg_binding = __jakt_tmp39.as.Identifier.name;
 Jakt::utility::Span const span = this->current().span();
 this->index++;
 variant_arguments.push(Jakt::parser::EnumVariantPatternArgument(static_cast<JaktInternal::Optional<ByteString>>(arg_name),static_cast<JaktInternal::Optional<Jakt::utility::Span>>(arg_name_span),arg_binding,span,is_reference,is_mutable));
@@ -10697,33 +9148,20 @@ this->index++;
 is_reference = false;
 is_mutable = false;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_57;};/*case end*/
 case 52 /* Comma */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 8 /* RParen */:{
+goto __jakt_label_57;case 8 /* RParen */:{
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_57;default:{
 this->error(ByteString::from_utf8_without_validation("Expected pattern argument name"sv),this->current().span());
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_57;}/*switch end*/
+break;}goto __jakt_label_57; __jakt_label_57:;;
 }
 }
 return variant_arguments;
@@ -10733,9 +9171,9 @@ return variant_arguments;
 JaktInternal::Optional<Jakt::parser::ParsedCall> Jakt::parser::Parser::parse_call() {
 {
 Jakt::parser::ParsedCall call = Jakt::parser::ParsedCall(DynamicArray<ByteString>::create_with({}),ByteString::from_utf8_without_validation(""sv),DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>>>::create_with({}),DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>>::create_with({}));
-Jakt::lexer::Token __jakt_tmp41 = this->current();
-if (__jakt_tmp41.__jakt_init_index() == 3 /* Identifier */){
-ByteString const name = __jakt_tmp41.as.Identifier.name;
+Jakt::lexer::Token __jakt_tmp40 = this->current();
+if (__jakt_tmp40.__jakt_init_index() == 3 /* Identifier */){
+ByteString const name = __jakt_tmp40.as.Identifier.name;
 call.name = name;
 this->index++;
 size_t const index_reset = this->index;
@@ -10743,46 +9181,31 @@ if (this->current().__jakt_init_index() == 28 /* LessThan */){
 this->index++;
 JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>> inner_types = DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>>::create_with({});
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, JaktInternal::Optional<Jakt::parser::ParsedCall>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 26 /* GreaterThan */:{
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 33 /* RightShift */:{
+goto __jakt_label_58;case 33 /* RightShift */:{
 this->inject_token(Jakt::lexer::Token::GreaterThan(this->current().span()));
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 52 /* Comma */:case 55 /* Eol */:{
+goto __jakt_label_58;case 52 /* Comma */:case 55 /* Eol */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_58;default:{
 size_t const index_before = this->index;
 NonnullRefPtr<typename Jakt::parser::ParsedType> const inner_type = this->parse_typename();
 if (index_before == this->index){
 this->index = index_reset;
-return JaktInternal::LoopBreak{};
+break;
 }
 inner_types.push(inner_type);
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_58;}/*switch end*/
+break;}goto __jakt_label_58; __jakt_label_58:;;
 }
 call.type_args = inner_types;
 }
@@ -10796,37 +9219,23 @@ return JaktInternal::OptionalNone();
 }
 
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, JaktInternal::Optional<Jakt::parser::ParsedCall>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* RParen */:{
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 55 /* Eol */:case 52 /* Comma */:{
+goto __jakt_label_59;case 55 /* Eol */:case 52 /* Comma */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_59;default:{
 Jakt::utility::Span const label_span = this->current().span();
 ByteString const label = this->parse_argument_label();
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = this->parse_expression(false,false);
 call.args.push(Tuple{label, label_span, expr});
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_59;}/*switch end*/
+break;}goto __jakt_label_59; __jakt_label_59:;;
 }
 if (this->can_have_trailing_closure){
 Jakt::utility::Span const start = this->current().span();
@@ -10835,30 +9244,20 @@ JaktInternal::Optional<Jakt::parser::ParsedBlock> block = JaktInternal::Optional
 JaktInternal::DynamicArray<Jakt::parser::ParsedParameter> params = DynamicArray<Jakt::parser::ParsedParameter>::create_with({});
 bool has_varargs = false;
 size_t errors_before = this->compiler->errors.size();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, JaktInternal::Optional<Jakt::parser::ParsedCall>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* LCurly */:{
 }
-return JaktInternal::ExplicitValue<void>();
-case 40 /* Pipe */:{
+goto __jakt_label_60;case 40 /* Pipe */:{
 Jakt::parser::ParsedFunctionParameters const parameters = this->parse_function_parameters(true);
 params = parameters.parameters;
 has_varargs = parameters.has_varargs;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_60;default:{
 return call;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_60;}/*switch end*/
+}goto __jakt_label_60; __jakt_label_60:;;
 if (this->current().__jakt_init_index() == 9 /* LCurly */){
 if (has_varargs){
 this->error(ByteString::from_utf8_without_validation("Function expressions cannot have varargs"sv),this->current().span());
@@ -10872,7 +9271,7 @@ call.args.push(Tuple{ByteString::from_utf8_without_validation(""sv), this->empty
 }
 else {
 this->index = start_index;
-this->compiler->errors = this->compiler->errors.operator[](JaktInternal::Range<size_t>{static_cast<size_t>(0LL),static_cast<size_t>(errors_before)}).to_array();
+this->compiler->errors = this->compiler->errors[JaktInternal::Range<size_t>{static_cast<size_t>(0LL),static_cast<size_t>(errors_before)}].to_array();
 return call;
 }
 
@@ -10901,29 +9300,24 @@ if (this->current().__jakt_init_index() == 7 /* LParen */){
 this->index++;
 JaktInternal::DynamicArray<Jakt::parser::ParsedNameWithGenericParameters> result = DynamicArray<Jakt::parser::ParsedNameWithGenericParameters>::create_with({});
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::parser::ParsedNameWithGenericParameters>>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 55 /* Eol */:case 52 /* Comma */:{
 this->index++;
-return JaktInternal::LoopContinue{};
+continue;
 }
-return JaktInternal::ExplicitValue<void>();
-case 56 /* Eof */: {
+goto __jakt_label_61;case 56 /* Eof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eof;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected ')' to close the trait list"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 8 /* RParen */:{
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 3 /* Identifier */: {
+goto __jakt_label_61;case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
@@ -10932,899 +9326,779 @@ this->index++;
 parsed_name.generic_parameters = this->parse_type_parameter_list();
 result.push(parsed_name);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 4 /* Semicolon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Semicolon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 5 /* Colon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Colon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 6 /* ColonColon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ColonColon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 7 /* LParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LParen;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 9 /* LCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LCurly;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 10 /* RCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RCurly;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 11 /* LSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LSquare;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 12 /* RSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RSquare;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 13 /* PercentSign */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSign;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 14 /* Plus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Plus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 15 /* Minus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Minus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 16 /* Equal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Equal;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 17 /* PlusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 18 /* PlusPlus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusPlus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 19 /* MinusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 20 /* MinusMinus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusMinus;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 21 /* AsteriskEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AsteriskEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 22 /* ForwardSlashEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlashEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 23 /* PercentSignEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSignEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 24 /* NotEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NotEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 25 /* DoubleEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DoubleEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 26 /* GreaterThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThan;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 27 /* GreaterThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThanOrEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 28 /* LessThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThan;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 29 /* LessThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThanOrEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 30 /* LeftArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftArithmeticShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 31 /* LeftShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 32 /* LeftShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShiftEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 33 /* RightShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 34 /* RightArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightArithmeticShift;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 35 /* RightShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShiftEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 36 /* Asterisk */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Asterisk;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 37 /* Ampersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Ampersand;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 38 /* AmpersandEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 39 /* AmpersandAmpersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandAmpersand;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 40 /* Pipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Pipe;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 41 /* PipeEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipeEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 42 /* PipePipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipePipe;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 43 /* Caret */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Caret;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 44 /* CaretEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CaretEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 45 /* Dollar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dollar;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 46 /* Tilde */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Tilde;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 47 /* ForwardSlash */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlash;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 48 /* ExclamationPoint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ExclamationPoint;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 49 /* QuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMark;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 50 /* QuestionMarkQuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMark;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 51 /* QuestionMarkQuestionMarkEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMarkEqual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 54 /* DotDot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DotDot;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 57 /* FatArrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.FatArrow;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 58 /* Arrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Arrow;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 59 /* And */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.And;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 60 /* Anon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Anon;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 61 /* As */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.As;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 62 /* Boxed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boxed;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 63 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 64 /* Catch */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Catch;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 65 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 66 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 67 /* Cpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Cpp;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 68 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 69 /* Destructor */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Destructor;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 70 /* Else */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Else;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 71 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 72 /* Extern */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Extern;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 73 /* Export */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Export;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 74 /* False */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.False;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 75 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 76 /* Fn */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Fn;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 77 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 78 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 79 /* Import */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Import;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 80 /* Relative */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Relative;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 81 /* In */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.In;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 82 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 83 /* Let */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Let;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 84 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 85 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 86 /* Must */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Must;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 87 /* Mut */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Mut;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 88 /* Namespace */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Namespace;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 89 /* Not */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Not;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 90 /* Or */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Or;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 91 /* Override */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Override;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 92 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 93 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 94 /* Raw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Raw;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 95 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 96 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 97 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 98 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 99 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 100 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 101 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 102 /* Throws */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throws;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 103 /* True */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.True;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 104 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 105 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 106 /* Virtual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Virtual;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 107 /* Weak */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Weak;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 108 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 109 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 110 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 111 /* Implements */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Implements;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 112 /* Requires */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Requires;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 113 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 case 114 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 this->error(ByteString::from_utf8_without_validation("Expected trait name"sv),span);
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_61;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+break;}goto __jakt_label_61; __jakt_label_61:;;
 }
 if (result.is_empty()){
 this->error(ByteString::from_utf8_without_validation("Expected trait list to have at least one trait inside it"sv),this->previous().span());
@@ -11854,9 +10128,7 @@ this->skip_newlines();
 bool saw_ending_bracket = false;
 bool next_generic_is_value = false;
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, JaktInternal::DynamicArray<Jakt::parser::ParsedGenericParameter>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
@@ -11875,48 +10147,33 @@ if ((this->current().__jakt_init_index() == 52 /* Comma */) || (this->current().
 this->index++;
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_62;};/*case end*/
 case 77 /* Comptime */:{
 this->index++;
 next_generic_is_value = true;
-return JaktInternal::LoopContinue{};
+continue;
 }
-return JaktInternal::ExplicitValue<void>();
-case 26 /* GreaterThan */:{
+goto __jakt_label_62;case 26 /* GreaterThan */:{
 this->index++;
 saw_ending_bracket = true;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 33 /* RightShift */:{
+goto __jakt_label_62;case 33 /* RightShift */:{
 this->inject_token(Jakt::lexer::Token::GreaterThan(this->current().span()));
 this->index += static_cast<size_t>(1ULL);
 saw_ending_bracket = true;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 114 /* Garbage */:{
+goto __jakt_label_62;case 114 /* Garbage */:{
 this->error(ByteString::from_utf8_without_validation("Expected `>` to end the generic parameters"sv),this->current().span());
 return generic_parameters;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_62;default:{
 this->error(ByteString::from_utf8_without_validation("Expected generic parameter name"sv),this->current().span());
 return generic_parameters;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_62;}/*switch end*/
+break;}goto __jakt_label_62; __jakt_label_62:;;
 }
 if (!saw_ending_bracket){
 this->error(ByteString::from_utf8_without_validation("Expected `>` to end the generic parameters"sv),this->current().span());
@@ -11929,9 +10186,9 @@ return generic_parameters;
 ByteString Jakt::parser::Parser::parse_argument_label() {
 {
 if (this->peek(static_cast<size_t>(1ULL)).__jakt_init_index() == 5 /* Colon */){
-Jakt::lexer::Token __jakt_tmp42 = this->current();
-if (__jakt_tmp42.__jakt_init_index() == 3 /* Identifier */){
-ByteString const name = __jakt_tmp42.as.Identifier.name;
+Jakt::lexer::Token __jakt_tmp41 = this->current();
+if (__jakt_tmp41.__jakt_init_index() == 3 /* Identifier */){
+ByteString const name = __jakt_tmp41.as.Identifier.name;
 this->index += static_cast<size_t>(2ULL);
 return name;
 }
@@ -11955,15 +10212,12 @@ return Jakt::parser::Visibility::Restricted(DynamicArray<Jakt::parser::Visibilit
 JaktInternal::DynamicArray<Jakt::parser::VisibilityRestriction> whitelist = DynamicArray<Jakt::parser::VisibilityRestriction>::create_with({});
 bool expect_comma = false;
 while (this->index < this->tokens.size()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, Jakt::parser::Visibility>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* RParen */:{
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 52 /* Comma */: {
+goto __jakt_label_63;case 52 /* Comma */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comma;Jakt::utility::Span const& span = __jakt_match_value.value;
 {
 if (expect_comma){
@@ -11975,8 +10229,7 @@ this->error(ByteString::from_utf8_without_validation("Unexpected comma"sv),span)
 
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_63;};/*case end*/
 default:{
 if (expect_comma){
 this->error(ByteString::from_utf8_without_validation("Expected comma"sv),this->current().span());
@@ -11984,9 +10237,9 @@ this->error(ByteString::from_utf8_without_validation("Expected comma"sv),this->c
 this->skip_newlines();
 JaktInternal::DynamicArray<ByteString> names = DynamicArray<ByteString>::create_with({});
 for (;;){
-Jakt::lexer::Token __jakt_tmp43 = this->current();
-if (__jakt_tmp43.__jakt_init_index() == 3 /* Identifier */){
-ByteString const name = __jakt_tmp43.as.Identifier.name;
+Jakt::lexer::Token __jakt_tmp42 = this->current();
+if (__jakt_tmp42.__jakt_init_index() == 3 /* Identifier */){
+ByteString const name = __jakt_tmp42.as.Identifier.name;
 names.push(name);
 this->index++;
 if (this->current().__jakt_init_index() == 6 /* ColonColon */){
@@ -12012,18 +10265,8 @@ whitelist.push(Jakt::parser::VisibilityRestriction(names,name));
 
 expect_comma = true;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_63;}/*switch end*/
+break;}goto __jakt_label_63; __jakt_label_63:;;
 }
 restricted_span.end = this->current().span().end;
 if (whitelist.is_empty()){
@@ -12053,20 +10296,16 @@ JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> f
 JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> output = DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedExpression>>::create_with({});
 JaktInternal::DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,NonnullRefPtr<typename Jakt::parser::ParsedExpression>>> dict_output = DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,NonnullRefPtr<typename Jakt::parser::ParsedExpression>>>::create_with({});
 while (!this->eof()){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, NonnullRefPtr<typename Jakt::parser::ParsedExpression>>{
-auto&& __jakt_match_variant = this->current();
+{auto&& __jakt_match_variant = this->current();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* RSquare */:{
 this->index++;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-case 52 /* Comma */:case 55 /* Eol */:{
+goto __jakt_label_64;case 52 /* Comma */:case 55 /* Eol */:{
 this->index++;
 }
-return JaktInternal::ExplicitValue<void>();
-case 4 /* Semicolon */:{
+goto __jakt_label_64;case 4 /* Semicolon */:{
 if (output.size() == static_cast<size_t>(1ULL)){
 this->index++;
 fill_size_expr = this->parse_expression(false,false);
@@ -12077,14 +10316,13 @@ this->index++;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-case 5 /* Colon */:{
+goto __jakt_label_64;case 5 /* Colon */:{
 this->index++;
 if (dict_output.is_empty()){
 if (this->current().__jakt_init_index() == 12 /* RSquare */){
 this->index++;
 is_dictionary = true;
-return JaktInternal::LoopBreak{};
+break;
 }
 else {
 this->error(ByteString::from_utf8_without_validation("Expected ‘]’"sv),this->current().span());
@@ -12096,11 +10334,10 @@ this->error(ByteString::from_utf8_without_validation("Missing key in dictionary 
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_64;default:{
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = this->parse_expression(false,false);
 if (expr->__jakt_init_index() == 30 /* Garbage */){
-return JaktInternal::LoopBreak{};
+break;
 }
 if (this->current().__jakt_init_index() == 5 /* Colon */){
 if (!output.is_empty()){
@@ -12119,28 +10356,18 @@ else if (!is_dictionary){
 output.push(expr);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_64;}/*switch end*/
+break;}goto __jakt_label_64; __jakt_label_64:;;
 }
 size_t const end = JaktInternal::checked_sub(this->index,static_cast<size_t>(1ULL));
-if ((end >= this->tokens.size()) || (!(this->tokens.operator[](end).__jakt_init_index() == 12 /* RSquare */))){
-this->error(ByteString::from_utf8_without_validation("Expected ‘]’ to close the array"sv),this->tokens.operator[](end).span());
+if ((end >= this->tokens.size()) || (!(this->tokens[end].__jakt_init_index() == 12 /* RSquare */))){
+this->error(ByteString::from_utf8_without_validation("Expected ‘]’ to close the array"sv),this->tokens[end].span());
 }
 if (is_dictionary){
-return Jakt::parser::ParsedExpression::JaktDictionary(dict_output,Jakt::parser::merge_spans(start,this->tokens.operator[](end).span()));
+return Jakt::parser::ParsedExpression::JaktDictionary(dict_output,Jakt::parser::merge_spans(start,this->tokens[end].span()));
 }
 else {
-return Jakt::parser::ParsedExpression::JaktArray(output,fill_size_expr,Jakt::parser::merge_spans(start,this->tokens.operator[](end).span()));
+return Jakt::parser::ParsedExpression::JaktArray(output,fill_size_expr,Jakt::parser::merge_spans(start,this->tokens[end].span()));
 }
 
 }
@@ -12309,79 +10536,49 @@ break;
 }
 ByteString Jakt::parser::ExternalName::as_name_for_definition() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ByteString>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Plain */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Plain;ByteString const& name = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(name);
-};/*case end*/
+return name;};/*case end*/
 case 1 /* PreprocessorName */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PreprocessorName;ByteString const& name = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(name);
-};/*case end*/
+return name;};/*case end*/
 case 2 /* Operator */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Operator;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("operator"sv) + name);
-};/*case end*/
+return ByteString::from_utf8_without_validation("operator"sv) + name;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 ByteString Jakt::parser::ExternalName::as_name_for_use() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ByteString>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Plain */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Plain;ByteString const& name = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(name);
-};/*case end*/
+return name;};/*case end*/
 case 1 /* PreprocessorName */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PreprocessorName;ByteString const& name = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(name);
-};/*case end*/
+return name;};/*case end*/
 case 2 /* Operator */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Operator;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal(" {} "sv),name));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal(" {} "sv),name);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 bool Jakt::parser::ExternalName::is_prefix() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Plain */:return JaktInternal::ExplicitValue(false);
-case 1 /* PreprocessorName */:return JaktInternal::ExplicitValue(false);
-case 2 /* Operator */: {
+case 0 /* Plain */:return false;case 1 /* PreprocessorName */:return false;case 2 /* Operator */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Operator;bool const& is_prefix = __jakt_match_value.is_prefix;
-return JaktInternal::ExplicitValue(is_prefix);
-};/*case end*/
+return is_prefix;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -12834,62 +11031,43 @@ case 12 /* UnknownUnsigned */:break;
 }
 size_t Jakt::parser::NumericConstant::to_usize() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, size_t>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& num = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<size_t>(num));
-};/*case end*/
+return infallible_integer_cast<size_t>(num);};/*case end*/
 case 1 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& num = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<size_t>(num));
-};/*case end*/
+return infallible_integer_cast<size_t>(num);};/*case end*/
 case 2 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& num = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<size_t>(num));
-};/*case end*/
+return infallible_integer_cast<size_t>(num);};/*case end*/
 case 3 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& num = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<size_t>(num));
-};/*case end*/
+return infallible_integer_cast<size_t>(num);};/*case end*/
 case 4 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& num = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<size_t>(num));
-};/*case end*/
+return infallible_integer_cast<size_t>(num);};/*case end*/
 case 5 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& num = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<size_t>(num));
-};/*case end*/
+return infallible_integer_cast<size_t>(num);};/*case end*/
 case 6 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& num = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<size_t>(num));
-};/*case end*/
+return infallible_integer_cast<size_t>(num);};/*case end*/
 case 7 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& num = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<size_t>(num));
-};/*case end*/
+return infallible_integer_cast<size_t>(num);};/*case end*/
 case 8 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;u64 const& num = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<size_t>(num));
-};/*case end*/
+return infallible_integer_cast<size_t>(num);};/*case end*/
 case 11 /* UnknownSigned */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnknownSigned;i64 const& num = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<size_t>(num));
-};/*case end*/
+return infallible_integer_cast<size_t>(num);};/*case end*/
 case 12 /* UnknownUnsigned */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnknownUnsigned;u64 const& num = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<size_t>(num));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(static_cast<size_t>(static_cast<size_t>(0ULL)));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return infallible_integer_cast<size_t>(num);};/*case end*/
+default:return static_cast<size_t>(static_cast<size_t>(0ULL));}/*switch end*/
+}
 }
 }
 
@@ -13123,55 +11301,28 @@ break;
 }
 bool Jakt::parser::ImportName::equals(Jakt::parser::ImportName const other) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Literal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Literal;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = other;
+{auto&& __jakt_match_variant = other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Literal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Literal;ByteString const& other_name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(name == other_name);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return name == other_name;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 1 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expression = __jakt_match_value.expression;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = other;
+{auto&& __jakt_match_variant = other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& other_expression = __jakt_match_value.expression;
-return JaktInternal::ExplicitValue(expression->equals(other_expression));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return expression->equals(other_expression);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -13191,14 +11342,11 @@ Jakt::utility::panic(ByteString::from_utf8_without_validation("Cannot get litera
 
 Jakt::utility::Span Jakt::parser::ImportName::span() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::utility::Span, Jakt::utility::Span>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Literal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Literal;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 1 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expression = __jakt_match_value.expression;
 {
@@ -13206,12 +11354,7 @@ return expression->span();
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -13320,30 +11463,19 @@ case 1 /* All */:break;
 }
 bool Jakt::parser::ImportList::is_empty() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* List */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.List;JaktInternal::DynamicArray<Jakt::parser::ImportName> const& names = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(names.is_empty());
-};/*case end*/
-case 1 /* All */:return JaktInternal::ExplicitValue(false);
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return names.is_empty();};/*case end*/
+case 1 /* All */:return false;default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
 void Jakt::parser::ImportList::add(Jakt::parser::ImportName const name) {
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, void>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* List */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.List;JaktInternal::DynamicArray<Jakt::parser::ImportName> const& names = __jakt_match_value.value;
@@ -13351,18 +11483,11 @@ auto&& __jakt_match_value = __jakt_match_variant.as.List;JaktInternal::DynamicAr
 JaktInternal::DynamicArray<Jakt::parser::ImportName> mutable_names = names;
 mutable_names.push(name);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_65;};/*case end*/
 case 1 /* All */:{
 }
-return JaktInternal::ExplicitValue<void>();
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_65;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_65; __jakt_label_65:;;
 }
 }
 
@@ -13792,22 +11917,10 @@ case 4 /* Garbage */:break;
 }
 ByteString Jakt::parser::RecordType::record_type_name() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ByteString>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Struct */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("struct"sv));
-case 1 /* Class */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("class"sv));
-case 2 /* ValueEnum */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("value enum"sv));
-case 3 /* SumEnum */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("sum enum"sv));
-case 4 /* Garbage */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("<garbage record type>"sv));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 0 /* Struct */:return ByteString::from_utf8_without_validation("struct"sv);case 1 /* Class */:return ByteString::from_utf8_without_validation("class"sv);case 2 /* ValueEnum */:return ByteString::from_utf8_without_validation("value enum"sv);case 3 /* SumEnum */:return ByteString::from_utf8_without_validation("sum enum"sv);case 4 /* Garbage */:return ByteString::from_utf8_without_validation("<garbage record type>"sv);default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
@@ -15367,94 +13480,50 @@ break;
 }
 bool Jakt::parser::ParsedStatement::equals(NonnullRefPtr<typename Jakt::parser::ParsedStatement> const rhs_statement) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_statement;
+{auto&& __jakt_match_variant = *rhs_statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(lhs_expr->equals(rhs_expr));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_expr->equals(rhs_expr);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 1 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;NonnullRefPtr<typename Jakt::parser::ParsedStatement> const& lhs_statement = __jakt_match_value.statement;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_statement;
+{auto&& __jakt_match_variant = *rhs_statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;NonnullRefPtr<typename Jakt::parser::ParsedStatement> const& rhs_statement = __jakt_match_value.statement;
-return JaktInternal::ExplicitValue(lhs_statement->equals(rhs_statement));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_statement->equals(rhs_statement);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 2 /* UnsafeBlock */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnsafeBlock;Jakt::parser::ParsedBlock const& lhs_block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_statement;
+{auto&& __jakt_match_variant = *rhs_statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* UnsafeBlock */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnsafeBlock;Jakt::parser::ParsedBlock const& rhs_block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(lhs_block.equals(rhs_block));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_block.equals(rhs_block);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 4 /* VarDecl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.VarDecl;Jakt::parser::ParsedVarDecl const& lhs_var = __jakt_match_value.var;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_init = __jakt_match_value.init;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_statement;
+{auto&& __jakt_match_variant = *rhs_statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* VarDecl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.VarDecl;Jakt::parser::ParsedVarDecl const& rhs_var = __jakt_match_value.var;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_init = __jakt_match_value.init;
-return JaktInternal::ExplicitValue(lhs_var.equals(rhs_var) && lhs_init->equals(rhs_init));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_var.equals(rhs_var) && lhs_init->equals(rhs_init);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 3 /* DestructuringAssignment */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DestructuringAssignment;JaktInternal::DynamicArray<Jakt::parser::ParsedVarDecl> const& lhs_vars = __jakt_match_value.vars;
 NonnullRefPtr<typename Jakt::parser::ParsedStatement> const& lhs_var_decl = __jakt_match_value.var_decl;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_statement;
+{auto&& __jakt_match_variant = *rhs_statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* DestructuringAssignment */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DestructuringAssignment;JaktInternal::DynamicArray<Jakt::parser::ParsedVarDecl> const& rhs_vars = __jakt_match_value.vars;
@@ -15472,7 +13541,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (!lhs_vars.operator[](i).equals(rhs_vars.operator[](i))){
+if (!lhs_vars[i].equals(rhs_vars[i])){
 return false;
 }
 }
@@ -15486,22 +13555,13 @@ return false;
 return true;
 }
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 5 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_condition = __jakt_match_value.condition;
 Jakt::parser::ParsedBlock const& lhs_then_block = __jakt_match_value.then_block;
 JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedStatement>> const& lhs_else_statement = __jakt_match_value.else_statement;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_statement;
+{auto&& __jakt_match_variant = *rhs_statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_condition = __jakt_match_value.condition;
@@ -15526,107 +13586,57 @@ return false;
 
 }
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 6 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::parser::ParsedBlock const& lhs_block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_statement;
+{auto&& __jakt_match_variant = *rhs_statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::parser::ParsedBlock const& rhs_block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(lhs_block.equals(rhs_block));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_block.equals(rhs_block);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 7 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;Jakt::parser::ParsedBlock const& lhs_block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_statement;
+{auto&& __jakt_match_variant = *rhs_statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;Jakt::parser::ParsedBlock const& rhs_block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(lhs_block.equals(rhs_block));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_block.equals(rhs_block);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 8 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_condition = __jakt_match_value.condition;
 Jakt::parser::ParsedBlock const& lhs_block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_statement;
+{auto&& __jakt_match_variant = *rhs_statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_condition = __jakt_match_value.condition;
 Jakt::parser::ParsedBlock const& rhs_block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(lhs_condition->equals(rhs_condition) && lhs_block.equals(rhs_block));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_condition->equals(rhs_condition) && lhs_block.equals(rhs_block);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 9 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;ByteString const& lhs_iterator_name = __jakt_match_value.iterator_name;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_range = __jakt_match_value.range;
 Jakt::parser::ParsedBlock const& lhs_block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_statement;
+{auto&& __jakt_match_variant = *rhs_statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;ByteString const& rhs_iterator_name = __jakt_match_value.iterator_name;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_range = __jakt_match_value.range;
 Jakt::parser::ParsedBlock const& rhs_block = __jakt_match_value.block;
 {
-return JaktInternal::ExplicitValue<bool>(((lhs_iterator_name == rhs_iterator_name) && lhs_range->equals(rhs_range)) && lhs_block.equals(rhs_block));
+return ((lhs_iterator_name == rhs_iterator_name) && lhs_range->equals(rhs_range)) && lhs_block.equals(rhs_block);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-case 10 /* Break */:return JaktInternal::ExplicitValue(rhs_statement->__jakt_init_index() == 10 /* Break */);
-case 11 /* Continue */:return JaktInternal::ExplicitValue(rhs_statement->__jakt_init_index() == 11 /* Continue */);
-case 12 /* Return */: {
+default:return false;}/*switch end*/
+}};/*case end*/
+case 10 /* Break */:return rhs_statement->__jakt_init_index() == 10 /* Break */;case 11 /* Continue */:return rhs_statement->__jakt_init_index() == 11 /* Continue */;case 12 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& lhs_expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_statement;
+{auto&& __jakt_match_variant = *rhs_statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& rhs_expr = __jakt_match_value.expr;
@@ -15646,39 +13656,20 @@ return false;
 
 }
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 13 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_statement;
+{auto&& __jakt_match_variant = *rhs_statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(lhs_expr->equals(rhs_expr));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_expr->equals(rhs_expr);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 14 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& lhs_expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_statement;
+{auto&& __jakt_match_variant = *rhs_statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 14 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& rhs_expr = __jakt_match_value.expr;
@@ -15695,151 +13686,93 @@ return lhs_expr.value()->equals(rhs_expr.value());
 
 }
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 15 /* InlineCpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.InlineCpp;Jakt::parser::ParsedBlock const& lhs_block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_statement;
+{auto&& __jakt_match_variant = *rhs_statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 15 /* InlineCpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.InlineCpp;Jakt::parser::ParsedBlock const& block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(lhs_block.equals(block));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_block.equals(block);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 16 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_expr = __jakt_match_value.expr;
 Jakt::parser::ParsedBlock const& lhs_else_block = __jakt_match_value.else_block;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_statement;
+{auto&& __jakt_match_variant = *rhs_statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 16 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_expr = __jakt_match_value.expr;
 Jakt::parser::ParsedBlock const& rhs_else_block = __jakt_match_value.else_block;
-return JaktInternal::ExplicitValue(lhs_expr->equals(rhs_expr) && lhs_else_block.equals(rhs_else_block));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-case 17 /* Garbage */:return JaktInternal::ExplicitValue(rhs_statement->__jakt_init_index() == 17 /* Garbage */);
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return lhs_expr->equals(rhs_expr) && lhs_else_block.equals(rhs_else_block);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
+case 17 /* Garbage */:return rhs_statement->__jakt_init_index() == 17 /* Garbage */;default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
 Jakt::utility::Span Jakt::parser::ParsedStatement::span() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::utility::Span, Jakt::utility::Span>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 1 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 2 /* UnsafeBlock */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnsafeBlock;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 3 /* DestructuringAssignment */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DestructuringAssignment;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 4 /* VarDecl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.VarDecl;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 5 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 6 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 7 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 8 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 9 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 10 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 11 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 12 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 13 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 14 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 15 /* InlineCpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.InlineCpp;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 16 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 17 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -16610,69 +14543,19 @@ case 33 /* Garbage */:break;
 }
 bool Jakt::parser::BinaryOperator::equals(Jakt::parser::BinaryOperator const rhs_op) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Add */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 0 /* Add */);
-case 1 /* Subtract */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 1 /* Subtract */);
-case 2 /* Multiply */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 2 /* Multiply */);
-case 3 /* Divide */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 3 /* Divide */);
-case 4 /* Modulo */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 4 /* Modulo */);
-case 5 /* LessThan */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 5 /* LessThan */);
-case 6 /* LessThanOrEqual */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 6 /* LessThanOrEqual */);
-case 7 /* GreaterThan */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 7 /* GreaterThan */);
-case 8 /* GreaterThanOrEqual */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 8 /* GreaterThanOrEqual */);
-case 9 /* Equal */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 9 /* Equal */);
-case 10 /* NotEqual */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 10 /* NotEqual */);
-case 11 /* BitwiseAnd */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 11 /* BitwiseAnd */);
-case 12 /* BitwiseXor */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 12 /* BitwiseXor */);
-case 13 /* BitwiseOr */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 13 /* BitwiseOr */);
-case 14 /* BitwiseLeftShift */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 14 /* BitwiseLeftShift */);
-case 15 /* BitwiseRightShift */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 15 /* BitwiseRightShift */);
-case 16 /* ArithmeticLeftShift */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 16 /* ArithmeticLeftShift */);
-case 17 /* ArithmeticRightShift */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 17 /* ArithmeticRightShift */);
-case 19 /* LogicalOr */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 19 /* LogicalOr */);
-case 18 /* LogicalAnd */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 18 /* LogicalAnd */);
-case 20 /* NoneCoalescing */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 20 /* NoneCoalescing */);
-case 21 /* Assign */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 21 /* Assign */);
-case 22 /* BitwiseAndAssign */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 22 /* BitwiseAndAssign */);
-case 23 /* BitwiseOrAssign */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 23 /* BitwiseOrAssign */);
-case 24 /* BitwiseXorAssign */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 24 /* BitwiseXorAssign */);
-case 25 /* BitwiseLeftShiftAssign */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 25 /* BitwiseLeftShiftAssign */);
-case 26 /* BitwiseRightShiftAssign */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 26 /* BitwiseRightShiftAssign */);
-case 27 /* AddAssign */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 27 /* AddAssign */);
-case 28 /* SubtractAssign */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 28 /* SubtractAssign */);
-case 29 /* MultiplyAssign */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 29 /* MultiplyAssign */);
-case 30 /* ModuloAssign */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 30 /* ModuloAssign */);
-case 31 /* DivideAssign */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 31 /* DivideAssign */);
-case 32 /* NoneCoalescingAssign */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 32 /* NoneCoalescingAssign */);
-case 33 /* Garbage */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 33 /* Garbage */);
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 0 /* Add */:return rhs_op.__jakt_init_index() == 0 /* Add */;case 1 /* Subtract */:return rhs_op.__jakt_init_index() == 1 /* Subtract */;case 2 /* Multiply */:return rhs_op.__jakt_init_index() == 2 /* Multiply */;case 3 /* Divide */:return rhs_op.__jakt_init_index() == 3 /* Divide */;case 4 /* Modulo */:return rhs_op.__jakt_init_index() == 4 /* Modulo */;case 5 /* LessThan */:return rhs_op.__jakt_init_index() == 5 /* LessThan */;case 6 /* LessThanOrEqual */:return rhs_op.__jakt_init_index() == 6 /* LessThanOrEqual */;case 7 /* GreaterThan */:return rhs_op.__jakt_init_index() == 7 /* GreaterThan */;case 8 /* GreaterThanOrEqual */:return rhs_op.__jakt_init_index() == 8 /* GreaterThanOrEqual */;case 9 /* Equal */:return rhs_op.__jakt_init_index() == 9 /* Equal */;case 10 /* NotEqual */:return rhs_op.__jakt_init_index() == 10 /* NotEqual */;case 11 /* BitwiseAnd */:return rhs_op.__jakt_init_index() == 11 /* BitwiseAnd */;case 12 /* BitwiseXor */:return rhs_op.__jakt_init_index() == 12 /* BitwiseXor */;case 13 /* BitwiseOr */:return rhs_op.__jakt_init_index() == 13 /* BitwiseOr */;case 14 /* BitwiseLeftShift */:return rhs_op.__jakt_init_index() == 14 /* BitwiseLeftShift */;case 15 /* BitwiseRightShift */:return rhs_op.__jakt_init_index() == 15 /* BitwiseRightShift */;case 16 /* ArithmeticLeftShift */:return rhs_op.__jakt_init_index() == 16 /* ArithmeticLeftShift */;case 17 /* ArithmeticRightShift */:return rhs_op.__jakt_init_index() == 17 /* ArithmeticRightShift */;case 19 /* LogicalOr */:return rhs_op.__jakt_init_index() == 19 /* LogicalOr */;case 18 /* LogicalAnd */:return rhs_op.__jakt_init_index() == 18 /* LogicalAnd */;case 20 /* NoneCoalescing */:return rhs_op.__jakt_init_index() == 20 /* NoneCoalescing */;case 21 /* Assign */:return rhs_op.__jakt_init_index() == 21 /* Assign */;case 22 /* BitwiseAndAssign */:return rhs_op.__jakt_init_index() == 22 /* BitwiseAndAssign */;case 23 /* BitwiseOrAssign */:return rhs_op.__jakt_init_index() == 23 /* BitwiseOrAssign */;case 24 /* BitwiseXorAssign */:return rhs_op.__jakt_init_index() == 24 /* BitwiseXorAssign */;case 25 /* BitwiseLeftShiftAssign */:return rhs_op.__jakt_init_index() == 25 /* BitwiseLeftShiftAssign */;case 26 /* BitwiseRightShiftAssign */:return rhs_op.__jakt_init_index() == 26 /* BitwiseRightShiftAssign */;case 27 /* AddAssign */:return rhs_op.__jakt_init_index() == 27 /* AddAssign */;case 28 /* SubtractAssign */:return rhs_op.__jakt_init_index() == 28 /* SubtractAssign */;case 29 /* MultiplyAssign */:return rhs_op.__jakt_init_index() == 29 /* MultiplyAssign */;case 30 /* ModuloAssign */:return rhs_op.__jakt_init_index() == 30 /* ModuloAssign */;case 31 /* DivideAssign */:return rhs_op.__jakt_init_index() == 31 /* DivideAssign */;case 32 /* NoneCoalescingAssign */:return rhs_op.__jakt_init_index() == 32 /* NoneCoalescingAssign */;case 33 /* Garbage */:return rhs_op.__jakt_init_index() == 33 /* Garbage */;default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
 bool Jakt::parser::BinaryOperator::is_assignment() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 21 /* Assign */:case 22 /* BitwiseAndAssign */:case 23 /* BitwiseOrAssign */:case 24 /* BitwiseXorAssign */:case 25 /* BitwiseLeftShiftAssign */:case 26 /* BitwiseRightShiftAssign */:case 27 /* AddAssign */:case 28 /* SubtractAssign */:case 29 /* MultiplyAssign */:case 30 /* ModuloAssign */:case 31 /* DivideAssign */:case 32 /* NoneCoalescingAssign */:return JaktInternal::ExplicitValue(true);
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 21 /* Assign */:case 22 /* BitwiseAndAssign */:case 23 /* BitwiseOrAssign */:case 24 /* BitwiseXorAssign */:case 25 /* BitwiseLeftShiftAssign */:case 26 /* BitwiseRightShiftAssign */:case 27 /* AddAssign */:case 28 /* SubtractAssign */:case 29 /* MultiplyAssign */:case 30 /* ModuloAssign */:case 31 /* DivideAssign */:case 32 /* NoneCoalescingAssign */:return true;default:return false;}/*switch end*/
+}
 }
 }
 
@@ -16791,25 +14674,16 @@ break;
 }
 NonnullRefPtr<typename Jakt::parser::ParsedType> Jakt::parser::TypeCast::parsed_type() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::parser::ParsedType>, NonnullRefPtr<typename Jakt::parser::ParsedType>>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Fallible */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Fallible;NonnullRefPtr<typename Jakt::parser::ParsedType> const& parsed_type = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(parsed_type);
-};/*case end*/
+return parsed_type;};/*case end*/
 case 1 /* Infallible */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Infallible;NonnullRefPtr<typename Jakt::parser::ParsedType> const& parsed_type = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(parsed_type);
-};/*case end*/
+return parsed_type;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -17237,84 +15111,39 @@ break;
 }
 bool Jakt::parser::UnaryOperator::equals(Jakt::parser::UnaryOperator const rhs_op) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* PreIncrement */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 0 /* PreIncrement */);
-case 1 /* PostIncrement */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 1 /* PostIncrement */);
-case 2 /* PreDecrement */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 2 /* PreDecrement */);
-case 3 /* PostDecrement */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 3 /* PostDecrement */);
-case 4 /* Negate */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 4 /* Negate */);
-case 5 /* Dereference */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 5 /* Dereference */);
-case 6 /* RawAddress */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 6 /* RawAddress */);
-case 7 /* Reference */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 7 /* Reference */);
-case 8 /* MutableReference */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 8 /* MutableReference */);
-case 9 /* LogicalNot */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 9 /* LogicalNot */);
-case 10 /* BitwiseNot */:return JaktInternal::ExplicitValue(rhs_op.__jakt_init_index() == 10 /* BitwiseNot */);
-case 11 /* TypeCast */: {
+case 0 /* PreIncrement */:return rhs_op.__jakt_init_index() == 0 /* PreIncrement */;case 1 /* PostIncrement */:return rhs_op.__jakt_init_index() == 1 /* PostIncrement */;case 2 /* PreDecrement */:return rhs_op.__jakt_init_index() == 2 /* PreDecrement */;case 3 /* PostDecrement */:return rhs_op.__jakt_init_index() == 3 /* PostDecrement */;case 4 /* Negate */:return rhs_op.__jakt_init_index() == 4 /* Negate */;case 5 /* Dereference */:return rhs_op.__jakt_init_index() == 5 /* Dereference */;case 6 /* RawAddress */:return rhs_op.__jakt_init_index() == 6 /* RawAddress */;case 7 /* Reference */:return rhs_op.__jakt_init_index() == 7 /* Reference */;case 8 /* MutableReference */:return rhs_op.__jakt_init_index() == 8 /* MutableReference */;case 9 /* LogicalNot */:return rhs_op.__jakt_init_index() == 9 /* LogicalNot */;case 10 /* BitwiseNot */:return rhs_op.__jakt_init_index() == 10 /* BitwiseNot */;case 11 /* TypeCast */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeCast;Jakt::parser::TypeCast const& lhs_type_cast = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = rhs_op;
+{auto&& __jakt_match_variant = rhs_op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* TypeCast */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeCast;Jakt::parser::TypeCast const& rhs_type_cast = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(lhs_type_cast.parsed_type()->equals(rhs_type_cast.parsed_type()));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_type_cast.parsed_type()->equals(rhs_type_cast.parsed_type());};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 12 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;NonnullRefPtr<typename Jakt::parser::ParsedType> const& lhs_type = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = rhs_op;
+{auto&& __jakt_match_variant = rhs_op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;NonnullRefPtr<typename Jakt::parser::ParsedType> const& rhs_type = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(lhs_type->equals(rhs_type));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_type->equals(rhs_type);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 14 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;NonnullRefPtr<typename Jakt::parser::ParsedType> const& lhs_type = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = rhs_op;
+{auto&& __jakt_match_variant = rhs_op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 14 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;NonnullRefPtr<typename Jakt::parser::ParsedType> const& rhs_type = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(lhs_type->equals(rhs_type));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_type->equals(rhs_type);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 13 /* IsEnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IsEnumVariant;NonnullRefPtr<typename Jakt::parser::ParsedType> const& lhs_inner_type = __jakt_match_value.inner;
 JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> const& lhs_bindings = __jakt_match_value.bindings;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = rhs_op;
+{auto&& __jakt_match_variant = rhs_op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* IsEnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IsEnumVariant;NonnullRefPtr<typename Jakt::parser::ParsedType> const& rhs_inner_type = __jakt_match_value.inner;
@@ -17332,7 +15161,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (!lhs_bindings.operator[](i).equals(rhs_bindings.operator[](i))){
+if (!lhs_bindings[i].equals(rhs_bindings[i])){
 bindings_equal = false;
 break;
 }
@@ -17345,26 +15174,14 @@ if (bindings_equal){
 equal = true;
 }
 }
-return JaktInternal::ExplicitValue<bool>(equal);
+return equal;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -17627,9 +15444,7 @@ return true;
 
 bool Jakt::parser::ParsedMatchPattern::is_equal_pattern(Jakt::parser::ParsedMatchPattern const rhs_parsed_match_pattern) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* EnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>> const& lhs_variant_names = __jakt_match_value.variant_names;
@@ -17650,8 +15465,8 @@ break;
 }
 size_t i = _magic_value.value();
 {
-ByteString const lhs_name = lhs_variant_names.operator[](JaktInternal::checked_sub(JaktInternal::checked_sub(lhs_variant_names.size(),i),static_cast<size_t>(1ULL))).template get<0>();
-ByteString const rhs_name = rhs_variant_names.operator[](JaktInternal::checked_sub(JaktInternal::checked_sub(rhs_variant_names.size(),i),static_cast<size_t>(1ULL))).template get<0>();
+ByteString const lhs_name = lhs_variant_names[JaktInternal::checked_sub(JaktInternal::checked_sub(lhs_variant_names.size(),i),static_cast<size_t>(1ULL))].template get<0>();
+ByteString const rhs_name = rhs_variant_names[JaktInternal::checked_sub(JaktInternal::checked_sub(rhs_variant_names.size(),i),static_cast<size_t>(1ULL))].template get<0>();
 if (lhs_name == rhs_name){
 }
 else {
@@ -17673,32 +15488,15 @@ return false;
 };/*case end*/
 case 1 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_parsed_expression = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = rhs_parsed_match_pattern;
+{auto&& __jakt_match_variant = rhs_parsed_match_pattern;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_parsed_expression = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(lhs_parsed_expression->equals(rhs_parsed_expression));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-case 2 /* CatchAll */:return JaktInternal::ExplicitValue(rhs_parsed_match_pattern.__jakt_init_index() == 2 /* CatchAll */);
-case 3 /* Invalid */:return JaktInternal::ExplicitValue(rhs_parsed_match_pattern.__jakt_init_index() == 3 /* Invalid */);
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return lhs_parsed_expression->equals(rhs_parsed_expression);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
+case 2 /* CatchAll */:return rhs_parsed_match_pattern.__jakt_init_index() == 2 /* CatchAll */;case 3 /* Invalid */:return rhs_parsed_match_pattern.__jakt_init_index() == 3 /* Invalid */;default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
@@ -17722,7 +15520,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (!lhs_variant_arguments.operator[](i).equals(rhs_variant_arguments.operator[](i))){
+if (!lhs_variant_arguments[i].equals(rhs_variant_arguments[i])){
 return false;
 }
 }
@@ -17870,30 +15668,22 @@ break;
 }
 bool Jakt::parser::ParsedMatchBody::equals(Jakt::parser::ParsedMatchBody const rhs_match_body) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_expr = __jakt_match_value.value;
 {
 Jakt::parser::ParsedMatchBody __jakt_tmp6 = rhs_match_body;
-return JaktInternal::ExplicitValue<bool>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool,bool> {
-auto __jakt_enum_value = (__jakt_tmp6.__jakt_init_index() == 0 /* Expression */);
+{auto __jakt_enum_value = __jakt_tmp6.__jakt_init_index() == 0 /* Expression */;
 if (__jakt_enum_value) {{
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const rhs_expr = __jakt_tmp6.as.Expression.value;
-return JaktInternal::ExplicitValue<bool>(lhs_expr->equals(rhs_expr));
+return lhs_expr->equals(rhs_expr);
 }
 VERIFY_NOT_REACHED();
 }else {{
 return false;
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -17901,32 +15691,21 @@ case 1 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::parser::ParsedBlock const& lhs_block = __jakt_match_value.value;
 {
 Jakt::parser::ParsedMatchBody __jakt_tmp7 = rhs_match_body;
-return JaktInternal::ExplicitValue<bool>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool,bool> {
-auto __jakt_enum_value = (__jakt_tmp7.__jakt_init_index() == 1 /* Block */);
+{auto __jakt_enum_value = __jakt_tmp7.__jakt_init_index() == 1 /* Block */;
 if (__jakt_enum_value) {{
 Jakt::parser::ParsedBlock const rhs_block = __jakt_tmp7.as.Block.value;
-return JaktInternal::ExplicitValue<bool>(lhs_block.equals(rhs_block));
+return lhs_block.equals(rhs_block);
 }
 VERIFY_NOT_REACHED();
 }else {{
 return false;
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -19933,515 +17712,294 @@ break;
 }
 Jakt::utility::Span Jakt::parser::ParsedExpression::span() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::utility::Span, Jakt::utility::Span>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Boolean */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boolean;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 1 /* NumericConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NumericConstant;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 2 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 3 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 4 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 5 /* MethodCall */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MethodCall;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 6 /* IndexedTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedTuple;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 7 /* IndexedStruct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedStruct;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 8 /* ComptimeIndex */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ComptimeIndex;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 9 /* Var */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Var;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 10 /* IndexedExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedExpression;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 11 /* UnaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 12 /* BinaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.BinaryOp;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 13 /* Operator */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Operator;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 14 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 15 /* OptionalNone */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalNone;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 16 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 17 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 18 /* Set */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Set;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 19 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 20 /* Range */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Range;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 21 /* ForcedUnwrap */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForcedUnwrap;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 22 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 23 /* EnumVariantArg */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariantArg;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 24 /* NamespacedVar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedVar;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 25 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 26 /* Must */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Must;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 27 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 28 /* TryBlock */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TryBlock;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 29 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 30 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 31 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 i64 Jakt::parser::ParsedExpression::precedence() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<i64, i64>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* Operator */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Operator;Jakt::parser::BinaryOperator const& op = __jakt_match_value.op;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<i64, i64>{
-auto&& __jakt_match_variant = op;
+{auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* Multiply */:case 4 /* Modulo */:case 3 /* Divide */:return JaktInternal::ExplicitValue(static_cast<i64>(100LL));
-case 0 /* Add */:case 1 /* Subtract */:return JaktInternal::ExplicitValue(static_cast<i64>(90LL));
-case 14 /* BitwiseLeftShift */:case 15 /* BitwiseRightShift */:case 16 /* ArithmeticLeftShift */:case 17 /* ArithmeticRightShift */:return JaktInternal::ExplicitValue(static_cast<i64>(85LL));
-case 5 /* LessThan */:case 6 /* LessThanOrEqual */:case 7 /* GreaterThan */:case 8 /* GreaterThanOrEqual */:case 9 /* Equal */:case 10 /* NotEqual */:return JaktInternal::ExplicitValue(static_cast<i64>(80LL));
-case 11 /* BitwiseAnd */:return JaktInternal::ExplicitValue(static_cast<i64>(73LL));
-case 12 /* BitwiseXor */:return JaktInternal::ExplicitValue(static_cast<i64>(72LL));
-case 13 /* BitwiseOr */:return JaktInternal::ExplicitValue(static_cast<i64>(71LL));
-case 18 /* LogicalAnd */:return JaktInternal::ExplicitValue(static_cast<i64>(70LL));
-case 19 /* LogicalOr */:case 20 /* NoneCoalescing */:return JaktInternal::ExplicitValue(static_cast<i64>(69LL));
-case 21 /* Assign */:case 22 /* BitwiseAndAssign */:case 23 /* BitwiseOrAssign */:case 24 /* BitwiseXorAssign */:case 25 /* BitwiseLeftShiftAssign */:case 26 /* BitwiseRightShiftAssign */:case 27 /* AddAssign */:case 28 /* SubtractAssign */:case 29 /* MultiplyAssign */:case 30 /* ModuloAssign */:case 31 /* DivideAssign */:case 32 /* NoneCoalescingAssign */:return JaktInternal::ExplicitValue(static_cast<i64>(50LL));
-default:return JaktInternal::ExplicitValue(static_cast<i64>(0LL));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(static_cast<i64>(0LL));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 2 /* Multiply */:case 4 /* Modulo */:case 3 /* Divide */:return static_cast<i64>(100LL);case 0 /* Add */:case 1 /* Subtract */:return static_cast<i64>(90LL);case 14 /* BitwiseLeftShift */:case 15 /* BitwiseRightShift */:case 16 /* ArithmeticLeftShift */:case 17 /* ArithmeticRightShift */:return static_cast<i64>(85LL);case 5 /* LessThan */:case 6 /* LessThanOrEqual */:case 7 /* GreaterThan */:case 8 /* GreaterThanOrEqual */:case 9 /* Equal */:case 10 /* NotEqual */:return static_cast<i64>(80LL);case 11 /* BitwiseAnd */:return static_cast<i64>(73LL);case 12 /* BitwiseXor */:return static_cast<i64>(72LL);case 13 /* BitwiseOr */:return static_cast<i64>(71LL);case 18 /* LogicalAnd */:return static_cast<i64>(70LL);case 19 /* LogicalOr */:case 20 /* NoneCoalescing */:return static_cast<i64>(69LL);case 21 /* Assign */:case 22 /* BitwiseAndAssign */:case 23 /* BitwiseOrAssign */:case 24 /* BitwiseXorAssign */:case 25 /* BitwiseLeftShiftAssign */:case 26 /* BitwiseRightShiftAssign */:case 27 /* AddAssign */:case 28 /* SubtractAssign */:case 29 /* MultiplyAssign */:case 30 /* ModuloAssign */:case 31 /* DivideAssign */:case 32 /* NoneCoalescingAssign */:return static_cast<i64>(50LL);default:return static_cast<i64>(0LL);}/*switch end*/
+}};/*case end*/
+default:return static_cast<i64>(0LL);}/*switch end*/
+}
 }
 }
 
 bool Jakt::parser::ParsedExpression::equals(NonnullRefPtr<typename Jakt::parser::ParsedExpression> const rhs_expression) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Boolean */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boolean;bool const& lhs_val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Boolean */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boolean;bool const& rhs_val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(lhs_val == rhs_val);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_val == rhs_val;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 1 /* NumericConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NumericConstant;Jakt::parser::NumericConstant const& lhs_val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* NumericConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NumericConstant;Jakt::parser::NumericConstant const& rhs_val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(lhs_val.to_usize() == rhs_val.to_usize());
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_val.to_usize() == rhs_val.to_usize();};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 2 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;ByteString const& lhs_val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;ByteString const& rhs_val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(lhs_val == rhs_val);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_val == rhs_val;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 3 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;ByteString const& lhs_val = __jakt_match_value.val;
 JaktInternal::Optional<ByteString> const& lhs_prefix = __jakt_match_value.prefix;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;ByteString const& rhs_val = __jakt_match_value.val;
 JaktInternal::Optional<ByteString> const& rhs_prefix = __jakt_match_value.prefix;
-return JaktInternal::ExplicitValue((lhs_val == rhs_val) && (lhs_prefix == rhs_prefix));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return (lhs_val == rhs_val) && (lhs_prefix == rhs_prefix);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 4 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::parser::ParsedCall const& lhs_call = __jakt_match_value.call;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::parser::ParsedCall const& rhs_call = __jakt_match_value.call;
-return JaktInternal::ExplicitValue(lhs_call.equals(rhs_call));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_call.equals(rhs_call);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 5 /* MethodCall */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MethodCall;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_expr = __jakt_match_value.expr;
 Jakt::parser::ParsedCall const& lhs_call = __jakt_match_value.call;
 bool const& lhs_optional = __jakt_match_value.is_optional;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* MethodCall */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MethodCall;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_expr = __jakt_match_value.expr;
 Jakt::parser::ParsedCall const& rhs_call = __jakt_match_value.call;
 bool const& rhs_optional = __jakt_match_value.is_optional;
-return JaktInternal::ExplicitValue(((lhs_optional == rhs_optional) && lhs_expr->equals(rhs_expr)) && lhs_call.equals(rhs_call));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return ((lhs_optional == rhs_optional) && lhs_expr->equals(rhs_expr)) && lhs_call.equals(rhs_call);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 6 /* IndexedTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedTuple;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_expr = __jakt_match_value.expr;
 size_t const& lhs_index = __jakt_match_value.index;
 bool const& lhs_optional = __jakt_match_value.is_optional;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* IndexedTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedTuple;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_expr = __jakt_match_value.expr;
 size_t const& rhs_index = __jakt_match_value.index;
 bool const& rhs_optional = __jakt_match_value.is_optional;
-return JaktInternal::ExplicitValue(((lhs_optional == rhs_optional) && lhs_expr->equals(rhs_expr)) && (lhs_index == rhs_index));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return ((lhs_optional == rhs_optional) && lhs_expr->equals(rhs_expr)) && (lhs_index == rhs_index);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 7 /* IndexedStruct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedStruct;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_expr = __jakt_match_value.expr;
 ByteString const& lhs_field = __jakt_match_value.field_name;
 bool const& lhs_optional = __jakt_match_value.is_optional;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* IndexedStruct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedStruct;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_expr = __jakt_match_value.expr;
 ByteString const& rhs_field = __jakt_match_value.field_name;
 bool const& rhs_optional = __jakt_match_value.is_optional;
-return JaktInternal::ExplicitValue(((lhs_optional == rhs_optional) && lhs_expr->equals(rhs_expr)) && (lhs_field == rhs_field));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return ((lhs_optional == rhs_optional) && lhs_expr->equals(rhs_expr)) && (lhs_field == rhs_field);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 8 /* ComptimeIndex */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ComptimeIndex;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_expr = __jakt_match_value.expr;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_index = __jakt_match_value.index;
 bool const& lhs_optional = __jakt_match_value.is_optional;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* ComptimeIndex */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ComptimeIndex;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_expr = __jakt_match_value.expr;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_index = __jakt_match_value.index;
 bool const& rhs_optional = __jakt_match_value.is_optional;
-return JaktInternal::ExplicitValue(((lhs_optional == rhs_optional) && lhs_expr->equals(rhs_expr)) && lhs_index->equals(rhs_index));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return ((lhs_optional == rhs_optional) && lhs_expr->equals(rhs_expr)) && lhs_index->equals(rhs_index);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 9 /* Var */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Var;ByteString const& lhs_name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* Var */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Var;ByteString const& rhs_name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(lhs_name == rhs_name);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_name == rhs_name;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 10 /* IndexedExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedExpression;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_base = __jakt_match_value.base;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* IndexedExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedExpression;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_base = __jakt_match_value.base;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue(lhs_base->equals(rhs_base) && lhs_index->equals(rhs_index));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_base->equals(rhs_base) && lhs_index->equals(rhs_index);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 11 /* UnaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_expr = __jakt_match_value.expr;
 Jakt::parser::UnaryOperator const& lhs_op = __jakt_match_value.op;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* UnaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_expr = __jakt_match_value.expr;
 Jakt::parser::UnaryOperator const& rhs_op = __jakt_match_value.op;
-return JaktInternal::ExplicitValue(lhs_expr->equals(rhs_expr) && lhs_op.equals(rhs_op));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_expr->equals(rhs_expr) && lhs_op.equals(rhs_op);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 12 /* BinaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.BinaryOp;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_lhs = __jakt_match_value.lhs;
 Jakt::parser::BinaryOperator const& lhs_op = __jakt_match_value.op;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_rhs = __jakt_match_value.rhs;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* BinaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.BinaryOp;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_lhs = __jakt_match_value.lhs;
 Jakt::parser::BinaryOperator const& rhs_op = __jakt_match_value.op;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_rhs = __jakt_match_value.rhs;
-return JaktInternal::ExplicitValue((lhs_lhs->equals(rhs_lhs) && lhs_op.equals(rhs_op)) && lhs_rhs->equals(rhs_rhs));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return (lhs_lhs->equals(rhs_lhs) && lhs_op.equals(rhs_op)) && lhs_rhs->equals(rhs_rhs);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 13 /* Operator */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Operator;Jakt::parser::BinaryOperator const& lhs_op = __jakt_match_value.op;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* Operator */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Operator;Jakt::parser::BinaryOperator const& rhs_op = __jakt_match_value.op;
-return JaktInternal::ExplicitValue(lhs_op.equals(rhs_op));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_op.equals(rhs_op);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 14 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 14 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(lhs_expr->equals(rhs_expr));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-case 15 /* OptionalNone */:return JaktInternal::ExplicitValue(rhs_expression->__jakt_init_index() == 15 /* OptionalNone */);
-case 16 /* JaktArray */: {
+return lhs_expr->equals(rhs_expr);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
+case 15 /* OptionalNone */:return rhs_expression->__jakt_init_index() == 15 /* OptionalNone */;case 16 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& lhs_values = __jakt_match_value.values;
 JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& lhs_fill_size = __jakt_match_value.fill_size;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 16 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& rhs_values = __jakt_match_value.values;
@@ -20461,9 +18019,7 @@ return false;
 }
 }
 
-return JaktInternal::ExplicitValue<bool>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool,bool> {
-auto __jakt_enum_value = (lhs_values.size() == rhs_values.size());
+{auto __jakt_enum_value = lhs_values.size() == rhs_values.size();
 if (__jakt_enum_value) {{
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(lhs_values.size())};
@@ -20474,7 +18030,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (!lhs_values.operator[](i)->equals(rhs_values.operator[](i))){
+if (!lhs_values[i]->equals(rhs_values[i])){
 return false;
 }
 }
@@ -20482,41 +18038,26 @@ return false;
 }
 }
 
-return JaktInternal::ExplicitValue<bool>(true);
+return true;
 }
 VERIFY_NOT_REACHED();
 }else {{
 return false;
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 17 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,NonnullRefPtr<typename Jakt::parser::ParsedExpression>>> const& lhs_values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,NonnullRefPtr<typename Jakt::parser::ParsedExpression>>> const& rhs_values = __jakt_match_value.values;
 {
-return JaktInternal::ExplicitValue<bool>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool,bool> {
-auto __jakt_enum_value = (lhs_values.size() == rhs_values.size());
+{auto __jakt_enum_value = lhs_values.size() == rhs_values.size();
 if (__jakt_enum_value) {{
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(lhs_values.size())};
@@ -20527,7 +18068,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (!(lhs_values.operator[](i).template get<0>()->equals(rhs_values.operator[](i).template get<0>()) && lhs_values.operator[](i).template get<1>()->equals(rhs_values.operator[](i).template get<1>()))){
+if (!(lhs_values[i].template get<0>()->equals(rhs_values[i].template get<0>()) && lhs_values[i].template get<1>()->equals(rhs_values[i].template get<1>()))){
 return false;
 }
 }
@@ -20535,41 +18076,26 @@ return false;
 }
 }
 
-return JaktInternal::ExplicitValue<bool>(true);
+return true;
 }
 VERIFY_NOT_REACHED();
 }else {{
 return false;
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 18 /* Set */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Set;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& lhs_values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 18 /* Set */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Set;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& rhs_values = __jakt_match_value.values;
 {
-return JaktInternal::ExplicitValue<bool>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool,bool> {
-auto __jakt_enum_value = (lhs_values.size() == rhs_values.size());
+{auto __jakt_enum_value = lhs_values.size() == rhs_values.size();
 if (__jakt_enum_value) {{
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(lhs_values.size())};
@@ -20580,7 +18106,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (!lhs_values.operator[](i)->equals(rhs_values.operator[](i))){
+if (!lhs_values[i]->equals(rhs_values[i])){
 return false;
 }
 }
@@ -20588,41 +18114,26 @@ return false;
 }
 }
 
-return JaktInternal::ExplicitValue<bool>(true);
+return true;
 }
 VERIFY_NOT_REACHED();
 }else {{
 return false;
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 19 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& lhs_values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 19 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& rhs_values = __jakt_match_value.values;
 {
-return JaktInternal::ExplicitValue<bool>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool,bool> {
-auto __jakt_enum_value = (lhs_values.size() == rhs_values.size());
+{auto __jakt_enum_value = lhs_values.size() == rhs_values.size();
 if (__jakt_enum_value) {{
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(lhs_values.size())};
@@ -20633,7 +18144,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (!lhs_values.operator[](i)->equals(rhs_values.operator[](i))){
+if (!lhs_values[i]->equals(rhs_values[i])){
 return false;
 }
 }
@@ -20641,35 +18152,22 @@ return false;
 }
 }
 
-return JaktInternal::ExplicitValue<bool>(true);
+return true;
 }
 VERIFY_NOT_REACHED();
 }else {{
 return false;
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 20 /* Range */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Range;JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& lhs_from = __jakt_match_value.from;
 JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& lhs_to = __jakt_match_value.to;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* Range */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Range;JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& rhs_from = __jakt_match_value.from;
@@ -20685,44 +18183,25 @@ equal = true;
 }
 
 }
-return JaktInternal::ExplicitValue<bool>(equal);
+return equal;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 21 /* ForcedUnwrap */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForcedUnwrap;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* ForcedUnwrap */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForcedUnwrap;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(lhs_expr->equals(rhs_expr));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_expr->equals(rhs_expr);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 22 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_expr = __jakt_match_value.expr;
 JaktInternal::DynamicArray<Jakt::parser::ParsedMatchCase> const& lhs_cases = __jakt_match_value.cases;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 22 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_expr = __jakt_match_value.expr;
@@ -20748,7 +18227,7 @@ break;
 }
 size_t k = _magic_value.value();
 {
-if (lhs_cases.operator[](i).equals(rhs_cases.operator[](k))){
+if (lhs_cases[i].equals(rhs_cases[k])){
 current_case_has_match = true;
 break;
 }
@@ -20776,40 +18255,21 @@ return false;
 
 }
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 23 /* EnumVariantArg */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariantArg;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* EnumVariantArg */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariantArg;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(lhs_expr->equals(rhs_expr));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_expr->equals(rhs_expr);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 24 /* NamespacedVar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedVar;ByteString const& lhs_name = __jakt_match_value.name;
 JaktInternal::DynamicArray<ByteString> const& lhs_namespace = __jakt_match_value.namespace_;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* NamespacedVar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedVar;ByteString const& rhs_name = __jakt_match_value.name;
@@ -20831,7 +18291,7 @@ if ([](ByteString const& self, ByteString rhs) -> bool {{
 return !(self == rhs);
 }
 }
-(lhs_namespace.operator[](i),rhs_namespace.operator[](i))){
+(lhs_namespace[i],rhs_namespace[i])){
 return false;
 }
 }
@@ -20839,25 +18299,16 @@ return false;
 }
 }
 
-return JaktInternal::ExplicitValue<bool>(lhs_name == rhs_name);
+return lhs_name == rhs_name;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 26 /* Must */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Must;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_expr = __jakt_match_value.expr;
 Jakt::utility::Span const& lhs_span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 26 /* Must */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Must;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_expr = __jakt_match_value.expr;
@@ -20867,25 +18318,16 @@ bool equals = (rhs_span.start == lhs_span.start) && (rhs_span.end == lhs_span.en
 if (!equals){
 equals = lhs_expr->equals(rhs_expr);
 }
-return JaktInternal::ExplicitValue<bool>(equals);
+return equals;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 27 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs_expr = __jakt_match_value.expr;
 JaktInternal::Optional<Jakt::parser::ParsedBlock> const& lhs_catch_block = __jakt_match_value.catch_block;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 27 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_expr = __jakt_match_value.expr;
@@ -20907,50 +18349,31 @@ equals = (!rhs_catch_block.has_value());
 }
 
 }
-return JaktInternal::ExplicitValue<bool>(equals);
+return equals;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 28 /* TryBlock */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TryBlock;NonnullRefPtr<typename Jakt::parser::ParsedStatement> const& lhs_stmt = __jakt_match_value.stmt;
 ByteString const& lhs_error_name = __jakt_match_value.error_name;
 Jakt::parser::ParsedBlock const& lhs_catch_block = __jakt_match_value.catch_block;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 28 /* TryBlock */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TryBlock;NonnullRefPtr<typename Jakt::parser::ParsedStatement> const& rhs_stmt = __jakt_match_value.stmt;
 ByteString const& rhs_error_name = __jakt_match_value.error_name;
 Jakt::parser::ParsedBlock const& rhs_catch_block = __jakt_match_value.catch_block;
-return JaktInternal::ExplicitValue((lhs_stmt->equals(rhs_stmt) && (lhs_error_name == rhs_error_name)) && lhs_catch_block.equals(rhs_catch_block));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return (lhs_stmt->equals(rhs_stmt) && (lhs_error_name == rhs_error_name)) && lhs_catch_block.equals(rhs_catch_block);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 25 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<Jakt::parser::ParsedCapture> const& lhs_captures = __jakt_match_value.captures;
 JaktInternal::DynamicArray<Jakt::parser::ParsedParameter> const& lhs_params = __jakt_match_value.params;
 bool const& lhs_can_throw = __jakt_match_value.can_throw;
 NonnullRefPtr<typename Jakt::parser::ParsedType> const& lhs_return_type = __jakt_match_value.return_type;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 25 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<Jakt::parser::ParsedCapture> const& rhs_captures = __jakt_match_value.captures;
@@ -20968,7 +18391,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (!(lhs_captures.operator[](i).common.init_common.name == rhs_captures.operator[](i).common.init_common.name)){
+if (!(lhs_captures[i].common.init_common.name == rhs_captures[i].common.init_common.name)){
 return false;
 }
 }
@@ -20985,7 +18408,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (!lhs_params.operator[](i).equals(rhs_params.operator[](i))){
+if (!lhs_params[i].equals(rhs_params[i])){
 return false;
 }
 }
@@ -21001,61 +18424,28 @@ return false;
 
 }
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 29 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;NonnullRefPtr<typename Jakt::parser::ParsedType> const& type = __jakt_match_value.type;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 29 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;NonnullRefPtr<typename Jakt::parser::ParsedType> const& rhs_type = __jakt_match_value.type;
-return JaktInternal::ExplicitValue(type->equals(rhs_type));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-case 30 /* Garbage */:return JaktInternal::ExplicitValue(rhs_expression->__jakt_init_index() == 30 /* Garbage */);
-case 31 /* Unsafe */: {
+return type->equals(rhs_type);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
+case 30 /* Garbage */:return rhs_expression->__jakt_init_index() == 30 /* Garbage */;case 31 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_expression;
+{auto&& __jakt_match_variant = *rhs_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 31 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(expr->equals(rhs_expr));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return expr->equals(rhs_expr);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -21968,136 +19358,89 @@ case 15 /* Empty */:break;
 }
 Jakt::utility::Span Jakt::parser::ParsedType::span() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::utility::Span, Jakt::utility::Span>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 15 /* Empty */:return JaktInternal::ExplicitValue(Jakt::utility::Span(Jakt::utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL)));
-case 0 /* Name */: {
+case 15 /* Empty */:return Jakt::utility::Span(Jakt::utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL));case 0 /* Name */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Name;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 1 /* NamespacedName */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedName;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 2 /* GenericType */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericType;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 3 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 4 /* Dictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dictionary;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 5 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 6 /* Set */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Set;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 7 /* Optional */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Optional;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 8 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 9 /* MutableReference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MutableReference;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 10 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 11 /* WeakPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.WeakPtr;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 12 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 13 /* Const */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Const;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 14 /* DependentType */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DependentType;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 bool Jakt::parser::ParsedType::equals(NonnullRefPtr<typename Jakt::parser::ParsedType> const rhs_parsed_type) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 14 /* DependentType */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DependentType;NonnullRefPtr<typename Jakt::parser::ParsedType> const& base = __jakt_match_value.base;
 ByteString const& name = __jakt_match_value.name;
 JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>> const& generic_args = __jakt_match_value.generic_args;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_parsed_type;
+{auto&& __jakt_match_variant = *rhs_parsed_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 14 /* DependentType */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DependentType;NonnullRefPtr<typename Jakt::parser::ParsedType> const& rhs_base = __jakt_match_value.base;
 ByteString const& rhs_name = __jakt_match_value.name;
 JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>> const& rhs_generic_args = __jakt_match_value.generic_args;
-return JaktInternal::ExplicitValue((base->equals(rhs_base) && (name == rhs_name)) && (generic_args.operator[](JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}) == rhs_generic_args.operator[](JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return (base->equals(rhs_base) && (name == rhs_name)) && (generic_args[JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}] == rhs_generic_args[JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}]);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 0 /* Name */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Name;ByteString const& lhs_name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_parsed_type;
+{auto&& __jakt_match_variant = *rhs_parsed_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Name */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Name;ByteString const& rhs_name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(lhs_name == rhs_name);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_name == rhs_name;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 1 /* NamespacedName */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedName;ByteString const& lhs_name = __jakt_match_value.name;
 JaktInternal::DynamicArray<ByteString> const& lhs_namespaces = __jakt_match_value.namespaces;
 JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>> const& lhs_params = __jakt_match_value.params;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_parsed_type;
+{auto&& __jakt_match_variant = *rhs_parsed_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* NamespacedName */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedName;ByteString const& rhs_name = __jakt_match_value.name;
@@ -22127,7 +19470,7 @@ if ([](ByteString const& self, ByteString rhs) -> bool {{
 return !(self == rhs);
 }
 }
-(lhs_namespaces.operator[](namespace_index),rhs_namespaces.operator[](namespace_index))){
+(lhs_namespaces[namespace_index],rhs_namespaces[namespace_index])){
 return false;
 }
 }
@@ -22147,7 +19490,7 @@ break;
 }
 size_t param_index = _magic_value.value();
 {
-if (!lhs_params.operator[](param_index)->equals(rhs_params.operator[](param_index))){
+if (!lhs_params[param_index]->equals(rhs_params[param_index])){
 return false;
 }
 }
@@ -22158,21 +19501,12 @@ return false;
 return true;
 }
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 2 /* GenericType */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericType;ByteString const& lhs_name = __jakt_match_value.name;
 JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>> const& lhs_generic_parameters = __jakt_match_value.generic_parameters;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_parsed_type;
+{auto&& __jakt_match_variant = *rhs_parsed_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* GenericType */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericType;ByteString const& rhs_name = __jakt_match_value.name;
@@ -22197,7 +19531,7 @@ break;
 }
 size_t param_index = _magic_value.value();
 {
-if (!lhs_generic_parameters.operator[](param_index)->equals(rhs_generic_parameters.operator[](param_index))){
+if (!lhs_generic_parameters[param_index]->equals(rhs_generic_parameters[param_index])){
 return false;
 }
 }
@@ -22208,60 +19542,31 @@ return false;
 return true;
 }
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 3 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;NonnullRefPtr<typename Jakt::parser::ParsedType> const& lhs_inner = __jakt_match_value.inner;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_parsed_type;
+{auto&& __jakt_match_variant = *rhs_parsed_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;NonnullRefPtr<typename Jakt::parser::ParsedType> const& rhs_inner = __jakt_match_value.inner;
-return JaktInternal::ExplicitValue(lhs_inner->equals(rhs_inner));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_inner->equals(rhs_inner);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 4 /* Dictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dictionary;NonnullRefPtr<typename Jakt::parser::ParsedType> const& lhs_key = __jakt_match_value.key;
 NonnullRefPtr<typename Jakt::parser::ParsedType> const& lhs_value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_parsed_type;
+{auto&& __jakt_match_variant = *rhs_parsed_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* Dictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dictionary;NonnullRefPtr<typename Jakt::parser::ParsedType> const& rhs_key = __jakt_match_value.key;
 NonnullRefPtr<typename Jakt::parser::ParsedType> const& rhs_value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(lhs_key->equals(rhs_key) && lhs_value->equals(rhs_value));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_key->equals(rhs_key) && lhs_value->equals(rhs_value);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 5 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>> const& lhs_types = __jakt_match_value.types;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_parsed_type;
+{auto&& __jakt_match_variant = *rhs_parsed_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>> const& rhs_types = __jakt_match_value.types;
@@ -22278,7 +19583,7 @@ break;
 }
 size_t type_index = _magic_value.value();
 {
-if (!lhs_types.operator[](type_index)->equals(rhs_types.operator[](type_index))){
+if (!lhs_types[type_index]->equals(rhs_types[type_index])){
 return false;
 }
 }
@@ -22289,136 +19594,67 @@ return false;
 return true;
 }
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 6 /* Set */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Set;NonnullRefPtr<typename Jakt::parser::ParsedType> const& lhs_inner = __jakt_match_value.inner;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_parsed_type;
+{auto&& __jakt_match_variant = *rhs_parsed_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* Set */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Set;NonnullRefPtr<typename Jakt::parser::ParsedType> const& rhs_inner = __jakt_match_value.inner;
-return JaktInternal::ExplicitValue(lhs_inner->equals(rhs_inner));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_inner->equals(rhs_inner);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 7 /* Optional */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Optional;NonnullRefPtr<typename Jakt::parser::ParsedType> const& lhs_inner = __jakt_match_value.inner;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_parsed_type;
+{auto&& __jakt_match_variant = *rhs_parsed_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* Optional */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Optional;NonnullRefPtr<typename Jakt::parser::ParsedType> const& rhs_inner = __jakt_match_value.inner;
-return JaktInternal::ExplicitValue(lhs_inner->equals(rhs_inner));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_inner->equals(rhs_inner);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 8 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;NonnullRefPtr<typename Jakt::parser::ParsedType> const& lhs_inner = __jakt_match_value.inner;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_parsed_type;
+{auto&& __jakt_match_variant = *rhs_parsed_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;NonnullRefPtr<typename Jakt::parser::ParsedType> const& rhs_inner = __jakt_match_value.inner;
-return JaktInternal::ExplicitValue(lhs_inner->equals(rhs_inner));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_inner->equals(rhs_inner);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 9 /* MutableReference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MutableReference;NonnullRefPtr<typename Jakt::parser::ParsedType> const& lhs_inner = __jakt_match_value.inner;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_parsed_type;
+{auto&& __jakt_match_variant = *rhs_parsed_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* MutableReference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MutableReference;NonnullRefPtr<typename Jakt::parser::ParsedType> const& rhs_inner = __jakt_match_value.inner;
-return JaktInternal::ExplicitValue(lhs_inner->equals(rhs_inner));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_inner->equals(rhs_inner);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 10 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;NonnullRefPtr<typename Jakt::parser::ParsedType> const& lhs_inner = __jakt_match_value.inner;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_parsed_type;
+{auto&& __jakt_match_variant = *rhs_parsed_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;NonnullRefPtr<typename Jakt::parser::ParsedType> const& rhs_inner = __jakt_match_value.inner;
-return JaktInternal::ExplicitValue(lhs_inner->equals(rhs_inner));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_inner->equals(rhs_inner);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 11 /* WeakPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.WeakPtr;NonnullRefPtr<typename Jakt::parser::ParsedType> const& lhs_inner = __jakt_match_value.inner;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_parsed_type;
+{auto&& __jakt_match_variant = *rhs_parsed_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* WeakPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.WeakPtr;NonnullRefPtr<typename Jakt::parser::ParsedType> const& rhs_inner = __jakt_match_value.inner;
-return JaktInternal::ExplicitValue(lhs_inner->equals(rhs_inner));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return lhs_inner->equals(rhs_inner);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 12 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<Jakt::parser::ParsedParameter> const& lhs_params = __jakt_match_value.params;
 bool const& lhs_can_throw = __jakt_match_value.can_throw;
 NonnullRefPtr<typename Jakt::parser::ParsedType> const& lhs_return_type = __jakt_match_value.return_type;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_parsed_type;
+{auto&& __jakt_match_variant = *rhs_parsed_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<Jakt::parser::ParsedParameter> const& rhs_params = __jakt_match_value.params;
@@ -22443,7 +19679,7 @@ break;
 }
 size_t param_index = _magic_value.value();
 {
-if (!lhs_params.operator[](param_index).equals(rhs_params.operator[](param_index))){
+if (!lhs_params[param_index].equals(rhs_params[param_index])){
 return false;
 }
 }
@@ -22454,42 +19690,19 @@ return false;
 return true;
 }
 };/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-case 15 /* Empty */:return JaktInternal::ExplicitValue(rhs_parsed_type->__jakt_init_index() == 15 /* Empty */);
-case 13 /* Const */: {
+default:return false;}/*switch end*/
+}};/*case end*/
+case 15 /* Empty */:return rhs_parsed_type->__jakt_init_index() == 15 /* Empty */;case 13 /* Const */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Const;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs_parsed_type;
+{auto&& __jakt_match_variant = *rhs_parsed_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* Const */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Const;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& rhs_expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(expr->equals(rhs_expr));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return expr->equals(rhs_expr);};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 

--- a/bootstrap/stage0/platform.cpp
+++ b/bootstrap/stage0/platform.cpp
@@ -7,16 +7,9 @@ namespace platform {
 ErrorOr<ByteString> library_name_for_target(ByteString const name,Jakt::jakt__platform::Target const target) {
 {
 ByteString const target_name = TRY((target.name(false)));
-return __jakt_format(StringView::from_string_literal("{}/{}"sv),target_name,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (target.os);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("windows"sv)) {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("jakt_{}_{}.lib"sv),name,target_name));
-}else {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("libjakt_{}_{}.a"sv),name,target_name));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+return __jakt_format(StringView::from_string_literal("{}/{}"sv),target_name,[&]() -> ByteString { auto __jakt_enum_value = target.os;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("windows"sv)) {return __jakt_format(StringView::from_string_literal("jakt_{}_{}.lib"sv),name,target_name);}else {return __jakt_format(StringView::from_string_literal("libjakt_{}_{}.a"sv),name,target_name);} 
+}());
 }
 }
 

--- a/bootstrap/stage0/repl.cpp
+++ b/bootstrap/stage0/repl.cpp
@@ -9,130 +9,76 @@ namespace Jakt {
 namespace repl {
 ErrorOr<ByteString> serialize_unary_operation(Jakt::types::CheckedUnaryOperator const op,ByteString const expr) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = op;
+{auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* PreIncrement */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("++"sv) + expr);
-case 1 /* PostIncrement */:return JaktInternal::ExplicitValue(expr + ByteString::from_utf8_without_validation("++"sv));
-case 2 /* PreDecrement */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("--"sv) + expr);
-case 3 /* PostDecrement */:return JaktInternal::ExplicitValue(expr + ByteString::from_utf8_without_validation("--"sv));
-case 4 /* Negate */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("-"sv) + expr);
-case 5 /* Dereference */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("*"sv) + expr);
-case 6 /* RawAddress */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("&raw "sv) + expr);
-case 7 /* Reference */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("&"sv) + expr);
-case 8 /* MutableReference */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("&mut "sv) + expr);
-case 9 /* LogicalNot */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("not "sv) + expr);
-case 10 /* BitwiseNot */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("~"sv) + expr);
-default:return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("(<Unimplemented unary operator> "sv) + expr) + ByteString::from_utf8_without_validation(")"sv));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 0 /* PreIncrement */:return ByteString::from_utf8_without_validation("++"sv) + expr;case 1 /* PostIncrement */:return expr + ByteString::from_utf8_without_validation("++"sv);case 2 /* PreDecrement */:return ByteString::from_utf8_without_validation("--"sv) + expr;case 3 /* PostDecrement */:return expr + ByteString::from_utf8_without_validation("--"sv);case 4 /* Negate */:return ByteString::from_utf8_without_validation("-"sv) + expr;case 5 /* Dereference */:return ByteString::from_utf8_without_validation("*"sv) + expr;case 6 /* RawAddress */:return ByteString::from_utf8_without_validation("&raw "sv) + expr;case 7 /* Reference */:return ByteString::from_utf8_without_validation("&"sv) + expr;case 8 /* MutableReference */:return ByteString::from_utf8_without_validation("&mut "sv) + expr;case 9 /* LogicalNot */:return ByteString::from_utf8_without_validation("not "sv) + expr;case 10 /* BitwiseNot */:return ByteString::from_utf8_without_validation("~"sv) + expr;default:return (ByteString::from_utf8_without_validation("(<Unimplemented unary operator> "sv) + expr) + ByteString::from_utf8_without_validation(")"sv);}/*switch end*/
+}
 }
 }
 
 ErrorOr<ByteString> serialize_ast_node(NonnullRefPtr<typename Jakt::types::CheckedExpression> const node) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = *node;
+{auto&& __jakt_match_variant = *node;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Boolean */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boolean;bool const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}"sv),val));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}"sv),val);};/*case end*/
 case 1 /* NumericConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NumericConstant;Jakt::types::CheckedNumericConstant const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = val;
+{auto&& __jakt_match_variant = val;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}i8"sv),value));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}i8"sv),value);};/*case end*/
 case 1 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}i16"sv),value));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}i16"sv),value);};/*case end*/
 case 2 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}i32"sv),value));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}i32"sv),value);};/*case end*/
 case 3 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}i64"sv),value));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}i64"sv),value);};/*case end*/
 case 4 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}u8"sv),value));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}u8"sv),value);};/*case end*/
 case 5 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}u16"sv),value));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}u16"sv),value);};/*case end*/
 case 6 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}u32"sv),value));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}u32"sv),value);};/*case end*/
 case 7 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}u64"sv),value));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}u64"sv),value);};/*case end*/
 case 9 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}f32"sv),value));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}f32"sv),value);};/*case end*/
 case 10 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}f64"sv),value));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}f64"sv),value);};/*case end*/
 case 8 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;u64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}uz"sv),value));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}uz"sv),value);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 2 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;Jakt::types::CheckedStringLiteral const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (val.type_id.equals(Jakt::types::builtin(Jakt::types::BuiltinType::JaktString())));
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("\"{}\""sv),val.to_string()));
-}else {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("(overloaded) \"{}\""sv),val.to_string()));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+{auto __jakt_enum_value = val.type_id.equals(Jakt::types::builtin(Jakt::types::BuiltinType::JaktString()));
+if (__jakt_enum_value) {return __jakt_format(StringView::from_string_literal("\"{}\""sv),val.to_string());}else {return __jakt_format(StringView::from_string_literal("(overloaded) \"{}\""sv),val.to_string());}}};/*case end*/
 case 3 /* ByteConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ByteConstant;ByteString const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("b'{}'"sv),val));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("b'{}'"sv),val);};/*case end*/
 case 4 /* CharacterConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CharacterConstant;ByteString const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("'{}'"sv),val));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("'{}'"sv),val);};/*case end*/
 case 5 /* CCharacterConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CCharacterConstant;ByteString const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("c'{}'"sv),val));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("c'{}'"sv),val);};/*case end*/
 case 6 /* UnaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 Jakt::types::CheckedUnaryOperator const& op = __jakt_match_value.op;
-return JaktInternal::ExplicitValue(TRY((Jakt::repl::serialize_unary_operation(op,TRY((Jakt::repl::serialize_ast_node(expr)))))));
-};/*case end*/
+return Jakt::repl::serialize_unary_operation(op,TRY((Jakt::repl::serialize_ast_node(expr))));};/*case end*/
 case 8 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& vals = __jakt_match_value.vals;
 {
@@ -150,14 +96,14 @@ size_t i = _magic_value.value();
 if (i != static_cast<size_t>(0ULL)){
 builder.append(StringView::from_string_literal(", "sv));
 }
-builder.append(TRY((Jakt::repl::serialize_ast_node(vals.operator[](i)))));
+builder.append(TRY((Jakt::repl::serialize_ast_node(vals[i]))));
 }
 
 }
 }
 
 builder.append(StringView::from_string_literal(")"sv));
-return JaktInternal::ExplicitValue<ByteString>(builder.to_string());
+return builder.to_string();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -173,7 +119,7 @@ ByteString to_output = ByteString::from_utf8_without_validation(""sv);
 if (to.has_value()){
 to_output = TRY((Jakt::repl::serialize_ast_node(to.value())));
 }
-return JaktInternal::ExplicitValue<ByteString>(__jakt_format(StringView::from_string_literal("{}..{}"sv),from_output,to_output));
+return __jakt_format(StringView::from_string_literal("{}..{}"sv),from_output,to_output);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -194,14 +140,14 @@ size_t i = _magic_value.value();
 if (i != static_cast<size_t>(0ULL)){
 builder.append(StringView::from_string_literal(", "sv));
 }
-builder.append(TRY((Jakt::repl::serialize_ast_node(vals.operator[](i)))));
+builder.append(TRY((Jakt::repl::serialize_ast_node(vals[i]))));
 }
 
 }
 }
 
 builder.append(StringView::from_string_literal("]"sv));
-return JaktInternal::ExplicitValue<ByteString>(builder.to_string());
+return builder.to_string();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -222,14 +168,14 @@ size_t i = _magic_value.value();
 if (i != static_cast<size_t>(0ULL)){
 builder.append(StringView::from_string_literal(", "sv));
 }
-builder.append(TRY((Jakt::repl::serialize_ast_node(vals.operator[](i)))));
+builder.append(TRY((Jakt::repl::serialize_ast_node(vals[i]))));
 }
 
 }
 }
 
 builder.append(StringView::from_string_literal("}"sv));
-return JaktInternal::ExplicitValue<ByteString>(builder.to_string());
+return builder.to_string();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -250,7 +196,7 @@ size_t i = _magic_value.value();
 if (i != static_cast<size_t>(0ULL)){
 builder.append(StringView::from_string_literal(", "sv));
 }
-JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const val = vals.operator[](i);
+JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const val = vals[i];
 builder.append(TRY((Jakt::repl::serialize_ast_node(val.template get<0>()))));
 builder.append(StringView::from_string_literal(": "sv));
 builder.append(TRY((Jakt::repl::serialize_ast_node(val.template get<1>()))));
@@ -260,30 +206,26 @@ builder.append(TRY((Jakt::repl::serialize_ast_node(val.template get<1>()))));
 }
 
 builder.append(StringView::from_string_literal("]"sv));
-return JaktInternal::ExplicitValue<ByteString>(builder.to_string());
+return builder.to_string();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 13 /* IndexedExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedExpression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const& index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}[{}]"sv),TRY((Jakt::repl::serialize_ast_node(expr))),TRY((Jakt::repl::serialize_ast_node(index)))));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}[{}]"sv),TRY((Jakt::repl::serialize_ast_node(expr))),TRY((Jakt::repl::serialize_ast_node(index))));};/*case end*/
 case 14 /* IndexedDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedDictionary;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const& index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}[{}]"sv),TRY((Jakt::repl::serialize_ast_node(expr))),TRY((Jakt::repl::serialize_ast_node(index)))));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}[{}]"sv),TRY((Jakt::repl::serialize_ast_node(expr))),TRY((Jakt::repl::serialize_ast_node(index))));};/*case end*/
 case 15 /* IndexedTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedTuple;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 size_t const& index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}.{}"sv),TRY((Jakt::repl::serialize_ast_node(expr))),index));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}.{}"sv),TRY((Jakt::repl::serialize_ast_node(expr))),index);};/*case end*/
 case 16 /* IndexedStruct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedStruct;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 JaktInternal::Optional<Jakt::ids::VarId> const& index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}.{}"sv),TRY((Jakt::repl::serialize_ast_node(expr))),index));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}.{}"sv),TRY((Jakt::repl::serialize_ast_node(expr))),index);};/*case end*/
 case 23 /* NamespacedVar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedVar;JaktInternal::DynamicArray<Jakt::types::CheckedNamespace> const& namespaces = __jakt_match_value.namespaces;
 NonnullRefPtr<Jakt::types::CheckedVariable> const& var = __jakt_match_value.var;
@@ -306,23 +248,19 @@ builder.append(StringView::from_string_literal("::"sv));
 }
 
 builder.append(var->name);
-return JaktInternal::ExplicitValue<ByteString>(builder.to_string());
+return builder.to_string();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 24 /* Var */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Var;NonnullRefPtr<Jakt::types::CheckedVariable> const& var = __jakt_match_value.var;
-return JaktInternal::ExplicitValue(var->name);
-};/*case end*/
-case 25 /* OptionalNone */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("None"sv));
-case 26 /* OptionalSome */: {
+return var->name;};/*case end*/
+case 25 /* OptionalNone */:return ByteString::from_utf8_without_validation("None"sv);case 26 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("Some({})"sv),TRY((Jakt::repl::serialize_ast_node(expr)))));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("Some({})"sv),TRY((Jakt::repl::serialize_ast_node(expr))));};/*case end*/
 case 27 /* ForcedUnwrap */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForcedUnwrap;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}!"sv),TRY((Jakt::repl::serialize_ast_node(expr)))));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}!"sv),TRY((Jakt::repl::serialize_ast_node(expr))));};/*case end*/
 case 21 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::types::CheckedCall const& call = __jakt_match_value.call;
 {
@@ -357,7 +295,7 @@ size_t i = _magic_value.value();
 if (i != static_cast<size_t>(0ULL)){
 builder.append(StringView::from_string_literal(", "sv));
 }
-JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const arg = call.args.operator[](i);
+JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const arg = call.args[i];
 if (!arg.template get<0>().is_empty()){
 builder.append(arg.template get<0>());
 builder.append(StringView::from_string_literal(": "sv));
@@ -369,19 +307,12 @@ builder.append(TRY((Jakt::repl::serialize_ast_node(arg.template get<1>()))));
 }
 
 builder.append(StringView::from_string_literal(")"sv));
-return JaktInternal::ExplicitValue<ByteString>(builder.to_string());
+return builder.to_string();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-case 35 /* Garbage */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("<Garbage>"sv));
-default:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("<Unimplemented>"sv));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 35 /* Garbage */:return ByteString::from_utf8_without_validation("<Garbage>"sv);default:return ByteString::from_utf8_without_validation("<Unimplemented>"sv);}/*switch end*/
+}
 }
 }
 
@@ -457,48 +388,30 @@ break;
 }
 Jakt::lexer::Token token = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, bool>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* LParen */:{
 unmatched_parens += static_cast<i64>(1LL);
 }
-return JaktInternal::ExplicitValue<void>();
-case 8 /* RParen */:{
+goto __jakt_label_200;case 8 /* RParen */:{
 unmatched_parens -= static_cast<i64>(1LL);
 }
-return JaktInternal::ExplicitValue<void>();
-case 11 /* LSquare */:{
+goto __jakt_label_200;case 11 /* LSquare */:{
 unmatched_brackets += static_cast<i64>(1LL);
 }
-return JaktInternal::ExplicitValue<void>();
-case 12 /* RSquare */:{
+goto __jakt_label_200;case 12 /* RSquare */:{
 unmatched_brackets -= static_cast<i64>(1LL);
 }
-return JaktInternal::ExplicitValue<void>();
-case 9 /* LCurly */:{
+goto __jakt_label_200;case 9 /* LCurly */:{
 unmatched_curlies += static_cast<i64>(1LL);
 }
-return JaktInternal::ExplicitValue<void>();
-case 10 /* RCurly */:{
+goto __jakt_label_200;case 10 /* RCurly */:{
 unmatched_curlies -= static_cast<i64>(1LL);
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_200;default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_200;}/*switch end*/
+break;}goto __jakt_label_200; __jakt_label_200:;;
 }
 
 }
@@ -544,238 +457,179 @@ break;
 }
 Jakt::lexer::Token token = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = token;
+{auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;Jakt::utility::Span const& span = __jakt_match_value.span;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Green()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Green()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;Jakt::utility::Span const& span = __jakt_match_value.span;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Green()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Green()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;Jakt::utility::Span const& span = __jakt_match_value.span;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Blue()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Blue()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 59 /* And */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.And;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 60 /* Anon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Anon;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 61 /* As */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.As;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 62 /* Boxed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boxed;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 63 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 64 /* Catch */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Catch;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 65 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 66 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 67 /* Cpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Cpp;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 68 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 69 /* Destructor */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Destructor;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 70 /* Else */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Else;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 71 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 72 /* Extern */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Extern;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 74 /* False */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.False;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 75 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 76 /* Fn */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Fn;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 77 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 78 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 79 /* Import */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Import;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 81 /* In */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.In;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 82 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 83 /* Let */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Let;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 84 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 85 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 87 /* Mut */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Mut;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 88 /* Namespace */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Namespace;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 89 /* Not */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Not;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 90 /* Or */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Or;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 91 /* Override */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Override;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 92 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 93 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 94 /* Raw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Raw;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 95 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 96 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 97 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 98 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 99 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 100 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 101 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 102 /* Throws */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throws;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 103 /* True */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.True;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 104 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 105 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 106 /* Virtual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Virtual;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 107 /* Weak */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Weak;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 108 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 109 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 110 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 111 /* Implements */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Implements;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 112 /* Requires */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Requires;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 113 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Yellow()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 54 /* DotDot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DotDot;Jakt::utility::Span const& span = __jakt_match_value.value;
-return ({TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Cyan()),JaktInternal::OptionalNone()))));}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::XTerm(Jakt::repl_backend__common::XTermColor::Cyan()),JaktInternal::OptionalNone()))));goto __jakt_label_201;};/*case end*/
 case 55 /* Eol */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eol;Jakt::utility::Span const& span = __jakt_match_value.span;
 JaktInternal::Optional<ByteString> const& comment = __jakt_match_value.comment;
@@ -784,22 +638,11 @@ if (comment.has_value()){
 TRY((editor.highlight(span,Jakt::repl_backend__common::Style(Jakt::repl_backend__common::Color::Components(static_cast<u8>(128),static_cast<u8>(128),static_cast<u8>(128)),JaktInternal::OptionalNone()))));
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_201;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_201;}/*switch end*/
+break;}goto __jakt_label_201; __jakt_label_201:;;
 }
 
 }
@@ -828,9 +671,9 @@ return {};
 } else {__jakt_var_141 = __jakt_var_142.release_value();
 }
 __jakt_var_141.release_value(); });
-Jakt::repl_backend__common::LineResult __jakt_tmp424 = line_result;
-if (__jakt_tmp424.__jakt_init_index() == 0 /* Line */){
-ByteString const line = __jakt_tmp424.as.Line.value;
+Jakt::repl_backend__common::LineResult __jakt_tmp288 = line_result;
+if (__jakt_tmp288.__jakt_init_index() == 0 /* Line */){
+ByteString const line = __jakt_tmp288.as.Line.value;
 if (line == ByteString::from_utf8_without_validation("\n"sv)){
 continue;
 }
@@ -863,9 +706,9 @@ return {};
 } else {__jakt_var_145 = __jakt_var_146.release_value();
 }
 __jakt_var_145.release_value(); });
-Jakt::repl_backend__common::LineResult __jakt_tmp425 = line_result;
-if (__jakt_tmp425.__jakt_init_index() == 0 /* Line */){
-ByteString const line = __jakt_tmp425.as.Line.value;
+Jakt::repl_backend__common::LineResult __jakt_tmp289 = line_result;
+if (__jakt_tmp289.__jakt_init_index() == 0 /* Line */){
+ByteString const line = __jakt_tmp289.as.Line.value;
 builder.append(line);
 this->compiler->current_file = this->file_id;
 this->compiler->current_file_contents = Jakt::repl::REPL::line_to_bytes(builder.to_string());
@@ -946,51 +789,36 @@ __jakt_var_157.release_value(); });
 if (TRY((this->handle_possible_error()))){
 continue;
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = result;
+{auto&& __jakt_match_variant = result;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 if (value.impl->__jakt_init_index() == 0 /* Void */){
-return JaktInternal::LoopContinue{};
+continue;
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_202;};/*case end*/
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 if (value.impl->__jakt_init_index() == 0 /* Void */){
-return JaktInternal::LoopContinue{};
+continue;
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_202;};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 if (value.impl->__jakt_init_index() == 0 /* Void */){
-return JaktInternal::LoopContinue{};
+continue;
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_202;};/*case end*/
 case 4 /* Break */:case 3 /* Continue */:case 2 /* Yield */:{
 }
-return JaktInternal::ExplicitValue<void>();
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_202;default: VERIFY_NOT_REACHED();}/*switch end*/
+break;}goto __jakt_label_202; __jakt_label_202:;;
 ByteString const output = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<void>>{
 auto&& __jakt_match_variant = result;

--- a/bootstrap/stage0/runtime/AK/CharacterTypes.h
+++ b/bootstrap/stage0/runtime/AK/CharacterTypes.h
@@ -100,6 +100,12 @@ constexpr bool is_ascii_c0_control(u32 code_point)
     return code_point < 0x20;
 }
 
+// https://infra.spec.whatwg.org/#c0-control-or-space
+constexpr bool is_ascii_c0_control_or_space(u32 code_point)
+{
+    return code_point <= 0x20;
+}
+
 constexpr bool is_ascii_control(u32 code_point)
 {
     return is_ascii_c0_control(code_point) || code_point == 0x7F;
@@ -190,6 +196,7 @@ using AK::is_ascii_base36_digit;
 using AK::is_ascii_binary_digit;
 using AK::is_ascii_blank;
 using AK::is_ascii_c0_control;
+using AK::is_ascii_c0_control_or_space;
 using AK::is_ascii_control;
 using AK::is_ascii_digit;
 using AK::is_ascii_graphical;

--- a/bootstrap/stage0/runtime/AK/CopyOnWrite.h
+++ b/bootstrap/stage0/runtime/AK/CopyOnWrite.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullRefPtr.h>
+
+namespace AK {
+
+template<typename T>
+class CopyOnWrite {
+public:
+    CopyOnWrite()
+        : m_value(adopt_ref(*new T))
+    {
+    }
+    T& mutable_value()
+    {
+        if (m_value->ref_count() > 1)
+            m_value = m_value->clone();
+        return *m_value;
+    }
+    T const& value() const { return *m_value; }
+
+    operator T const&() const { return value(); }
+    operator T&() { return mutable_value(); }
+
+    T const* operator->() const { return &value(); }
+    T* operator->() { return &mutable_value(); }
+
+    T const* ptr() const { return m_value.ptr(); }
+    T* ptr() { return m_value.ptr(); }
+
+private:
+    NonnullRefPtr<T> m_value;
+};
+
+}

--- a/bootstrap/stage0/runtime/AK/Debug.h
+++ b/bootstrap/stage0/runtime/AK/Debug.h
@@ -78,6 +78,10 @@
 #    define CSS_TOKENIZER_DEBUG 0
 #endif
 
+#ifndef CSS_TRANSITIONS_DEBUG
+#    define CSS_TRANSITIONS_DEBUG 0
+#endif
+
 #ifndef DDS_DEBUG
 #    define DDS_DEBUG 0
 #endif
@@ -448,6 +452,10 @@
 
 #ifndef SQLSERVER_DEBUG
 #    define SQLSERVER_DEBUG 0
+#endif
+
+#ifndef STYLE_INVALIDATION_DEBUG
+#    define STYLE_INVALIDATION_DEBUG 0
 #endif
 
 #ifndef SYNTAX_HIGHLIGHTING_DEBUG

--- a/bootstrap/stage0/runtime/AK/Debug.h.in
+++ b/bootstrap/stage0/runtime/AK/Debug.h.in
@@ -78,6 +78,10 @@
 #    cmakedefine01 CSS_TOKENIZER_DEBUG
 #endif
 
+#ifndef CSS_TRANSITIONS_DEBUG
+#    cmakedefine01 CSS_TRANSITIONS_DEBUG
+#endif
+
 #ifndef DDS_DEBUG
 #    cmakedefine01 DDS_DEBUG
 #endif
@@ -448,6 +452,10 @@
 
 #ifndef SQLSERVER_DEBUG
 #    cmakedefine01 SQLSERVER_DEBUG
+#endif
+
+#ifndef STYLE_INVALIDATION_DEBUG
+#    cmakedefine01 STYLE_INVALIDATION_DEBUG
 #endif
 
 #ifndef SYNTAX_HIGHLIGHTING_DEBUG

--- a/bootstrap/stage0/runtime/AK/String.cpp
+++ b/bootstrap/stage0/runtime/AK/String.cpp
@@ -16,6 +16,22 @@
 
 namespace AK {
 
+String String::from_utf8_with_replacement_character(StringView view, WithBOMHandling with_bom_handling)
+{
+    if (auto bytes = view.bytes(); with_bom_handling == WithBOMHandling::Yes && bytes.size() >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+        view = view.substring_view(3);
+
+    if (Utf8View(view).validate())
+        return String::from_utf8_without_validation(view.bytes());
+
+    StringBuilder builder;
+
+    for (auto c : Utf8View { view })
+        builder.append_code_point(c);
+
+    return builder.to_string_without_validation();
+}
+
 String String::from_utf8_without_validation(ReadonlyBytes bytes)
 {
     String result;

--- a/bootstrap/stage0/runtime/AK/String.h
+++ b/bootstrap/stage0/runtime/AK/String.h
@@ -49,6 +49,15 @@ public:
 
     // Creates a new String from a sequence of UTF-8 encoded code points.
     static ErrorOr<String> from_utf8(StringView);
+
+    enum class WithBOMHandling {
+        Yes,
+        No,
+    };
+
+    // Creates a new String using the replacement character for invalid bytes
+    [[nodiscard]] static String from_utf8_with_replacement_character(StringView, WithBOMHandling = WithBOMHandling::Yes);
+
     template<typename T>
     requires(IsOneOf<RemoveCVReference<T>, ByteString, DeprecatedFlyString, FlyString, String>)
     static ErrorOr<String> from_utf8(T&&) = delete;

--- a/bootstrap/stage0/runtime/AK/Utf16View.cpp
+++ b/bootstrap/stage0/runtime/AK/Utf16View.cpp
@@ -63,6 +63,13 @@ ErrorOr<void> code_point_to_utf16(Utf16Data& string, u32 code_point)
     return {};
 }
 
+size_t utf16_code_unit_length_from_utf8(StringView string)
+{
+    // FIXME: This is inefficient!
+    auto utf16_data = MUST(AK::utf8_to_utf16(string));
+    return Utf16View { utf16_data }.length_in_code_units();
+}
+
 bool Utf16View::is_high_surrogate(u16 code_unit)
 {
     return (code_unit >= high_surrogate_min) && (code_unit <= high_surrogate_max);

--- a/bootstrap/stage0/runtime/AK/Utf16View.h
+++ b/bootstrap/stage0/runtime/AK/Utf16View.h
@@ -25,6 +25,8 @@ ErrorOr<Utf16Data> utf8_to_utf16(Utf8View const&);
 ErrorOr<Utf16Data> utf32_to_utf16(Utf32View const&);
 ErrorOr<void> code_point_to_utf16(Utf16Data&, u32);
 
+size_t utf16_code_unit_length_from_utf8(StringView);
+
 class Utf16View;
 
 class Utf16CodePointIterator {

--- a/bootstrap/stage0/runtime/lib.h
+++ b/bootstrap/stage0/runtime/lib.h
@@ -399,7 +399,7 @@ template<typename T, typename U>
 constexpr static bool lenient_is(U value)
 {
     using NonRef = RemoveCVReference<U>;
-    if constexpr (IsSame<NonRef, T> || IsSame<NonRef, NonnullRefPtr<T>> || IsSame<NonRef, RefPtr<T>>)
+    if constexpr (IsSame<NonRef, T> || IsSame<NonRef, T*> || IsSame<NonRef, NonnullRefPtr<T>> || IsSame<NonRef, RefPtr<T>>)
         return true;
     else
         return Jakt::is<T>(forward<U>(value));

--- a/bootstrap/stage0/typechecker.cpp
+++ b/bootstrap/stage0/typechecker.cpp
@@ -19,10 +19,10 @@ break;
 }
 Jakt::parser::IncludeAction action = _magic_value.value();
 {
-Jakt::parser::IncludeAction __jakt_tmp378 = action;
-if (__jakt_tmp378.__jakt_init_index() == 0 /* Define */){
-ByteString const name = __jakt_tmp378.as.Define.name;
-ByteString const value = __jakt_tmp378.as.Define.value;
+Jakt::parser::IncludeAction __jakt_tmp244 = action;
+if (__jakt_tmp244.__jakt_init_index() == 0 /* Define */){
+ByteString const name = __jakt_tmp244.as.Define.name;
+ByteString const value = __jakt_tmp244.as.Define.value;
 defines.set(name,value);
 }
 }
@@ -251,6 +251,29 @@ TRY((Jakt::typechecker::dump_scope(id,program,JaktInternal::checked_add(cindent,
 return {};
 }
 
+Jakt::typechecker::BindingKey search_empty_pattern(JaktInternal::ArraySlice<Jakt::types::CheckedMatchCase> const cases) {
+{
+{
+JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(cases.size())};
+for (;;){
+JaktInternal::Optional<size_t> const _magic_value = _magic.next();
+if (!_magic_value.has_value()){
+break;
+}
+size_t idx = _magic_value.value();
+{
+if (cases[idx].bindings.is_empty()){
+return Jakt::typechecker::BindingKey::Found(idx);
+}
+}
+
+}
+}
+
+return Jakt::typechecker::BindingKey::New(Dictionary<ByteString, Jakt::ids::VarId>::create_with_entries({}));
+}
+}
+
 ByteString Jakt::typechecker::TraitImplementationDescriptor::debug_description() const { auto builder = ByteStringBuilder::create();builder.append("TraitImplementationDescriptor("sv);{
 JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};
 JaktInternal::PrettyPrint::must_output_indentation(builder);
@@ -399,7 +422,7 @@ JaktInternal::Optional<Jakt::utility::FileId> const input_file = compiler->curre
 if (!input_file.has_value()){
 compiler->panic(ByteString::from_utf8_without_validation("trying to typecheck a non-existent file"sv));
 }
-ByteString const true_module_name = compiler->files.operator[](input_file.value().id).basename(true);
+ByteString const true_module_name = compiler->files[input_file.value().id].basename(true);
 Jakt::ids::ModuleId const placeholder_module_id = Jakt::ids::ModuleId(static_cast<size_t>(0ULL));
 ByteString const root_module_name = compiler->current_file_path().value().basename(true);
 Jakt::typechecker::Typechecker typechecker = Jakt::typechecker::Typechecker(compiler,Jakt::types::CheckedProgram::__jakt_create(compiler,DynamicArray<NonnullRefPtr<Jakt::types::Module>>::create_with({}),Dictionary<ByteString, JaktInternal::Dictionary<Jakt::ids::TypeId,JaktInternal::DynamicArray<Jakt::parser::ParsedName>>>::create_with_entries({}),Dictionary<ByteString, Jakt::types::LoadedModule>::create_with_entries({})),placeholder_module_id,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),Jakt::typechecker::BreakContinueLegalityTracker::None(),Jakt::typechecker::ReturnLegalityTracker::None(),false,compiler->dump_type_hints,compiler->dump_try_hints,static_cast<u64>(0ULL),Jakt::types::GenericInferences(Dictionary<Jakt::ids::TypeId, Jakt::ids::TypeId>::create_with_entries({})),JaktInternal::OptionalNone(),root_module_name,false,false,Dictionary<ByteString, Jakt::ids::ScopeId>::create_with_entries({}),JaktInternal::OptionalNone(),static_cast<u64>(0ULL),Jakt::types::CheckedBlock(DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>>::create_with({}),Jakt::ids::ScopeId(Jakt::ids::ModuleId(static_cast<size_t>(18446744073709551615ULL)),static_cast<size_t>(18446744073709551615ULL)),Jakt::types::BlockControlFlow::NeverReturns(),JaktInternal::OptionalNone(),false));
@@ -416,7 +439,7 @@ NonnullRefPtr<Jakt::types::Scope> root_scope = typechecker.get_scope(root_scope_
 root_scope->children.push(main_scope_id);
 TRY((typechecker.typecheck_module_import(Jakt::parser::ParsedModuleImport(Jakt::parser::ImportName::Literal(ByteString::from_utf8_without_validation("jakt::prelude::prelude"sv),Jakt::utility::Span(Jakt::utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL))),JaktInternal::OptionalNone(),Jakt::parser::ImportList::All(),false,static_cast<size_t>(0ULL)),root_scope_id)));
 {
-JaktInternal::DictionaryIterator<size_t,Jakt::ids::StructId> _magic = typechecker.program->modules.operator[](static_cast<i64>(0LL))->builtin_implementation_structs.iterator();
+JaktInternal::DictionaryIterator<size_t,Jakt::ids::StructId> _magic = typechecker.program->modules[static_cast<i64>(0LL)]->builtin_implementation_structs.iterator();
 for (;;){
 JaktInternal::Optional<JaktInternal::Tuple<size_t,Jakt::ids::StructId>> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
@@ -436,7 +459,7 @@ TRY((typechecker.typecheck_entity_trait_implementations_predecl(struct_.scope_id
 }
 
 {
-JaktInternal::DictionaryIterator<size_t,Jakt::ids::StructId> _magic = typechecker.program->modules.operator[](static_cast<i64>(0LL))->builtin_implementation_structs.iterator();
+JaktInternal::DictionaryIterator<size_t,Jakt::ids::StructId> _magic = typechecker.program->modules[static_cast<i64>(0LL)]->builtin_implementation_structs.iterator();
 for (;;){
 JaktInternal::Optional<JaktInternal::Tuple<size_t,Jakt::ids::StructId>> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
@@ -884,7 +907,7 @@ return JaktInternal::OptionalNone();
 if (trait_impls.size() > static_cast<size_t>(1ULL)){
 this->error(__jakt_format(StringView::from_string_literal("type ‘{}’ implements trait ‘{}’ more than once, but a singular implementation is allowed"sv),TRY((this->type_name(type_id,false))),trait_name),span);
 }
-return Jakt::typechecker::TraitImplementationDescriptor(trait_id.value(),trait_name,trait_impls.operator[](static_cast<i64>(0LL)));
+return Jakt::typechecker::TraitImplementationDescriptor(trait_id.value(),trait_name,trait_impls[static_cast<i64>(0LL)]);
 }
 }
 
@@ -994,7 +1017,7 @@ bool Jakt::typechecker::Typechecker::add_function_to_scope(Jakt::ids::ScopeId co
 {
 NonnullRefPtr<Jakt::types::Scope> scope = this->get_scope(parent_scope_id);
 if (scope->functions.contains(name)){
-JaktInternal::DynamicArray<Jakt::ids::FunctionId> const existing_function_binding = scope->functions.operator[](name);
+JaktInternal::DynamicArray<Jakt::ids::FunctionId> const existing_function_binding = scope->functions[name];
 {
 JaktInternal::ArrayIterator<Jakt::ids::FunctionId> _magic = overload_set.iterator();
 for (;;){
@@ -1026,7 +1049,7 @@ this->error_with_hint(__jakt_format(StringView::from_string_literal("Redefinitio
 }
 }
 
-scope->functions.operator[](name).push(function_id);
+scope->functions[name].push(function_id);
 }
 
 }
@@ -1126,7 +1149,7 @@ this->generic_inferences.restore(old_generic_inferences);
 
 });
 this->generic_inferences.set_all(trait_->generic_parameters,trait_descriptor.implemented_type_args);
-NonnullRefPtr<Jakt::types::CheckedFunction> const expected_function = this->get_function(methods.operator[](function_name));
+NonnullRefPtr<Jakt::types::CheckedFunction> const expected_function = this->get_function(methods[function_name]);
 {
 JaktInternal::ArrayIterator<Jakt::ids::FunctionId> _magic = candidate_ids.iterator();
 for (;;){
@@ -1178,7 +1201,7 @@ Jakt::ids::StructId const id = __jakt_tmp84->as.GenericInstance.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp84->as.GenericInstance.args;
 Jakt::ids::StructId const optional_struct_id = TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv))));
 if (id.equals(optional_struct_id)){
-return args.operator[](static_cast<i64>(0LL));
+return args[static_cast<i64>(0LL)];
 }
 }
 return type_id;
@@ -1193,7 +1216,7 @@ if (__jakt_tmp85->__jakt_init_index() == 20 /* GenericInstance */){
 Jakt::ids::StructId const id = __jakt_tmp85->as.GenericInstance.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp85->as.GenericInstance.args;
 if (id.equals(optional_struct_id)){
-return this->get_type(args.operator[](static_cast<i64>(0LL)));
+return this->get_type(args[static_cast<i64>(0LL)]);
 }
 }
 return type;
@@ -1276,14 +1299,14 @@ break;
 }
 size_t i = _magic_value.value();
 {
-JaktInternal::Optional<Jakt::ids::ScopeId> const found_scope = this->program->find_namespace_in_immediate_children_of_scope(parent_scope.value(),name_list.operator[](i).name,false);
+JaktInternal::Optional<Jakt::ids::ScopeId> const found_scope = this->program->find_namespace_in_immediate_children_of_scope(parent_scope.value(),name_list[i].name,false);
 JaktInternal::Optional<Jakt::ids::ScopeId> __jakt_tmp88 = found_scope;
 if (__jakt_tmp88.has_value()){
 Jakt::ids::ScopeId const scope_id = __jakt_tmp88.value();
 parent_scope = scope_id;
 }
 else {
-this->error(__jakt_format(StringView::from_string_literal("Cannot find scope for ‘{}‘"sv),name_list.operator[](i).name),name_list.operator[](i).span);
+this->error(__jakt_format(StringView::from_string_literal("Cannot find scope for ‘{}‘"sv),name_list[i].name),name_list[i].span);
 parent_scope = JaktInternal::OptionalNone();
 break;
 }
@@ -1329,13 +1352,9 @@ this->program->exports.set(exp.file.name,exported_types);
 
 ErrorOr<Jakt::types::CheckedVisibility> Jakt::typechecker::Typechecker::typecheck_visibility(Jakt::parser::Visibility const visibility,Jakt::ids::ScopeId const scope_id) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::CheckedVisibility, ErrorOr<Jakt::types::CheckedVisibility>>{
-auto&& __jakt_match_variant = visibility;
+{auto&& __jakt_match_variant = visibility;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 1 /* Private */:return JaktInternal::ExplicitValue(Jakt::types::CheckedVisibility::Private());
-case 0 /* Public */:return JaktInternal::ExplicitValue(Jakt::types::CheckedVisibility::Public());
-case 2 /* Restricted */: {
+case 1 /* Private */:return Jakt::types::CheckedVisibility::Private();case 0 /* Public */:return Jakt::types::CheckedVisibility::Public();case 2 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;JaktInternal::DynamicArray<Jakt::parser::VisibilityRestriction> const& whitelist = __jakt_match_value.whitelist;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
@@ -1372,17 +1391,12 @@ restricted_scopes.push(TRY((unresolved->try_resolve(this->program))));
 }
 }
 
-return JaktInternal::ExplicitValue<Jakt::types::CheckedVisibility>(Jakt::types::CheckedVisibility::Restricted(restricted_scopes,span));
+return Jakt::types::CheckedVisibility::Restricted(restricted_scopes,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -1398,8 +1412,8 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::parser::ParsedNamespace const child_namespace = parsed_namespace.namespaces.operator[](i);
-Jakt::ids::ScopeId const child_namespace_scope_id = children.operator[](i);
+Jakt::parser::ParsedNamespace const child_namespace = parsed_namespace.namespaces[i];
+Jakt::ids::ScopeId const child_namespace_scope_id = children[i];
 TRY((this->typecheck_namespace_fields(child_namespace,child_namespace_scope_id)));
 }
 
@@ -1432,7 +1446,7 @@ JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<Jakt::utility::Span,Jakt
 ScopeGuard __jakt_var_26([&] {
 i += static_cast<size_t>(1ULL);
 });
-TRY((this->typecheck_namespace_fields(chunk.parsed_namespace,chunk.generated_scopes.operator[](i))));
+TRY((this->typecheck_namespace_fields(chunk.parsed_namespace,chunk.generated_scopes[i])));
 }
 
 }
@@ -1541,28 +1555,20 @@ this->set_self_type_id(struct_type_id);
 ScopeGuard __jakt_var_27([&] {
 this->self_type_id = old_self_type_id;
 });
-JaktInternal::DynamicArray<Jakt::parser::ParsedField> const parsed_fields = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::parser::ParsedField>, ErrorOr<void>>{
-auto&& __jakt_match_variant = record.record_type;
+JaktInternal::DynamicArray<Jakt::parser::ParsedField> const parsed_fields = [&]() -> JaktInternal::DynamicArray<Jakt::parser::ParsedField> { auto&& __jakt_match_variant = record.record_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::parser::ParsedField> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(fields);
-};/*case end*/
+return fields;};/*case end*/
 case 1 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;JaktInternal::DynamicArray<Jakt::parser::ParsedField> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(fields);
-};/*case end*/
+return fields;};/*case end*/
 default:{
 this->compiler->panic(ByteString::from_utf8_without_validation("typecheck_struct_fields cannot handle non-structs"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 bool const in_generated_code = this->get_scope(structure.scope_id)->is_from_generated_code;
 {
 JaktInternal::ArrayIterator<Jakt::parser::ParsedField> _magic = parsed_fields.iterator();
@@ -1580,21 +1586,10 @@ TRY((this->check_that_type_doesnt_contain_reference(checked_member_type,parsed_v
 }
 NonnullRefPtr<Jakt::types::Module> module = this->current_module();
 Jakt::ids::VarId const variable_id = module->add_variable(Jakt::types::CheckedVariable::__jakt_create(parsed_var_decl.name,checked_member_type,parsed_var_decl.is_mutable,parsed_var_decl.span,JaktInternal::OptionalNone(),TRY((this->typecheck_visibility(unchecked_member.visibility,checked_struct_scope_id))),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),parsed_var_decl.external_name));
-JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>> const default_value_expression = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>>,ErrorOr<void>> {
-auto __jakt_enum_value = (unchecked_member.default_value.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>>>(Tuple{unchecked_member.default_value.value(), checked_struct_scope_id}));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>> const default_value_expression = [&]() -> JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>> { auto __jakt_enum_value = unchecked_member.default_value.has_value();
+if (__jakt_enum_value) {return static_cast<JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>>>(Tuple{unchecked_member.default_value.value(), checked_struct_scope_id});}else if (!__jakt_enum_value) {return JaktInternal::OptionalNone();}VERIFY_NOT_REACHED();
+ 
+}();
 structure.fields.push(Jakt::types::CheckedField::__jakt_create(variable_id,default_value_expression,JaktInternal::OptionalNone()));
 }
 
@@ -1607,15 +1602,12 @@ return {};
 
 ErrorOr<void> Jakt::typechecker::Typechecker::typecheck_module_import(Jakt::parser::ParsedModuleImport const import_,Jakt::ids::ScopeId const scope_id) {
 {
-JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>> const module_names_and_spans = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>, ErrorOr<void>>{
-auto&& __jakt_match_variant = import_.module_name;
+JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>> const module_names_and_spans = TRY(([&]() -> ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>> { auto&& __jakt_match_variant = import_.module_name;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Literal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Literal;ByteString const& name = __jakt_match_value.name;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>>(DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>::create_with({Tuple{name, span}})));
-};/*case end*/
+return static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>>(DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>::create_with({Tuple{name, span}}));};/*case end*/
 case 1 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expression = __jakt_match_value.expression;
 {
@@ -1623,33 +1615,28 @@ NonnullRefPtr<Jakt::interpreter::Interpreter> interpreter = this->interpreter();
 NonnullRefPtr<Jakt::interpreter::InterpreterScope> eval_scope = Jakt::interpreter::InterpreterScope::from_runtime_scope(scope_id,this->program,JaktInternal::OptionalNone());
 Jakt::ids::ScopeId const exec_scope = this->create_scope(scope_id,true,ByteString::from_utf8_without_validation("comptime-import"sv),true);
 Jakt::interpreter::StatementResult const result = TRY((interpreter->execute_expression(TRY((this->typecheck_expression(expression,exec_scope,Jakt::types::SafetyMode::Safe(),JaktInternal::OptionalNone()))),eval_scope)));
-return JaktInternal::ExplicitValue<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>, ErrorOr<void>>{
-auto&& __jakt_match_variant = result;
+{auto&& __jakt_match_variant = result;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */:case 2 /* Yield */:case 3 /* Continue */:case 4 /* Break */:{
 this->error_with_hint(ByteString::from_utf8_without_validation("module name must evaluate to a string literal or an array of strings"sv),expression->span(),ByteString::from_utf8_without_validation("this expression evaluates to an invalid value"sv),expression->span());
-return JaktInternal::ExplicitValue<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>>(JaktInternal::OptionalNone());
+return JaktInternal::OptionalNone();
 }
 VERIFY_NOT_REACHED();
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& error = __jakt_match_value.value;
 {
 this->error_with_hint(ByteString::from_utf8_without_validation("module name must evaluate to a string literal or an array of strings"sv),expression->span(),__jakt_format(StringView::from_string_literal("this expression threw an error: {}"sv),error),expression->span());
-return JaktInternal::ExplicitValue<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>>(JaktInternal::OptionalNone());
+return JaktInternal::OptionalNone();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>, ErrorOr<void>>{
-auto&& __jakt_match_variant = *value.impl;
+{auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& string = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>>(DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>::create_with({Tuple{string, value.span}})));
-};/*case end*/
+return static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>>(DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>::create_with({Tuple{string, value.span}}));};/*case end*/
 case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& values = __jakt_match_value.values;
 {
@@ -1666,68 +1653,40 @@ break;
 }
 Jakt::types::Value value = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = *value.impl;
+{auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& string = __jakt_match_value.value;
-return ({result.push(Tuple{string, value.span});}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+result.push(Tuple{string, value.span});goto __jakt_label_108;};/*case end*/
 default:{
 this->error_with_hint(ByteString::from_utf8_without_validation("module name must evaluate to a string literal or an array of strings"sv),value.span,ByteString::from_utf8_without_validation("this expression evaluates to an invalid value"sv),value.span);
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_108;}/*switch end*/
+break;}goto __jakt_label_108; __jakt_label_108:;;
 }
 
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>>(static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>>(result));
+return static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>>(result);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
 this->error_with_hint(ByteString::from_utf8_without_validation("module name must evaluate to a string literal"sv),expression->span(),ByteString::from_utf8_without_validation("this expression evaluates to a non-string value"sv),expression->span());
-return JaktInternal::ExplicitValue<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>>>(JaktInternal::OptionalNone());
+return JaktInternal::OptionalNone();
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 if (!module_names_and_spans.has_value()){
 return {};
 }
@@ -1748,21 +1707,10 @@ names.push(name_and_span.template get<0>());
 JaktInternal::Optional<Jakt::types::LoadedModule> maybe_loaded_module = this->program->get_loaded_module(name_and_span.template get<0>());
 if (!maybe_loaded_module.has_value()){
 JaktInternal::Optional<Jakt::jakt__path::Path> const maybe_file_name = TRY((this->compiler->search_for_path(name_and_span.template get<0>(),import_is_relative,parent_path_count)));
-Jakt::jakt__path::Path const file_name = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::jakt__path::Path,ErrorOr<void>> {
-auto __jakt_enum_value = (maybe_file_name.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(maybe_file_name.value());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->get_root_path().parent().join(name_and_span.template get<0>()).replace_extension(ByteString::from_utf8_without_validation("jakt"sv)))));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+Jakt::jakt__path::Path const file_name = TRY(([&]() -> ErrorOr<Jakt::jakt__path::Path> { auto __jakt_enum_value = maybe_file_name.has_value();
+if (__jakt_enum_value) {return maybe_file_name.value();}else if (!__jakt_enum_value) {return this->get_root_path().parent().join(name_and_span.template get<0>()).replace_extension(ByteString::from_utf8_without_validation("jakt"sv));}VERIFY_NOT_REACHED();
+ 
+}()));
 if (File::exists(file_name.to_string())){
 module_name_and_span = name_and_span;
 break;
@@ -1787,29 +1735,15 @@ ByteString const module_name = module_name_module_span_.template get<0>();
 Jakt::utility::Span const module_span = module_name_module_span_.template get<1>();
 
 JaktInternal::Optional<Jakt::jakt__path::Path> const maybe_file_name = TRY((this->compiler->search_for_path(module_name,import_is_relative,parent_path_count)));
-Jakt::jakt__path::Path const file_name = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::jakt__path::Path,ErrorOr<void>> {
-auto __jakt_enum_value = (maybe_file_name.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(maybe_file_name.value());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->get_root_path().parent().join(module_name).replace_extension(ByteString::from_utf8_without_validation("jakt"sv)))));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+Jakt::jakt__path::Path const file_name = TRY(([&]() -> ErrorOr<Jakt::jakt__path::Path> { auto __jakt_enum_value = maybe_file_name.has_value();
+if (__jakt_enum_value) {return maybe_file_name.value();}else if (!__jakt_enum_value) {return this->get_root_path().parent().join(module_name).replace_extension(ByteString::from_utf8_without_validation("jakt"sv));}VERIFY_NOT_REACHED();
+ 
+}()));
 bool const is_in_the_stdlib = TRY((file_name.absolute())).to_string().starts_with(TRY((this->compiler->std_include_path.absolute())).to_string());
-ByteString const sanitized_module_name = Jakt::utility::join(Jakt::utility::map<ByteString, ByteString>(TRY((({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::jakt__path::Path,ErrorOr<void>> {
-auto __jakt_enum_value = (is_in_the_stdlib);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::jakt__path::Path::from_string(__jakt_format(StringView::from_string_literal("{}/{}"sv),ByteString::from_utf8_without_validation("jakt"sv),TRY((file_name.absolute())).relative_to(TRY((this->compiler->std_include_path.absolute()))).to_string())));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((file_name.absolute())).relative_to(TRY((this->get_root_path().parent().absolute()))));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}).replace_extension(ByteString::from_utf8_without_validation(""sv)))).components(),[](ByteString item) -> ByteString {{
+ByteString const sanitized_module_name = Jakt::utility::join(Jakt::utility::map<ByteString, ByteString>(TRY((TRY(([&]() -> ErrorOr<Jakt::jakt__path::Path> { auto __jakt_enum_value = is_in_the_stdlib;
+if (__jakt_enum_value) {return Jakt::jakt__path::Path::from_string(__jakt_format(StringView::from_string_literal("{}/{}"sv),ByteString::from_utf8_without_validation("jakt"sv),TRY((file_name.absolute())).relative_to(TRY((this->compiler->std_include_path.absolute()))).to_string()));}else if (!__jakt_enum_value) {return TRY((file_name.absolute())).relative_to(TRY((this->get_root_path().parent().absolute())));}VERIFY_NOT_REACHED();
+ 
+}())).replace_extension(ByteString::from_utf8_without_validation(""sv)))).components(),[](ByteString item) -> ByteString {{
 if (item == ByteString::from_utf8_without_validation(".."sv)){
 return ByteString::from_utf8_without_validation("parent"sv);
 }
@@ -2240,30 +2174,17 @@ break;
 }
 Jakt::parser::IncludeAction action = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = action;
+{auto&& __jakt_match_variant = action;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Define */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Define;ByteString const& name = __jakt_match_value.name;
 ByteString const& value = __jakt_match_value.value;
-return ({builder.appendff(ByteString::from_utf8_without_validation("#define {} {}\n"sv),name,value);}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+builder.appendff(ByteString::from_utf8_without_validation("#define {} {}\n"sv),name,value);goto __jakt_label_109;};/*case end*/
 case 1 /* Undefine */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Undefine;ByteString const& name = __jakt_match_value.name;
-return ({builder.appendff(ByteString::from_utf8_without_validation("#undef {}\n"sv),name);}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+builder.appendff(ByteString::from_utf8_without_validation("#undef {}\n"sv),name);goto __jakt_label_109;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+break;}goto __jakt_label_109; __jakt_label_109:;;
 }
 
 }
@@ -2285,30 +2206,17 @@ break;
 }
 Jakt::parser::IncludeAction action = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = action;
+{auto&& __jakt_match_variant = action;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Define */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Define;ByteString const& name = __jakt_match_value.name;
 ByteString const& value = __jakt_match_value.value;
-return ({builder.appendff(ByteString::from_utf8_without_validation("#define {} {}\n"sv),name,value);}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+builder.appendff(ByteString::from_utf8_without_validation("#define {} {}\n"sv),name,value);goto __jakt_label_110;};/*case end*/
 case 1 /* Undefine */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Undefine;ByteString const& name = __jakt_match_value.name;
-return ({builder.appendff(ByteString::from_utf8_without_validation("#undef {}\n"sv),name);}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+builder.appendff(ByteString::from_utf8_without_validation("#undef {}\n"sv),name);goto __jakt_label_110;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+break;}goto __jakt_label_110; __jakt_label_110:;;
 }
 
 }
@@ -2370,8 +2278,8 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::parser::ParsedNamespace const child_namespace = parsed_namespace.namespaces.operator[](i);
-Jakt::ids::ScopeId const child_namespace_scope_id = children.operator[](i);
+Jakt::parser::ParsedNamespace const child_namespace = parsed_namespace.namespaces[i];
+Jakt::ids::ScopeId const child_namespace_scope_id = children[i];
 TRY((this->typecheck_namespace_constructors(child_namespace,child_namespace_scope_id)));
 }
 
@@ -2404,7 +2312,7 @@ JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<Jakt::utility::Span,Jakt
 ScopeGuard __jakt_var_31([&] {
 i += static_cast<size_t>(1ULL);
 });
-TRY((this->typecheck_namespace_constructors(chunk.parsed_namespace,chunk.generated_scopes.operator[](i))));
+TRY((this->typecheck_namespace_constructors(chunk.parsed_namespace,chunk.generated_scopes[i])));
 }
 
 }
@@ -2506,8 +2414,8 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::parser::ParsedNamespace const child_namespace = parsed_namespace.namespaces.operator[](i);
-Jakt::ids::ScopeId const child_namespace_scope_id = children.operator[](i);
+Jakt::parser::ParsedNamespace const child_namespace = parsed_namespace.namespaces[i];
+Jakt::ids::ScopeId const child_namespace_scope_id = children[i];
 TRY((this->typecheck_namespace_aliases(child_namespace,child_namespace_scope_id,allow)));
 }
 
@@ -2540,7 +2448,7 @@ JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<Jakt::utility::Span,Jakt
 ScopeGuard __jakt_var_32([&] {
 i += static_cast<size_t>(1ULL);
 });
-TRY((this->typecheck_namespace_aliases(chunk.parsed_namespace,chunk.generated_scopes.operator[](i),allow)));
+TRY((this->typecheck_namespace_aliases(chunk.parsed_namespace,chunk.generated_scopes[i],allow)));
 }
 
 }
@@ -2573,23 +2481,17 @@ return {};
 
 ErrorOr<void> Jakt::typechecker::Typechecker::typecheck_alias(Jakt::parser::ParsedAlias const alias,Jakt::ids::ScopeId const scope_id,Jakt::typechecker::ImportRestrictions const allow) {
 {
-Jakt::parser::ParsedName const aliased_name = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::ParsedName,ErrorOr<void>> {
-auto __jakt_enum_value = (alias.alias_name.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(alias.alias_name.value());
-}else {{
+Jakt::parser::ParsedName const aliased_name = [&]() -> Jakt::parser::ParsedName { auto __jakt_enum_value = alias.alias_name.has_value();
+if (__jakt_enum_value) {return alias.alias_name.value();}else {{
 Jakt::parser::ParsedNameWithGenericParameters const name = alias.target.last().value();
 if (!name.generic_parameters.is_empty()){
 this->error_with_hint(__jakt_format(StringView::from_string_literal("Cannot alias a generic instance of a type to the type itself"sv)),name.name_span,__jakt_format(StringView::from_string_literal("Add an alias name here: 'as <name>'"sv)),name.name_span);
 }
-return JaktInternal::ExplicitValue<Jakt::parser::ParsedName>(Jakt::parser::ParsedName(name.name,name.name_span));
+return Jakt::parser::ParsedName(name.name,name.name_span);
 }
 VERIFY_NOT_REACHED();
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+} 
+}();
 Jakt::ids::ScopeId resolved_scope_id = scope_id;
 JaktInternal::DynamicArray<Jakt::types::ResolvedNamespace> alias_path = DynamicArray<Jakt::types::ResolvedNamespace>::create_with({});
 {
@@ -2601,37 +2503,31 @@ break;
 }
 size_t i = _magic_value.value();
 {
-JaktInternal::Optional<JaktInternal::Tuple<Jakt::ids::ScopeId,bool>> const namespace_ = TRY((this->find_namespace_in_scope(resolved_scope_id,alias.target.operator[](i).name,false,JaktInternal::OptionalNone())));
+JaktInternal::Optional<JaktInternal::Tuple<Jakt::ids::ScopeId,bool>> const namespace_ = TRY((this->find_namespace_in_scope(resolved_scope_id,alias.target[i].name,false,JaktInternal::OptionalNone())));
 if (!namespace_.has_value()){
-this->error(__jakt_format(StringView::from_string_literal("Unknown namespace '{}'"sv),alias.target.operator[](i).name),alias.target.operator[](i).name_span);
+this->error(__jakt_format(StringView::from_string_literal("Unknown namespace '{}'"sv),alias.target[i].name),alias.target[i].name_span);
 return {};
 }
 resolved_scope_id = namespace_.value().template get<0>();
-alias_path.push(Jakt::types::ResolvedNamespace(alias.target.operator[](i).name,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()));
+alias_path.push(Jakt::types::ResolvedNamespace(alias.target[i].name,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()));
 }
 
 }
 }
 
 NonnullRefPtr<Jakt::types::Scope> scope = this->get_scope(scope_id);
-Jakt::ids::ScopeId const alias_scope_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::ScopeId,ErrorOr<void>> {
-auto __jakt_enum_value = (scope->alias_scope.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(scope->alias_scope.value());
-}else if (!__jakt_enum_value) {{
+Jakt::ids::ScopeId const alias_scope_id = [&]() -> Jakt::ids::ScopeId { auto __jakt_enum_value = scope->alias_scope.has_value();
+if (__jakt_enum_value) {return scope->alias_scope.value();}else if (!__jakt_enum_value) {{
 Jakt::ids::ScopeId const new_scope_id = this->create_scope(scope_id,false,__jakt_format(StringView::from_string_literal("alias-scope({})"sv),scope->debug_name),false);
 NonnullRefPtr<Jakt::types::Scope> new_scope = this->get_scope(new_scope_id);
 new_scope->alias_path = alias_path;
 this->get_scope(scope_id)->children.push(new_scope_id);
-return JaktInternal::ExplicitValue<Jakt::ids::ScopeId>(new_scope_id);
+return new_scope_id;
 }
 VERIFY_NOT_REACHED();
 }VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 TRY((this->find_and_import_name_from_scope(alias.target.last().value().name,alias.target.last().value().name_span,aliased_name.name,aliased_name.span,resolved_scope_id,alias_scope_id,allow)));
 }
 return {};
@@ -2649,8 +2545,8 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::parser::ParsedNamespace const child_namespace = parsed_namespace.namespaces.operator[](i);
-Jakt::ids::ScopeId const child_namespace_scope_id = children.operator[](i);
+Jakt::parser::ParsedNamespace const child_namespace = parsed_namespace.namespaces[i];
+Jakt::ids::ScopeId const child_namespace_scope_id = children[i];
 TRY((this->typecheck_namespace_function_predecl(child_namespace,child_namespace_scope_id,comptime_pass,generic_pass)));
 }
 
@@ -2832,7 +2728,7 @@ JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<Jakt::utility::Span,Jakt
 ScopeGuard __jakt_var_33([&] {
 i += static_cast<size_t>(1ULL);
 });
-TRY((this->typecheck_namespace_function_predecl(chunk.parsed_namespace,chunk.generated_scopes.operator[](i),comptime_pass,generic_pass)));
+TRY((this->typecheck_namespace_function_predecl(chunk.parsed_namespace,chunk.generated_scopes[i],comptime_pass,generic_pass)));
 }
 
 }
@@ -2949,25 +2845,15 @@ self = (self + rhs);
 }
 }
 (debug_name,ByteString::from_utf8_without_validation(")"sv));
-JaktInternal::Tuple<JaktInternal::Optional<Jakt::ids::ScopeId>,bool> existing_scope_id_existing_scope_is_imported_ = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Optional<Jakt::ids::ScopeId>,bool>,ErrorOr<void>> {
-auto __jakt_enum_value = (namespace_.name.has_value());
+JaktInternal::Tuple<JaktInternal::Optional<Jakt::ids::ScopeId>,bool> existing_scope_id_existing_scope_is_imported_ = TRY(([&]() -> ErrorOr<JaktInternal::Tuple<JaktInternal::Optional<Jakt::ids::ScopeId>,bool>> { auto __jakt_enum_value = namespace_.name.has_value();
 if (__jakt_enum_value) {{
 JaktInternal::Optional<JaktInternal::Tuple<Jakt::ids::ScopeId,bool>> const result = TRY((this->find_namespace_in_scope(scope_id,namespace_.name.value(),false,JaktInternal::OptionalNone())));
-return JaktInternal::ExplicitValue<JaktInternal::Tuple<JaktInternal::Optional<Jakt::ids::ScopeId>,bool>>(Tuple{result.map([](auto& _value) { return _value.template get<0>(); }), result.map([](auto& _value) { return _value.template get<1>(); }).value_or_lazy_evaluated([&] { return false; })});
+return Tuple{result.map([](auto& _value) { return _value.template get<0>(); }), result.map([](auto& _value) { return _value.template get<1>(); }).value_or_lazy_evaluated([&] { return false; })};
 }
 VERIFY_NOT_REACHED();
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), false});
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+}else if (!__jakt_enum_value) {return Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), false};}VERIFY_NOT_REACHED();
+ 
+}()));
 JaktInternal::Optional<Jakt::ids::ScopeId> existing_scope_id = existing_scope_id_existing_scope_is_imported_.template get<0>();
 bool existing_scope_is_imported = existing_scope_id_existing_scope_is_imported_.template get<1>();
 
@@ -2995,20 +2881,9 @@ self = (self + rhs);
 }
 (debug_name,ByteString::from_utf8_without_validation(")"sv));
 }
-Jakt::ids::ScopeId const parent_scope_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::ScopeId,ErrorOr<void>> {
-auto __jakt_enum_value = (namespace_.import_path_if_extern.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::ids::ScopeId(Jakt::ids::ModuleId(static_cast<size_t>(1ULL)),static_cast<size_t>(0ULL)));
-}else {return JaktInternal::ExplicitValue(scope_id);
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+Jakt::ids::ScopeId const parent_scope_id = [&]() -> Jakt::ids::ScopeId { auto __jakt_enum_value = namespace_.import_path_if_extern.has_value();
+if (__jakt_enum_value) {return Jakt::ids::ScopeId(Jakt::ids::ModuleId(static_cast<size_t>(1ULL)),static_cast<size_t>(0ULL));}else {return scope_id;} 
+}();
 Jakt::ids::ScopeId const child_scope_id = this->create_scope(parent_scope_id,false,debug_name,false);
 NonnullRefPtr<Jakt::types::Scope> child_scope = this->get_scope(child_scope_id);
 child_scope->namespace_name = namespace_.name;
@@ -3143,9 +3018,7 @@ NonnullRefPtr<typename Jakt::types::Type> type = this->get_type(for_type);
 if (type->is_builtin()){
 type = this->get_type(this->get_struct(this->program->builtin_implementation_struct(type->as_builtin_type(),this->program->prelude_module_id())).type_id);
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = *type;
+{auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
@@ -3153,49 +3026,35 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId c
 Jakt::types::CheckedStruct struct_ = this->get_struct(struct_id);
 TRY((this->resolve_external_trait_implementations(implementation,struct_.scope_id,struct_.trait_implementations,for_type,scope_id,default_pass)));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_111;};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& struct_id = __jakt_match_value.id;
 {
 Jakt::types::CheckedStruct struct_ = this->get_struct(struct_id);
 TRY((this->resolve_external_trait_implementations(implementation,struct_.scope_id,struct_.trait_implementations,for_type,scope_id,default_pass)));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_111;};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
 {
 Jakt::types::CheckedEnum enum_ = this->get_enum(enum_id);
 TRY((this->resolve_external_trait_implementations(implementation,enum_.scope_id,enum_.trait_implementations,for_type,scope_id,default_pass)));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_111;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& enum_id = __jakt_match_value.id;
 {
 Jakt::types::CheckedEnum enum_ = this->get_enum(enum_id);
 TRY((this->resolve_external_trait_implementations(implementation,enum_.scope_id,enum_.trait_implementations,for_type,scope_id,default_pass)));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_111;};/*case end*/
 default:{
 if (!default_pass){
 this->error(__jakt_format(StringView::from_string_literal("Cannot implement traits for type '{}'"sv),TRY((this->type_name(for_type,false)))),implementation.for_type->span());
 }
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_111;}/*switch end*/
+break;}goto __jakt_label_111; __jakt_label_111:;;
 }
 
 }
@@ -3411,7 +3270,7 @@ if (type->is_builtin()){
 type_id = Jakt::types::builtin(type->as_builtin_type());
 }
 if (results.contains(name)){
-results.operator[](name).push(Tuple{span, type_id});
+results[name].push(Tuple{span, type_id});
 }
 else {
 results.set(name, DynamicArray<JaktInternal::Tuple<Jakt::utility::Span,Jakt::ids::TypeId>>::create_with({Tuple{span, type_id}}));
@@ -3443,8 +3302,8 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::parser::ParsedNamespace const child_namespace = parsed_namespace.namespaces.operator[](i);
-Jakt::ids::ScopeId const child_namespace_scope_id = children.operator[](i);
+Jakt::parser::ParsedNamespace const child_namespace = parsed_namespace.namespaces[i];
+Jakt::ids::ScopeId const child_namespace_scope_id = children[i];
 TRY((this->typecheck_namespace_methods_predecl(child_namespace,child_namespace_scope_id,comptime_pass,generic_pass)));
 }
 
@@ -3552,7 +3411,7 @@ JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<Jakt::utility::Span,Jakt
 ScopeGuard __jakt_var_36([&] {
 i += static_cast<size_t>(1ULL);
 });
-TRY((this->typecheck_namespace_methods_predecl(chunk.parsed_namespace,chunk.generated_scopes.operator[](i),comptime_pass,generic_pass)));
+TRY((this->typecheck_namespace_methods_predecl(chunk.parsed_namespace,chunk.generated_scopes[i],comptime_pass,generic_pass)));
 }
 
 }
@@ -3598,7 +3457,7 @@ this->generic_inferences.restore(old_generic_inferences);
 }
 
 });
-this->generic_inferences.set_all(trait_->generic_parameters,impls.operator[](index).template get<1>());
+this->generic_inferences.set_all(trait_->generic_parameters,impls[index].template get<1>());
 {
 JaktInternal::DictionaryIterator<ByteString,Jakt::ids::FunctionId> _magic = methods.iterator();
 for (;;){
@@ -3612,7 +3471,7 @@ JaktInternal::Tuple<ByteString,Jakt::ids::FunctionId> const jakt__name__function
 ByteString const name = jakt__name__function_id__.template get<0>();
 Jakt::ids::FunctionId const function_id = jakt__name__function_id__.template get<1>();
 
-NonnullRefPtr<Jakt::types::CheckedFunction>& function = this->program->modules.operator[](function_id.module.id)->functions.operator[](function_id.id);
+NonnullRefPtr<Jakt::types::CheckedFunction>& function = this->program->modules[function_id.module.id]->functions[function_id.id];
 if (function->block.statements.is_empty()){
 continue;
 }
@@ -3659,9 +3518,7 @@ Jakt::parser::ParsedMethod method = _magic_value.value();
 {
 JaktInternal::Optional<Jakt::ids::TypeId> this_arg_type_id = JaktInternal::OptionalNone();
 if (method.parsed_function.params.first().map([](auto& _value) { return _value.variable; }).map([](auto& _value) { return _value.name; }).value_or_lazy_evaluated([&] { return ByteString::from_utf8_without_validation(""sv); }) == ByteString::from_utf8_without_validation("this"sv)){
-this_arg_type_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ids::TypeId>, ErrorOr<void>>{
-auto&& __jakt_match_variant = *this->get_type(for_type);
+this_arg_type_id = [&]() -> JaktInternal::Optional<Jakt::ids::TypeId> { auto&& __jakt_match_variant = *this->get_type(for_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
@@ -3687,7 +3544,7 @@ type_arguments.push(param.type_id);
 
 type = this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),id,type_arguments));
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ids::TypeId>>(type);
+return type;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -3715,22 +3572,13 @@ type_arguments.push(param.type_id);
 
 type = this->find_or_add_type_id(Jakt::types::Type::GenericEnumInstance(Jakt::parser::CheckedQualifiers(false),id,type_arguments));
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::ids::TypeId>>(type);
+return type;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(for_type);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+default:return for_type;}/*switch end*/
+ 
+}();
 }
 TRY((this->typecheck_function_predecl(method.parsed_function,entity_scope_id,this_arg_type_id,JaktInternal::OptionalNone(),Jakt::types::ResolutionMixin(scope_id,true,true,true,true,true,true,true,true,true))));
 }
@@ -3748,23 +3596,15 @@ ErrorOr<void> Jakt::typechecker::Typechecker::typecheck_trait_predecl(Jakt::pars
 {
 Jakt::ids::ScopeId const trait_scope_id = this->create_scope(scope_id,false,__jakt_format(StringView::from_string_literal("trait({})"sv),parsed_trait.name),false);
 TRY((this->add_type_to_scope(trait_scope_id,ByteString::from_utf8_without_validation("Self"sv),this->find_or_add_type_id(Jakt::types::Type::Self(Jakt::parser::CheckedQualifiers(false))),parsed_trait.name_span)));
-NonnullRefPtr<Jakt::types::CheckedTrait> checked_trait = Jakt::types::CheckedTrait::__jakt_create(parsed_trait.name,parsed_trait.name_span,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::CheckedTraitRequirements, ErrorOr<void>>{
-auto&& __jakt_match_variant = parsed_trait.requirements;
+NonnullRefPtr<Jakt::types::CheckedTrait> checked_trait = Jakt::types::CheckedTrait::__jakt_create(parsed_trait.name,parsed_trait.name_span,[&]() -> Jakt::types::CheckedTraitRequirements { auto&& __jakt_match_variant = parsed_trait.requirements;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 1 /* Methods */:return JaktInternal::ExplicitValue(Jakt::types::CheckedTraitRequirements::Methods(Dictionary<ByteString, Jakt::ids::FunctionId>::create_with_entries({})));
-default:return JaktInternal::ExplicitValue(Jakt::types::CheckedTraitRequirements::Nothing());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),DynamicArray<Jakt::types::CheckedGenericParameter>::create_with({}),trait_scope_id);
+case 1 /* Methods */:return Jakt::types::CheckedTraitRequirements::Methods(Dictionary<ByteString, Jakt::ids::FunctionId>::create_with_entries({}));default:return Jakt::types::CheckedTraitRequirements::Nothing();}/*switch end*/
+ 
+}(),DynamicArray<Jakt::types::CheckedGenericParameter>::create_with({}),trait_scope_id);
 NonnullRefPtr<Jakt::types::Module> module = this->current_module();
-Jakt::ids::TraitId const trait_id = Jakt::ids::TraitId(this->current_module_id,this->program->modules.operator[](this->current_module_id.id)->traits.size());
+Jakt::ids::TraitId const trait_id = Jakt::ids::TraitId(this->current_module_id,this->program->modules[this->current_module_id.id]->traits.size());
 Jakt::ids::TypeId const trait_type_id = this->find_or_add_type_id(Jakt::types::Type::Trait(Jakt::parser::CheckedQualifiers(false),trait_id));
-this->program->modules.operator[](this->current_module_id.id)->traits.push(checked_trait);
+this->program->modules[this->current_module_id.id]->traits.push(checked_trait);
 JaktInternal::Optional<Jakt::ids::TypeId> const old_self_type_id = this->self_type_id;
 this->set_self_type_id(trait_type_id);
 ScopeGuard __jakt_var_39([&] {
@@ -3775,7 +3615,7 @@ TRY((this->add_type_to_scope(scope_id,parsed_trait.name,trait_type_id,parsed_tra
 TRY((this->add_trait_to_scope(scope_id,parsed_trait.name,trait_id,parsed_trait.name_span)));
 NonnullRefPtr<Jakt::types::Scope> trait_scope = this->get_scope(trait_scope_id);
 trait_scope->relevant_type_id = trait_type_id;
-JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> generic_parameters = module->traits.operator[](trait_id.id)->generic_parameters;
+JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> generic_parameters = module->traits[trait_id.id]->generic_parameters;
 generic_parameters.ensure_capacity(parsed_trait.generic_parameters.size());
 {
 JaktInternal::ArrayIterator<Jakt::parser::ParsedGenericParameter> _magic = parsed_trait.generic_parameters.iterator();
@@ -3800,7 +3640,7 @@ TRY((this->add_type_to_scope(trait_scope_id,gen_parameter.name,parameter_type_id
 }
 }
 
-Jakt::ids::StructId const synthetic_struct_id = Jakt::ids::StructId(this->current_module_id,this->program->modules.operator[](this->current_module_id.id)->structures.size());
+Jakt::ids::StructId const synthetic_struct_id = Jakt::ids::StructId(this->current_module_id,this->program->modules[this->current_module_id.id]->structures.size());
 module->structures.push(Jakt::types::CheckedStruct(parsed_trait.name,parsed_trait.name_span,generic_parameters,JaktInternal::OptionalNone(),DynamicArray<NonnullRefPtr<Jakt::types::CheckedField>>::create_with({}),trait_scope_id,Jakt::parser::DefinitionLinkage::External(),Dictionary<ByteString, JaktInternal::DynamicArray<JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>::create_with_entries({}),Jakt::parser::RecordType::Struct(DynamicArray<Jakt::parser::ParsedField>::create_with({}),JaktInternal::OptionalNone()),trait_type_id,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone()));
 Jakt::ids::TypeId const struct_type_id = this->find_or_add_type_id(Jakt::types::Type::Struct(Jakt::parser::CheckedQualifiers(false),synthetic_struct_id));
 Jakt::parser::ParsedTraitRequirements __jakt_tmp100 = parsed_trait.requirements;
@@ -3848,15 +3688,13 @@ return {};
 
 ErrorOr<void> Jakt::typechecker::Typechecker::typecheck_trait(Jakt::parser::ParsedTrait const parsed_trait,Jakt::ids::TraitId const trait_id,Jakt::ids::ScopeId const scope_id,bool const comptime_pass) {
 {
-NonnullRefPtr<Jakt::types::CheckedTrait> checked_trait = this->program->modules.operator[](trait_id.module.id)->traits.operator[](trait_id.id);
+NonnullRefPtr<Jakt::types::CheckedTrait> checked_trait = this->program->modules[trait_id.module.id]->traits[trait_id.id];
 JaktInternal::Optional<Jakt::ids::TypeId> const old_self_type_id = this->self_type_id;
 this->set_self_type_id(this->find_or_add_type_id(Jakt::types::Type::Trait(Jakt::parser::CheckedQualifiers(false),trait_id)));
 ScopeGuard __jakt_var_40([&] {
 this->self_type_id = old_self_type_id;
 });
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = parsed_trait.requirements;
+{auto&& __jakt_match_variant = parsed_trait.requirements;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* ComptimeExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ComptimeExpression;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expression = __jakt_match_value.value;
@@ -3866,18 +3704,11 @@ NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_expression 
 checked_trait->requirements = Jakt::types::CheckedTraitRequirements::ComptimeExpression(checked_expression);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_112;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_112;}/*switch end*/
+}goto __jakt_label_112; __jakt_label_112:;;
 }
 return {};
 }
@@ -3895,22 +3726,14 @@ this->set_self_type_id(enum_type_id);
 ScopeGuard __jakt_var_41([&] {
 this->self_type_id = old_self_type_id;
 });
-bool const is_boxed = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, ErrorOr<void>>{
-auto&& __jakt_match_variant = parsed_record.record_type;
+bool const is_boxed = [&]() -> bool { auto&& __jakt_match_variant = parsed_record.record_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* SumEnum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SumEnum;bool const& is_boxed = __jakt_match_value.is_boxed;
-return JaktInternal::ExplicitValue(is_boxed);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return is_boxed;};/*case end*/
+default:return false;}/*switch end*/
+ 
+}();
 module->enums.push(Jakt::types::CheckedEnum(parsed_record.name,parsed_record.name_span,DynamicArray<Jakt::types::CheckedGenericParameter>::create_with({}),DynamicArray<Jakt::types::CheckedEnumVariant>::create_with({}),DynamicArray<NonnullRefPtr<Jakt::types::CheckedField>>::create_with({}),this->prelude_scope_id(),parsed_record.definition_linkage,Dictionary<ByteString, JaktInternal::DynamicArray<JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>::create_with_entries({}),parsed_record.record_type,enum_type_id,enum_type_id,is_boxed));
 }
 return {};
@@ -3929,38 +3752,22 @@ NonnullRefPtr<Jakt::types::Scope> scope = this->get_scope(enum_scope_id);
 scope->namespace_name = parsed_record.name;
 scope->relevant_type_id = enum_type_id;
 this->add_enum_to_scope(scope_id,parsed_record.name,enum_id,parsed_record.name_span);
-Jakt::ids::TypeId const underlying_type_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId, ErrorOr<void>>{
-auto&& __jakt_match_variant = parsed_record.record_type;
+Jakt::ids::TypeId const underlying_type_id = TRY(([&]() -> ErrorOr<Jakt::ids::TypeId> { auto&& __jakt_match_variant = parsed_record.record_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* ValueEnum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ValueEnum;NonnullRefPtr<typename Jakt::parser::ParsedType> const& underlying_type = __jakt_match_value.underlying_type;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_typename(underlying_type,scope_id,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()))));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::Void()));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-bool const is_boxed = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, ErrorOr<void>>{
-auto&& __jakt_match_variant = parsed_record.record_type;
+return this->typecheck_typename(underlying_type,scope_id,JaktInternal::OptionalNone(),JaktInternal::OptionalNone());};/*case end*/
+default:return Jakt::types::builtin(Jakt::types::BuiltinType::Void());}/*switch end*/
+ 
+}()));
+bool const is_boxed = [&]() -> bool { auto&& __jakt_match_variant = parsed_record.record_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* SumEnum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SumEnum;bool const& is_boxed = __jakt_match_value.is_boxed;
-return JaktInternal::ExplicitValue(is_boxed);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return is_boxed;};/*case end*/
+default:return false;}/*switch end*/
+ 
+}();
 JaktInternal::DynamicArray<NonnullRefPtr<Jakt::types::CheckedField>> checked_fields = DynamicArray<NonnullRefPtr<Jakt::types::CheckedField>>::create_with({});
 JaktInternal::Set<ByteString> seen_fields = Set<ByteString>::create_with_values({});
 Jakt::parser::RecordType __jakt_tmp102 = parsed_record.record_type;
@@ -3988,21 +3795,10 @@ TRY((this->dump_type_hint(type_id,var_decl.span)));
 }
 NonnullRefPtr<Jakt::types::Module> module = this->current_module();
 Jakt::ids::VarId const variable_id = module->add_variable(checked_var);
-JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>> const default_value_expression = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>>,ErrorOr<void>> {
-auto __jakt_enum_value = (field.default_value.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>>>(Tuple{field.default_value.value(), enum_scope_id}));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>> const default_value_expression = [&]() -> JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>> { auto __jakt_enum_value = field.default_value.has_value();
+if (__jakt_enum_value) {return static_cast<JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>>>(Tuple{field.default_value.value(), enum_scope_id});}else if (!__jakt_enum_value) {return JaktInternal::OptionalNone();}VERIFY_NOT_REACHED();
+ 
+}();
 checked_fields.push(Jakt::types::CheckedField::__jakt_create(variable_id,default_value_expression,JaktInternal::OptionalNone()));
 }
 
@@ -4011,8 +3807,8 @@ checked_fields.push(Jakt::types::CheckedField::__jakt_create(variable_id,default
 
 }
 NonnullRefPtr<Jakt::types::Module> module = this->current_module();
-module->enums.operator[](enum_id.id) = Jakt::types::CheckedEnum(parsed_record.name,parsed_record.name_span,DynamicArray<Jakt::types::CheckedGenericParameter>::create_with({}),DynamicArray<Jakt::types::CheckedEnumVariant>::create_with({}),checked_fields,enum_scope_id,parsed_record.definition_linkage,Dictionary<ByteString, JaktInternal::DynamicArray<JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>::create_with_entries({}),parsed_record.record_type,underlying_type_id,enum_type_id,is_boxed);
-JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> generic_parameters = module->enums.operator[](enum_id.id).generic_parameters;
+module->enums[enum_id.id] = Jakt::types::CheckedEnum(parsed_record.name,parsed_record.name_span,DynamicArray<Jakt::types::CheckedGenericParameter>::create_with({}),DynamicArray<Jakt::types::CheckedEnumVariant>::create_with({}),checked_fields,enum_scope_id,parsed_record.definition_linkage,Dictionary<ByteString, JaktInternal::DynamicArray<JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>::create_with_entries({}),parsed_record.record_type,underlying_type_id,enum_type_id,is_boxed);
+JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> generic_parameters = module->enums[enum_id.id].generic_parameters;
 generic_parameters.ensure_capacity(parsed_record.generic_parameters.size());
 {
 JaktInternal::ArrayIterator<Jakt::parser::ParsedGenericParameter> _magic = parsed_record.generic_parameters.iterator();
@@ -4038,7 +3834,7 @@ TRY((this->add_type_to_scope(enum_scope_id,gen_parameter.name,parameter_type_id,
 }
 
 if (parsed_record.implements_list.has_value()){
-TRY((this->fill_trait_implementation_list(parsed_record.implements_list.value(),module->enums.operator[](enum_id.id).trait_implementations,enum_scope_id,JaktInternal::OptionalNone())));
+TRY((this->fill_trait_implementation_list(parsed_record.implements_list.value(),module->enums[enum_id.id].trait_implementations,enum_scope_id,JaktInternal::OptionalNone())));
 }
 }
 return {};
@@ -4118,21 +3914,10 @@ checked_function->add_param(Jakt::types::CheckedParameter(param.requires_label,c
 else {
 Jakt::ids::TypeId const param_type = TRY((this->typecheck_typename(param.variable.parsed_type,method_scope_id,param.variable.name,JaktInternal::OptionalNone())));
 NonnullRefPtr<Jakt::types::CheckedVariable> const checked_variable = Jakt::types::CheckedVariable::__jakt_create(param.variable.name,param_type,param.variable.is_mutable,param.variable.span,param.variable.parsed_type->span(),Jakt::types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
-checked_function->add_param(Jakt::types::CheckedParameter(param.requires_label,checked_variable,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>>,ErrorOr<void>> {
-auto __jakt_enum_value = (param.default_argument.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Tuple{param.default_argument.value(), method_scope_id});
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-})));
+checked_function->add_param(Jakt::types::CheckedParameter(param.requires_label,checked_variable,[&]() -> JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>> { auto __jakt_enum_value = param.default_argument.has_value();
+if (__jakt_enum_value) {return Tuple{param.default_argument.value(), method_scope_id};}else if (!__jakt_enum_value) {return JaktInternal::OptionalNone();}VERIFY_NOT_REACHED();
+ 
+}()));
 }
 
 }
@@ -4174,7 +3959,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-reverse_chain.push(chain.operator[](JaktInternal::checked_sub(JaktInternal::checked_sub(chain.size(),static_cast<size_t>(1ULL)),i)));
+reverse_chain.push(chain[JaktInternal::checked_sub(JaktInternal::checked_sub(chain.size(),static_cast<size_t>(1ULL)),i)]);
 }
 
 }
@@ -4244,19 +4029,12 @@ Jakt::ids::ScopeId const function_scope_id = this->create_scope(struct_.scope_id
 Jakt::ids::ScopeId const block_scope_id = this->create_scope(function_scope_id,false,__jakt_format(StringView::from_string_literal("generated-constructor-block({})"sv),parsed_record.name),true);
 JaktInternal::DynamicArray<Jakt::ids::StructId> const inheritance_chain = this->struct_inheritance_chain(struct_id);
 JaktInternal::DynamicArray<Jakt::types::CheckedParameter> constructor_parameters = DynamicArray<Jakt::types::CheckedParameter>::create_with({});
-size_t const parent_index_in_chain = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<void>> {
-auto __jakt_enum_value = (inheritance_chain.size() >= static_cast<size_t>(2ULL));
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::checked_sub(inheritance_chain.size(),static_cast<size_t>(2ULL)));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+size_t const parent_index_in_chain = [&]() -> size_t { auto __jakt_enum_value = inheritance_chain.size() >= static_cast<size_t>(2ULL);
+if (__jakt_enum_value) {return JaktInternal::checked_sub(inheritance_chain.size(),static_cast<size_t>(2ULL));}else if (!__jakt_enum_value) {return static_cast<size_t>(0ULL);}VERIFY_NOT_REACHED();
+ 
+}();
 {
-JaktInternal::ArrayIterator<Jakt::ids::StructId> _magic = inheritance_chain.operator[](JaktInternal::Range<size_t>{static_cast<size_t>(parent_index_in_chain),static_cast<size_t>(9223372036854775807LL)}).iterator();
+JaktInternal::ArrayIterator<Jakt::ids::StructId> _magic = inheritance_chain[JaktInternal::Range<size_t>{static_cast<size_t>(parent_index_in_chain),static_cast<size_t>(9223372036854775807LL)}].iterator();
 for (;;){
 JaktInternal::Optional<Jakt::ids::StructId> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
@@ -4268,7 +4046,7 @@ Jakt::types::CheckedStruct const parent_struct = this->get_struct(parent_struct_
 NonnullRefPtr<Jakt::types::Scope> const scope = this->get_scope(parent_struct.scope_id);
 JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::ids::FunctionId>> const parent_constructors = scope->functions.get(parent_struct.name);
 if (parent_constructors.has_value()){
-Jakt::ids::FunctionId const id = parent_constructors.value().operator[](static_cast<i64>(0LL));
+Jakt::ids::FunctionId const id = parent_constructors.value()[static_cast<i64>(0LL)];
 NonnullRefPtr<Jakt::types::CheckedFunction> const ctor = this->get_function(id);
 constructor_parameters.push_values(ctor->params);
 }
@@ -4407,7 +4185,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (args.operator[](i).equals(generic_arguments.operator[](i))){
+if (args[i].equals(generic_arguments[i])){
 }
 else {
 args_match = false;
@@ -4487,8 +4265,8 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::types::CheckedGenericParameter const parameter = trait_->generic_parameters.operator[](i);
-Jakt::ids::TypeId const type = generic_parameters.operator[](i);
+Jakt::types::CheckedGenericParameter const parameter = trait_->generic_parameters[i];
+Jakt::ids::TypeId const type = generic_parameters[i];
 TRY((this->check_types_for_compat(parameter.type_id,type,this->generic_inferences,parameter.span)));
 }
 
@@ -4515,18 +4293,14 @@ this->set_self_type_id(struct_type_id);
 ScopeGuard __jakt_var_46([&] {
 this->self_type_id = old_self_type_id;
 });
-Jakt::ids::ScopeId const struct_scope_id = this->current_module()->structures.operator[](struct_id.id).scope_id;
+Jakt::ids::ScopeId const struct_scope_id = this->current_module()->structures[struct_id.id].scope_id;
 TRY((this->add_struct_to_scope(scope_id,parsed_record.name,struct_id,parsed_record.name_span)));
 JaktInternal::Optional<Jakt::ids::StructId> super_struct_id = JaktInternal::OptionalNone();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = parsed_record.record_type;
+{auto&& __jakt_match_variant = parsed_record.record_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedType>> const& super_parsed_type = __jakt_match_value.super_type;
-return ({({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<void>> {
-auto __jakt_enum_value = (super_parsed_type.has_value());
+{auto __jakt_enum_value = super_parsed_type.has_value();
 if (__jakt_enum_value) {{
 Jakt::ids::TypeId const super_type_id = TRY((this->typecheck_typename(super_parsed_type.value(),scope_id,JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
 NonnullRefPtr<typename Jakt::types::Type> const super_type = this->get_type(super_type_id);
@@ -4540,22 +4314,13 @@ this->error(ByteString::from_utf8_without_validation("Class can only inherit fro
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (!__jakt_enum_value) {{
+goto __jakt_label_114;}else if (!__jakt_enum_value) {{
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_114;}VERIFY_NOT_REACHED();
+}goto __jakt_label_114; __jakt_label_114:;;goto __jakt_label_113;};/*case end*/
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedType>> const& super_parsed_type = __jakt_match_value.super_type;
-return ({({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<void>> {
-auto __jakt_enum_value = (super_parsed_type.has_value());
+{auto __jakt_enum_value = super_parsed_type.has_value();
 if (__jakt_enum_value) {{
 Jakt::ids::TypeId const super_type_id = TRY((this->typecheck_typename(super_parsed_type.value(),scope_id,JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
 NonnullRefPtr<typename Jakt::types::Type> const super_type = this->get_type(super_type_id);
@@ -4569,31 +4334,18 @@ this->error(ByteString::from_utf8_without_validation("Struct can only inherit fr
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (!__jakt_enum_value) {{
+goto __jakt_label_115;}else if (!__jakt_enum_value) {{
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_115;}VERIFY_NOT_REACHED();
+}goto __jakt_label_115; __jakt_label_115:;;goto __jakt_label_113;};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Expected Struct or Class in typecheck_struct_predecl"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_113;}/*switch end*/
+}goto __jakt_label_113; __jakt_label_113:;;
 NonnullRefPtr<Jakt::types::Module> module = this->current_module();
-module->structures.operator[](struct_id.id) = Jakt::types::CheckedStruct(parsed_record.name,parsed_record.name_span,DynamicArray<Jakt::types::CheckedGenericParameter>::create_with({}),JaktInternal::OptionalNone(),DynamicArray<NonnullRefPtr<Jakt::types::CheckedField>>::create_with({}),struct_scope_id,parsed_record.definition_linkage,Dictionary<ByteString, JaktInternal::DynamicArray<JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>::create_with_entries({}),parsed_record.record_type,struct_type_id,super_struct_id,parsed_record.external_name,JaktInternal::OptionalNone(),parsed_record.create_function_name);
-JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> generic_parameters = module->structures.operator[](struct_id.id).generic_parameters;
+module->structures[struct_id.id] = Jakt::types::CheckedStruct(parsed_record.name,parsed_record.name_span,DynamicArray<Jakt::types::CheckedGenericParameter>::create_with({}),JaktInternal::OptionalNone(),DynamicArray<NonnullRefPtr<Jakt::types::CheckedField>>::create_with({}),struct_scope_id,parsed_record.definition_linkage,Dictionary<ByteString, JaktInternal::DynamicArray<JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>::create_with_entries({}),parsed_record.record_type,struct_type_id,super_struct_id,parsed_record.external_name,JaktInternal::OptionalNone(),parsed_record.create_function_name);
+JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> generic_parameters = module->structures[struct_id.id].generic_parameters;
 generic_parameters.ensure_capacity(parsed_record.generic_parameters.size());
 {
 JaktInternal::ArrayIterator<Jakt::parser::ParsedGenericParameter> _magic = parsed_record.generic_parameters.iterator();
@@ -4619,7 +4371,7 @@ TRY((this->add_type_to_scope(struct_scope_id,gen_parameter.name,parameter_type_i
 }
 
 bool const is_extern = parsed_record.definition_linkage.__jakt_init_index() == 1 /* External */;
-module->structures.operator[](struct_id.id).generic_parameters = generic_parameters;
+module->structures[struct_id.id].generic_parameters = generic_parameters;
 this->current_struct_type_id = JaktInternal::OptionalNone();
 }
 return {};
@@ -4641,7 +4393,7 @@ this->set_self_type_id(struct_type_id);
 ScopeGuard __jakt_var_48([&] {
 this->self_type_id = old_self_type_id;
 });
-Jakt::ids::ScopeId const struct_scope_id = this->current_module()->structures.operator[](struct_id.id).scope_id;
+Jakt::ids::ScopeId const struct_scope_id = this->current_module()->structures[struct_id.id].scope_id;
 NonnullRefPtr<Jakt::types::Module> module = this->current_module();
 {
 JaktInternal::ArrayIterator<Jakt::parser::ParsedMethod> _magic = parsed_record.methods.iterator();
@@ -4675,7 +4427,7 @@ this->error(ByteString::from_utf8_without_validation("Functions cannot be both o
 }
 
 if ((!comptime_pass) && parsed_record.implements_list.has_value()){
-TRY((this->fill_trait_implementation_list(parsed_record.implements_list.value(),module->structures.operator[](struct_id.id).trait_implementations,struct_scope_id,JaktInternal::OptionalNone())));
+TRY((this->fill_trait_implementation_list(parsed_record.implements_list.value(),module->structures[struct_id.id].trait_implementations,struct_scope_id,JaktInternal::OptionalNone())));
 {
 JaktInternal::ArrayIterator<Jakt::parser::ParsedNameWithGenericParameters> _magic = parsed_record.implements_list.value().iterator();
 for (;;){
@@ -4687,7 +4439,7 @@ Jakt::parser::ParsedNameWithGenericParameters implements_entry = _magic_value.va
 {
 JaktInternal::Optional<Jakt::ids::TraitId> const trait_id = TRY((this->find_trait_in_scope(scope_id,implements_entry.name)));
 if (trait_id.has_value()){
-NonnullRefPtr<Jakt::types::CheckedTrait> const trait_ = this->program->modules.operator[](trait_id.value().module.id)->traits.operator[](trait_id.value().id);
+NonnullRefPtr<Jakt::types::CheckedTrait> const trait_ = this->program->modules[trait_id.value().module.id]->traits[trait_id.value().id];
 Jakt::types::CheckedTraitRequirements __jakt_tmp109 = trait_->requirements;
 if (__jakt_tmp109.__jakt_init_index() == 1 /* Methods */){
 JaktInternal::Dictionary<ByteString,Jakt::ids::FunctionId> const methods = __jakt_tmp109.as.Methods.value;
@@ -4707,7 +4459,7 @@ Jakt::ids::FunctionId const function_id = jakt__name__function_id__.template get
 if (TRY((this->find_functions_with_name_in_scope(struct_scope_id,name,JaktInternal::OptionalNone()))).has_value()){
 continue;
 }
-NonnullRefPtr<Jakt::types::CheckedFunction> const function = this->program->modules.operator[](function_id.module.id)->functions.operator[](function_id.id);
+NonnullRefPtr<Jakt::types::CheckedFunction> const function = this->program->modules[function_id.module.id]->functions[function_id.id];
 if (function->block.statements.is_empty()){
 continue;
 }
@@ -4751,9 +4503,7 @@ scope->namespace_name = parsed_record.name;
 scope->external_name = parsed_record.external_name;
 scope->relevant_type_id = struct_type_id;
 module->structures.push(Jakt::types::CheckedStruct(parsed_record.name,parsed_record.name_span,DynamicArray<Jakt::types::CheckedGenericParameter>::create_with({}),JaktInternal::OptionalNone(),DynamicArray<NonnullRefPtr<Jakt::types::CheckedField>>::create_with({}),struct_scope_id,parsed_record.definition_linkage,Dictionary<ByteString, JaktInternal::DynamicArray<JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>::create_with_entries({}),parsed_record.record_type,struct_type_id,JaktInternal::OptionalNone(),parsed_record.external_name,JaktInternal::OptionalNone(),parsed_record.create_function_name));
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = parsed_record.record_type;
+{auto&& __jakt_match_variant = parsed_record.record_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::parser::ParsedField> const& fields = __jakt_match_value.fields;
@@ -4800,8 +4550,7 @@ this->error_with_hint(__jakt_format(StringView::from_string_literal("Can't have 
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_116;};/*case end*/
 case 1 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;JaktInternal::DynamicArray<Jakt::parser::ParsedField> const& fields = __jakt_match_value.fields;
 {
@@ -4847,18 +4596,11 @@ this->error_with_hint(__jakt_format(StringView::from_string_literal("Can't have 
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_116;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_116;}/*switch end*/
+}goto __jakt_label_116; __jakt_label_116:;;
 }
 return {};
 }
@@ -4938,8 +4680,8 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::types::CheckedGenericParameter const generic_param = trait_->generic_parameters.operator[](i);
-Jakt::ids::TypeId const generic_param_type = generic_params.operator[](i);
+Jakt::types::CheckedGenericParameter const generic_param = trait_->generic_parameters[i];
+Jakt::ids::TypeId const generic_param_type = generic_params[i];
 NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp111 = this->get_type(generic_param.type_id);
 if (__jakt_tmp111->__jakt_init_index() == 18 /* TypeVariable */){
 ByteString const name = __jakt_tmp111->as.TypeVariable.name;
@@ -4964,21 +4706,10 @@ continue;
 }
 
 }
-TRY((this->typecheck_function_predecl(method->parsed_function.value(),scope_id,type_id,JaktInternal::OptionalNone(),({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::types::ResolutionMixin>,ErrorOr<void>> {
-auto __jakt_enum_value = (mixin_scope_id.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::ResolutionMixin(mixin_scope_id.value(),true,true,true,true,true,true,true,true,true));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-}))));
+TRY((this->typecheck_function_predecl(method->parsed_function.value(),scope_id,type_id,JaktInternal::OptionalNone(),[&]() -> JaktInternal::Optional<Jakt::types::ResolutionMixin> { auto __jakt_enum_value = mixin_scope_id.has_value();
+if (__jakt_enum_value) {return Jakt::types::ResolutionMixin(mixin_scope_id.value(),true,true,true,true,true,true,true,true,true);}else if (!__jakt_enum_value) {return JaktInternal::OptionalNone();}VERIFY_NOT_REACHED();
+ 
+}())));
 }
 
 }
@@ -5284,8 +5015,8 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::parser::ParsedNamespace const child_namespace = parsed_namespace.namespaces.operator[](i);
-Jakt::ids::ScopeId const child_namespace_scope_id = children.operator[](i);
+Jakt::parser::ParsedNamespace const child_namespace = parsed_namespace.namespaces[i];
+Jakt::ids::ScopeId const child_namespace_scope_id = children[i];
 TRY((this->typecheck_namespace_declarations(child_namespace,child_namespace_scope_id,comptime_pass,generic_pass)));
 }
 
@@ -5318,7 +5049,7 @@ JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<Jakt::utility::Span,Jakt
 ScopeGuard __jakt_var_51([&] {
 i += static_cast<size_t>(1ULL);
 });
-TRY((this->typecheck_namespace_declarations(chunk.parsed_namespace,chunk.generated_scopes.operator[](i),comptime_pass,generic_pass)));
+TRY((this->typecheck_namespace_declarations(chunk.parsed_namespace,chunk.generated_scopes[i],comptime_pass,generic_pass)));
 }
 
 }
@@ -5462,9 +5193,7 @@ if (type->is_builtin()){
 Jakt::ids::StructId const struct_id = this->program->builtin_implementation_struct(type->as_builtin_type(),this->program->prelude_module_id());
 for_type = this->find_or_add_type_id(Jakt::types::Type::Struct(Jakt::parser::CheckedQualifiers(false),struct_id));
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = *this->get_type(for_type);
+{auto&& __jakt_match_variant = *this->get_type(for_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
@@ -5492,8 +5221,7 @@ TRY((this->typecheck_function(method.parsed_function,struct_.scope_id)));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_117;};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& struct_id = __jakt_match_value.id;
 {
@@ -5520,8 +5248,7 @@ TRY((this->typecheck_function(method.parsed_function,struct_.scope_id)));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_117;};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
 {
@@ -5548,8 +5275,7 @@ TRY((this->typecheck_function(method.parsed_function,enum_.scope_id)));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_117;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& enum_id = __jakt_match_value.id;
 {
@@ -5576,22 +5302,11 @@ TRY((this->typecheck_function(method.parsed_function,enum_.scope_id)));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_117;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_117;}/*switch end*/
+break;}goto __jakt_label_117; __jakt_label_117:;;
 }
 
 }
@@ -5636,9 +5351,7 @@ common_fields.push(field->variable_id);
 }
 }
 
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = parsed_record.record_type;
+{auto&& __jakt_match_variant = parsed_record.record_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* ValueEnum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ValueEnum;NonnullRefPtr<typename Jakt::parser::ParsedType> const& underlying_type = __jakt_match_value.underlying_type;
@@ -5660,28 +5373,20 @@ this->error(__jakt_format(StringView::from_string_literal("Enum variant '{}' is 
 }
 else {
 seen_names.add(variant.name);
-NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedExpression>,ErrorOr<void>> {
-auto __jakt_enum_value = (variant.value.has_value());
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr = TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>> { auto __jakt_enum_value = variant.value.has_value();
 if (__jakt_enum_value) {{
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const value_expression = TRY((this->cast_to_underlying(variant.value.value(),parent_scope_id,underlying_type)));
 JaktInternal::Optional<Jakt::types::NumberConstant> const number_constant = value_expression->to_number_constant(this->program);
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<void>> {
-auto __jakt_enum_value = (number_constant.has_value());
+{auto __jakt_enum_value = number_constant.has_value();
 if (__jakt_enum_value) {{
-next_constant_value = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<u64, ErrorOr<void>>{
-auto&& __jakt_match_variant = number_constant.value();
+next_constant_value = [&]() -> u64 { auto&& __jakt_match_variant = number_constant.value();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Signed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Signed;i64 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<u64>(JaktInternal::checked_add(val,static_cast<i64>(1LL))));
-};/*case end*/
+return infallible_integer_cast<u64>(JaktInternal::checked_add(val,static_cast<i64>(1LL)));};/*case end*/
 case 1 /* Unsigned */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsigned;u64 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(JaktInternal::checked_add(val,static_cast<u64>(1ULL)));
-};/*case end*/
+return JaktInternal::checked_add(val,static_cast<u64>(1ULL));};/*case end*/
 case 2 /* Floating */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Floating;f64 const& val = __jakt_match_value.value;
 {
@@ -5689,46 +5394,19 @@ Jakt::utility::todo(ByteString::from_utf8_without_validation("Implement floats"s
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+ 
+}();
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_119;}else {{
 this->error(__jakt_format(StringView::from_string_literal("Enum variant '{}' in enum '{}' has a non-constant value: {}"sv),variant.name,enum_.name,value_expression),variant.span);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(value_expression);
+goto __jakt_label_119;}}goto __jakt_label_119; __jakt_label_119:;;
+return value_expression;
 }
 VERIFY_NOT_REACHED();
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->cast_to_underlying(Jakt::parser::ParsedExpression::NumericConstant(Jakt::parser::NumericConstant::UnknownUnsigned(next_constant_value++),variant.span),parent_scope_id,underlying_type))));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+}else if (!__jakt_enum_value) {return this->cast_to_underlying(Jakt::parser::ParsedExpression::NumericConstant(Jakt::parser::NumericConstant::UnknownUnsigned(next_constant_value++),variant.span),parent_scope_id,underlying_type);}VERIFY_NOT_REACHED();
+ 
+}()));
 enum_.variants.push(Jakt::types::CheckedEnumVariant::WithValue(enum_id,variant.name,expr,variant.span));
 Jakt::ids::VarId const var_id = module->add_variable(Jakt::types::CheckedVariable::__jakt_create(variant.name,enum_.type_id,false,variant.span,JaktInternal::OptionalNone(),Jakt::types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone()));
 this->add_var_to_scope(enum_.scope_id,variant.name,var_id,variant.span);
@@ -5740,8 +5418,7 @@ this->add_var_to_scope(enum_.scope_id,variant.name,var_id,variant.span);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_118;};/*case end*/
 case 3 /* SumEnum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SumEnum;bool const& is_boxed = __jakt_match_value.is_boxed;
 JaktInternal::DynamicArray<Jakt::parser::SumEnumVariant> const& variants = __jakt_match_value.variants;
@@ -5765,8 +5442,8 @@ bool const is_structlike = (variant.params.has_value() && (variant.params.value(
 return !(self == rhs);
 }
 }
-(variant.params.value().operator[](static_cast<i64>(0LL)).name,ByteString::from_utf8_without_validation(""sv));
-bool const is_typed = (variant.params.has_value() && (variant.params.value().size() == static_cast<size_t>(1ULL))) && (variant.params.value().operator[](static_cast<i64>(0LL)).name == ByteString::from_utf8_without_validation(""sv));
+(variant.params.value()[static_cast<i64>(0LL)].name,ByteString::from_utf8_without_validation(""sv));
+bool const is_typed = (variant.params.has_value() && (variant.params.value().size() == static_cast<size_t>(1ULL))) && (variant.params.value()[static_cast<i64>(0LL)].name == ByteString::from_utf8_without_validation(""sv));
 if (is_structlike){
 JaktInternal::Set<ByteString> seen_fields = Set<ByteString>::create_with_values({});
 {
@@ -5831,8 +5508,8 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::parser::ParsedVarDecl const param = variant_params.operator[](i);
-JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const default_value = variant_default_values.operator[](i);
+Jakt::parser::ParsedVarDecl const param = variant_params[i];
+JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const default_value = variant_default_values[i];
 if (seen_fields.contains(param.name)){
 this->error(__jakt_format(StringView::from_string_literal("Enum variant '{}' has a member named '{}' more than once"sv),variant.name,param.name),param.span);
 continue;
@@ -5840,21 +5517,10 @@ continue;
 seen_fields.add(param.name);
 Jakt::ids::TypeId const type_id = TRY((this->typecheck_typename(param.parsed_type,enum_.scope_id,param.name,JaktInternal::OptionalNone())));
 NonnullRefPtr<Jakt::types::CheckedVariable> const checked_var = Jakt::types::CheckedVariable::__jakt_create(param.name,type_id,param.is_mutable,param.span,JaktInternal::OptionalNone(),Jakt::types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
-params.push(Jakt::types::CheckedParameter(true,checked_var,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>>,ErrorOr<void>> {
-auto __jakt_enum_value = (default_value.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Tuple{default_value.value(), enum_.scope_id});
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-})));
+params.push(Jakt::types::CheckedParameter(true,checked_var,[&]() -> JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>> { auto __jakt_enum_value = default_value.has_value();
+if (__jakt_enum_value) {return Tuple{default_value.value(), enum_.scope_id};}else if (!__jakt_enum_value) {return JaktInternal::OptionalNone();}VERIFY_NOT_REACHED();
+ 
+}()));
 if (this->dump_type_hints && (param.parsed_type->__jakt_init_index() == 15 /* Empty */)){
 TRY((this->dump_type_hint(type_id,param.span)));
 }
@@ -5895,7 +5561,7 @@ params.push(param);
 }
 }
 
-Jakt::parser::ParsedVarDecl const param = variant.params.value().operator[](static_cast<i64>(0LL));
+Jakt::parser::ParsedVarDecl const param = variant.params.value()[static_cast<i64>(0LL)];
 Jakt::ids::TypeId const type_id = TRY((this->typecheck_typename(param.parsed_type,enum_.scope_id,param.name,JaktInternal::OptionalNone())));
 enum_.variants.push(Jakt::types::CheckedEnumVariant::Typed(enum_id,variant.name,type_id,variant.span));
 JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::ids::FunctionId>> const maybe_enum_variant_constructor = TRY((this->find_functions_with_name_in_scope(enum_.scope_id,variant.name,JaktInternal::OptionalNone())));
@@ -5943,18 +5609,11 @@ this->add_function_to_scope(enum_.scope_id,variant.name,DynamicArray<Jakt::ids::
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_118;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_118;}/*switch end*/
+}goto __jakt_label_118; __jakt_label_118:;;
 }
 return {};
 }
@@ -6034,7 +5693,7 @@ if (!all_virtuals.contains(function->name)){
 all_virtuals.set(function->name, DynamicArray<NonnullRefPtr<Jakt::types::CheckedFunction>>::create_with({function}));
 }
 else {
-all_virtuals.operator[](function->name).push(function);
+all_virtuals[function->name].push(function);
 }
 
 }
@@ -6099,8 +5758,8 @@ break;
 }
 size_t param_index = _magic_value.value();
 {
-Jakt::types::CheckedParameter const method_param = method_function->params.operator[](param_index);
-Jakt::types::CheckedParameter const virtual_param = override_target.value()->params.operator[](param_index);
+Jakt::types::CheckedParameter const method_param = method_function->params[param_index];
+Jakt::types::CheckedParameter const virtual_param = override_target.value()->params[param_index];
 if (virtual_param.variable->is_mutable != method_param.variable->is_mutable){
 this->error(ByteString::from_utf8_without_validation("Override function parameter mutability does not match virtual function"sv),method_param.variable->definition_span);
 }
@@ -6144,9 +5803,7 @@ ErrorOr<JaktInternal::Optional<Jakt::ids::FunctionId>> Jakt::typechecker::Typech
 JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> parent_generic_parameters = DynamicArray<Jakt::types::CheckedGenericParameter>::create_with({});
 Jakt::ids::ScopeId parent_scope_id = this->prelude_scope_id();
 Jakt::parser::DefinitionLinkage parent_definition_linkage = Jakt::parser::DefinitionLinkage::Internal();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Optional<Jakt::ids::FunctionId>>>{
-auto&& __jakt_match_variant = parent_id;
+{auto&& __jakt_match_variant = parent_id;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
@@ -6156,8 +5813,7 @@ parent_scope_id = structure.scope_id;
 parent_definition_linkage = structure.definition_linkage;
 parent_generic_parameters = structure.generic_parameters;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_120;};/*case end*/
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
 {
@@ -6166,8 +5822,7 @@ parent_scope_id = enum_.scope_id;
 parent_definition_linkage = enum_.definition_linkage;
 parent_generic_parameters = enum_.generic_parameters;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_120;};/*case end*/
 case 2 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& trait_id = __jakt_match_value.value;
 {
@@ -6176,15 +5831,9 @@ parent_scope_id = trait_->scope_id;
 parent_definition_linkage = Jakt::parser::DefinitionLinkage::Internal();
 parent_generic_parameters = trait_->generic_parameters;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_120;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}goto __jakt_label_120; __jakt_label_120:;;
 if ((!func.generic_parameters.is_empty()) && (!func.must_instantiate)){
 return JaktInternal::OptionalNone();
 }
@@ -6215,17 +5864,10 @@ this->error(ByteString::from_utf8_without_validation("Cannot have a mutable bind
 }
 }
 NonnullRefPtr<Jakt::types::CheckedVariable> const variable = Jakt::types::CheckedVariable::__jakt_create(parameter.variable.name,type_id,parameter.variable.is_mutable,parameter.variable.span,JaktInternal::OptionalNone(),Jakt::types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
-Jakt::types::CheckedParameter const checked_parameter = Jakt::types::CheckedParameter(parameter.requires_label,variable,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>>,ErrorOr<Jakt::types::CheckedParameter>> {
-auto __jakt_enum_value = (parameter.default_argument.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Tuple{parameter.default_argument.value(), scope_id});
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}VERIFY_NOT_REACHED();
+Jakt::types::CheckedParameter const checked_parameter = Jakt::types::CheckedParameter(parameter.requires_label,variable,[&]() -> JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>> { auto __jakt_enum_value = parameter.default_argument.has_value();
+if (__jakt_enum_value) {return Tuple{parameter.default_argument.value(), scope_id};}else if (!__jakt_enum_value) {return JaktInternal::OptionalNone();}VERIFY_NOT_REACHED();
+ 
 }());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
 if (check_scope.has_value()){
 NonnullRefPtr<Jakt::types::Module> module = this->current_module();
 Jakt::ids::VarId const var_id = module->add_variable(variable);
@@ -6322,16 +5964,9 @@ NonnullRefPtr<Jakt::types::Module> current_module = this->current_module();
 Jakt::ids::FunctionId const function_id = current_module->add_function(checked_function);
 Jakt::ids::ScopeId const checked_function_scope_id = checked_function->function_scope_id;
 bool const external_linkage = parsed_function.linkage.__jakt_init_index() == 1 /* External */;
-JaktInternal::Optional<Jakt::ids::ScopeId> const check_scope = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ids::ScopeId>,ErrorOr<Jakt::ids::FunctionId>> {
-auto __jakt_enum_value = (is_generic || (parsed_function.return_type->__jakt_init_index() == 15 /* Empty */));
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(this->create_scope(parent_scope_id,parsed_function.can_throw,scope_debug_name,true)));
-}else {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+JaktInternal::Optional<Jakt::ids::ScopeId> const check_scope = [&]() -> JaktInternal::Optional<Jakt::ids::ScopeId> { auto __jakt_enum_value = is_generic || (parsed_function.return_type->__jakt_init_index() == 15 /* Empty */);
+if (__jakt_enum_value) {return static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(this->create_scope(parent_scope_id,parsed_function.can_throw,scope_debug_name,true));}else {return JaktInternal::OptionalNone();} 
+}();
 i64 i = static_cast<i64>(0LL);
 {
 JaktInternal::ArrayIterator<Jakt::parser::ParsedGenericParameter> _magic = parsed_function.generic_parameters.iterator();
@@ -6352,8 +5987,8 @@ TRY((this->fill_trait_requirements(generic_parameter.requires_list.value(),param
 }
 checked_function->generics->params.push(parameter);
 }
-else if (checked_function->generics->params.operator[](i).kind.__jakt_init_index() == 1 /* Parameter */){
-type_var_type_id = checked_function->generics->params.operator[](i).type_id();
+else if (checked_function->generics->params[i].kind.__jakt_init_index() == 1 /* Parameter */){
+type_var_type_id = checked_function->generics->params[i].type_id();
 }
 if ((!parsed_function.must_instantiate) || external_linkage){
 TRY((this->add_type_to_scope(checked_function_scope_id,generic_parameter.name,type_var_type_id,generic_parameter.span)));
@@ -6406,28 +6041,15 @@ Jakt::parser::ArgumentStoreLevel const _ = jakt__index_____.template get<1>();
 if (index >= checked_function->params.size()){
 this->compiler->panic(ByteString::from_utf8_without_validation("stores_argument() index out of bounds"sv));
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::ids::FunctionId>>{
-auto&& __jakt_match_variant = *this->get_type(checked_function->params.operator[](index).variable->type_id);
+{auto&& __jakt_match_variant = *this->get_type(checked_function->params[index].variable->type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 27 /* Reference */:case 28 /* MutableReference */:{
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
-this->error_with_hint(ByteString::from_utf8_without_validation("This parameter is not a reference"sv),checked_function->params.operator[](index).variable->definition_span,ByteString::from_utf8_without_validation("stores_argument() may only be used to declare reference lifetime requirements"sv),checked_function->params.operator[](index).variable->definition_span);
+goto __jakt_label_121;default:{
+this->error_with_hint(ByteString::from_utf8_without_validation("This parameter is not a reference"sv),checked_function->params[index].variable->definition_span,ByteString::from_utf8_without_validation("stores_argument() may only be used to declare reference lifetime requirements"sv),checked_function->params[index].variable->definition_span);
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_121;}/*switch end*/
+break;}goto __jakt_label_121; __jakt_label_121:;;
 }
 
 }
@@ -6468,17 +6090,10 @@ ScopeGuard __jakt_var_56([&] {
 this->exit_ignore_error_mode(snapshot);
 });
 Jakt::types::CheckedBlock const block = TRY((this->typecheck_block(parsed_function.block,check_scope.value(),Jakt::types::SafetyMode::Safe(),JaktInternal::OptionalNone())));
-Jakt::ids::TypeId const return_type_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId,ErrorOr<Jakt::ids::FunctionId>> {
-auto __jakt_enum_value = (function_return_type_id.equals(Jakt::types::unknown_type_id()));
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(this->infer_function_return_type(block));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(TRY((this->resolve_type_var(function_return_type_id,parent_scope_id))));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+Jakt::ids::TypeId const return_type_id = TRY(([&]() -> ErrorOr<Jakt::ids::TypeId> { auto __jakt_enum_value = function_return_type_id.equals(Jakt::types::unknown_type_id());
+if (__jakt_enum_value) {return this->infer_function_return_type(block);}else if (!__jakt_enum_value) {return this->resolve_type_var(function_return_type_id,parent_scope_id);}VERIFY_NOT_REACHED();
+ 
+}()));
 checked_function->block = block;
 checked_function->return_type_id = return_type_id;
 }
@@ -6499,19 +6114,10 @@ return {};
 bool Jakt::typechecker::Typechecker::type_contains_reference(Jakt::ids::TypeId const type_id) {
 {
 NonnullRefPtr<typename Jakt::types::Type> const type = this->get_type(type_id);
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *type;
+{auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 27 /* Reference */:case 28 /* MutableReference */:return JaktInternal::ExplicitValue(true);
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 27 /* Reference */:case 28 /* MutableReference */:return true;default:return false;}/*switch end*/
+}
 }
 }
 
@@ -6540,8 +6146,8 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId c
 return JaktInternal::ExplicitValue(Tuple{this->get_struct(id).trait_implementations, this->get_struct(id).name_span});
 };/*case end*/
 default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>,Jakt::utility::Span>,ErrorOr<void>> {
-auto __jakt_enum_value = (type->is_builtin());
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>,Jakt::utility::Span>, ErrorOr<void>>{
+auto __jakt_enum_value = type->is_builtin();
 if (__jakt_enum_value) {{
 Jakt::ids::StructId const struct_id = this->program->builtin_implementation_struct(type->as_builtin_type(),this->program->prelude_module_id());
 return JaktInternal::ExplicitValue<JaktInternal::Tuple<JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>,Jakt::utility::Span>>(Tuple{this->get_struct(struct_id).trait_implementations, this->get_struct(struct_id).name_span});
@@ -6556,7 +6162,8 @@ return ErrorOr<void>{};
 Jakt::abort();
 }
 }VERIFY_NOT_REACHED();
-}());
+}()
+);
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
@@ -6581,9 +6188,7 @@ break;
 Jakt::ids::TraitId constraint = _magic_value.value();
 {
 NonnullRefPtr<Jakt::types::CheckedTrait> const trait_ = this->program->get_trait(constraint);
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = trait_->requirements;
+{auto&& __jakt_match_variant = trait_->requirements;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Nothing */:case 1 /* Methods */:{
 ByteString const trait_name = trait_->name;
@@ -6592,8 +6197,7 @@ if ((!implemented_trait.has_value()) || (!implemented_trait.value().first().map(
 this->error_with_hint(__jakt_format(StringView::from_string_literal("Cannot use ‘{}’ here as it doesn't implement the trait ‘{}’"sv),TRY((this->type_name(generic_argument,false))),trait_name),arg_span,ByteString::from_utf8_without_validation("Consider implementing the required trait for this type"sv),decl_span);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* ComptimeExpression */: {
+goto __jakt_label_122;case 2 /* ComptimeExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ComptimeExpression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.value;
 {
 NonnullRefPtr<Jakt::interpreter::Interpreter> interpreter = this->interpreter();
@@ -6604,71 +6208,38 @@ if (!__jakt_var_58.is_error()) __jakt_var_57 = __jakt_var_58.release_value();
 __jakt_var_57; });
 bool meets_requirement = false;
 if (result.has_value()){
-meets_requirement = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, ErrorOr<void>>{
-auto&& __jakt_match_variant = result.value();
+meets_requirement = [&]() -> bool { auto&& __jakt_match_variant = result.value();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, ErrorOr<void>>{
-auto&& __jakt_match_variant = *value.impl;
+{auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Bool */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Bool;bool const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
+return x;};/*case end*/
 default:{
 this->error(__jakt_format(StringView::from_string_literal("Invalid result type for comptime requirements in trait ‘{}’, expected ‘bool’ but got ‘{}’"sv),trait_->name,value.impl),arg_span);
-return JaktInternal::ExplicitValue<bool>(false);
+return false;
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default:{
 this->error(__jakt_format(StringView::from_string_literal("Invalid result type for comptime requirements in trait ‘{}’, expected ‘bool’ but got ‘{}’"sv),trait_->name,result),arg_span);
-return JaktInternal::ExplicitValue<bool>(false);
+return false;
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+ 
+}();
 }
 if (!meets_requirement){
 this->error(__jakt_format(StringView::from_string_literal("Cannot use ‘{}’ here as it doesn't meet the comptime requirements for ‘{}’"sv),TRY((this->type_name(generic_argument,false))),trait_->name),arg_span);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_122;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+break;}goto __jakt_label_122; __jakt_label_122:;;
 }
 
 }
@@ -6742,10 +6313,10 @@ size_t i = _magic_value.value();
 {
 Jakt::utility::Span arg_span = call_span;
 if (type_args.size() > i){
-arg_span = type_args.operator[](i)->span();
+arg_span = type_args[i]->span();
 }
 if (generic_arguments.size() > i){
-TRY((this->check_type_argument_requirements(generic_arguments.operator[](i),checked_function->generics->params.operator[](i).checked_parameter.constraints,arg_span,scope_id)));
+TRY((this->check_type_argument_requirements(generic_arguments[i],checked_function->generics->params[i].checked_parameter.constraints,arg_span,scope_id)));
 }
 }
 
@@ -6756,28 +6327,19 @@ Jakt::utility::Span const span = parsed_function.name_span;
 if (this_type_id.has_value()){
 JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> const p = DynamicArray<Jakt::types::CheckedGenericParameter>::create_with({});
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const a = DynamicArray<Jakt::ids::TypeId>::create_with({});
-JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::DynamicArray<Jakt::ids::TypeId>> const params_args_ = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>, ErrorOr<Jakt::ids::FunctionId>>{
-auto&& __jakt_match_variant = *this->get_type(this_type_id.value());
+JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::DynamicArray<Jakt::ids::TypeId>> const params_args_ = [&]() -> JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::DynamicArray<Jakt::ids::TypeId>> { auto&& __jakt_match_variant = *this->get_type(this_type_id.value());
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(Tuple{this->get_struct(id).generic_parameters, args});
-};/*case end*/
+return Tuple{this->get_struct(id).generic_parameters, args};};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(Tuple{this->get_enum(id).generic_parameters, args});
-};/*case end*/
-default:return JaktInternal::ExplicitValue(Tuple{p, a});
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return Tuple{this->get_enum(id).generic_parameters, args};};/*case end*/
+default:return Tuple{p, a};}/*switch end*/
+ 
+}();
 JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> const params = params_args_.template get<0>();
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = params_args_.template get<1>();
 
@@ -6790,51 +6352,34 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::types::CheckedGenericParameter const param = params.operator[](i);
-Jakt::ids::TypeId const arg = generic_substitutions.map(args.operator[](i));
+Jakt::types::CheckedGenericParameter const param = params[i];
+Jakt::ids::TypeId const arg = generic_substitutions.map(args[i]);
 NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp118 = this->get_type(param.type_id);
 if (__jakt_tmp118->__jakt_init_index() == 18 /* TypeVariable */){
 ByteString const type_name = __jakt_tmp118->as.TypeVariable.name;
-JaktInternal::Optional<Jakt::ids::ScopeId> const dependent_scope_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ids::ScopeId>, ErrorOr<Jakt::ids::FunctionId>>{
-auto&& __jakt_match_variant = *this->get_type(param.type_id);
+JaktInternal::Optional<Jakt::ids::ScopeId> const dependent_scope_id = [&]() -> JaktInternal::Optional<Jakt::ids::ScopeId> { auto&& __jakt_match_variant = *this->get_type(param.type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& struct_id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(this->get_struct(struct_id).scope_id);
-};/*case end*/
+return this->get_struct(struct_id).scope_id;};/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->get_struct(struct_id).scope_id);
-};/*case end*/
+return this->get_struct(struct_id).scope_id;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& enum_id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(this->get_enum(enum_id).scope_id);
-};/*case end*/
+return this->get_enum(enum_id).scope_id;};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->get_enum(enum_id).scope_id);
-};/*case end*/
+return this->get_enum(enum_id).scope_id;};/*case end*/
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& trait_id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(this->get_trait(trait_id)->scope_id);
-};/*case end*/
+return this->get_trait(trait_id)->scope_id;};/*case end*/
 case 26 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& trait_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->get_trait(trait_id)->scope_id);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+return this->get_trait(trait_id)->scope_id;};/*case end*/
+default:return JaktInternal::OptionalNone();}/*switch end*/
+ 
+}();
 TRY((this->add_type_to_scope(scope_id,type_name,arg,span)));
 if (dependent_scope_id.has_value()){
 NonnullRefPtr<Jakt::types::Scope> scope = this->get_scope(scope_id);
@@ -6868,46 +6413,29 @@ NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp119 = this->get_type(paramet
 if (__jakt_tmp119->__jakt_init_index() == 18 /* TypeVariable */){
 ByteString const type_name = __jakt_tmp119->as.TypeVariable.name;
 bool const is_value = __jakt_tmp119->as.TypeVariable.is_value;
-JaktInternal::Optional<Jakt::ids::ScopeId> const dependent_scope_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ids::ScopeId>, ErrorOr<Jakt::ids::FunctionId>>{
-auto&& __jakt_match_variant = *this->get_type(parameter_type_id);
+JaktInternal::Optional<Jakt::ids::ScopeId> const dependent_scope_id = [&]() -> JaktInternal::Optional<Jakt::ids::ScopeId> { auto&& __jakt_match_variant = *this->get_type(parameter_type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& struct_id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(this->get_struct(struct_id).scope_id);
-};/*case end*/
+return this->get_struct(struct_id).scope_id;};/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->get_struct(struct_id).scope_id);
-};/*case end*/
+return this->get_struct(struct_id).scope_id;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& enum_id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(this->get_enum(enum_id).scope_id);
-};/*case end*/
+return this->get_enum(enum_id).scope_id;};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->get_enum(enum_id).scope_id);
-};/*case end*/
+return this->get_enum(enum_id).scope_id;};/*case end*/
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& trait_id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(this->get_trait(trait_id)->scope_id);
-};/*case end*/
+return this->get_trait(trait_id)->scope_id;};/*case end*/
 case 26 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& trait_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->get_trait(trait_id)->scope_id);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+return this->get_trait(trait_id)->scope_id;};/*case end*/
+default:return JaktInternal::OptionalNone();}/*switch end*/
+ 
+}();
 TRY((this->add_type_to_scope(scope_id,type_name,type_id,span)));
 NonnullRefPtr<Jakt::types::Scope> scope = this->get_scope(scope_id);
 if (is_value){
@@ -6969,7 +6497,7 @@ if (parsed_function.params.size() > static_cast<size_t>(1ULL)){
 this->error(param_type_error,parsed_function.name_span);
 }
 if (!parsed_function.params.is_empty()){
-NonnullRefPtr<typename Jakt::parser::ParsedType> __jakt_tmp121 = parsed_function.params.operator[](static_cast<i64>(0LL)).variable.parsed_type;
+NonnullRefPtr<typename Jakt::parser::ParsedType> __jakt_tmp121 = parsed_function.params[static_cast<i64>(0LL)].variable.parsed_type;
 if (__jakt_tmp121->__jakt_init_index() == 3 /* JaktArray */){
 NonnullRefPtr<typename Jakt::parser::ParsedType> const inner = __jakt_tmp121->as.JaktArray.inner;
 Jakt::utility::Span const span = __jakt_tmp121->as.JaktArray.span;
@@ -6996,14 +6524,11 @@ this->error(param_type_error,parsed_function.name_span);
 
 }
 ByteString const return_type_error = ByteString::from_utf8_without_validation("Main function must return c_int"sv);
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = *parsed_function.return_type;
+{auto&& __jakt_match_variant = *parsed_function.return_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 15 /* Empty */:{
 }
-return JaktInternal::ExplicitValue<void>();
-case 0 /* Name */: {
+goto __jakt_label_123;case 0 /* Name */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Name;ByteString const& name = __jakt_match_value.name;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
@@ -7015,19 +6540,12 @@ return !(self == rhs);
 this->error(return_type_error,span);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_123;};/*case end*/
 default:{
 this->error(return_type_error,parsed_function.return_type_span);
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_123;}/*switch end*/
+}goto __jakt_label_123; __jakt_label_123:;;
 }
 return {};
 }
@@ -7110,16 +6628,9 @@ Jakt::types::CheckedBlock const block = TRY((this->typecheck_block(parsed_functi
 if (block.yielded_type.has_value()){
 this->error_with_hint(ByteString::from_utf8_without_validation("Functions are not allowed to yield values"sv),parsed_function.block.find_yield_span().value(),ByteString::from_utf8_without_validation("You might want to return instead"sv),parsed_function.block.find_yield_keyword_span().value());
 }
-Jakt::ids::TypeId const return_type_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId,ErrorOr<void>> {
-auto __jakt_enum_value = (function_return_type_id.equals(Jakt::types::unknown_type_id()));
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(this->infer_function_return_type(block));
-}else {return JaktInternal::ExplicitValue(TRY((this->resolve_type_var(function_return_type_id,function_scope_id))));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+Jakt::ids::TypeId const return_type_id = TRY(([&]() -> ErrorOr<Jakt::ids::TypeId> { auto __jakt_enum_value = function_return_type_id.equals(Jakt::types::unknown_type_id());
+if (__jakt_enum_value) {return this->infer_function_return_type(block);}else {return this->resolve_type_var(function_return_type_id,function_scope_id);} 
+}()));
 if ((!(function_linkage.__jakt_init_index() == 1 /* External */)) && ((!return_type_id.equals(Jakt::types::void_type_id())) && (!block.control_flow.always_transfers_control()))){
 if (return_type_id.equals(Jakt::types::never_type_id()) && (!block.control_flow.never_returns())){
 this->error(ByteString::from_utf8_without_validation("Control reaches end of never-returning function"sv),parsed_function.name_span);
@@ -7129,19 +6640,11 @@ this->error(ByteString::from_utf8_without_validation("Control reaches end of non
 }
 }
 if (!(function_linkage.__jakt_init_index() == 1 /* External */)){
-if (({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, ErrorOr<void>>{
-auto&& __jakt_match_variant = *this->get_type(function_return_type_id);
+if ([&]() -> bool { auto&& __jakt_match_variant = *this->get_type(function_return_type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 26 /* Trait */:case 22 /* GenericTraitInstance */:return JaktInternal::ExplicitValue(true);
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-})){
+case 26 /* Trait */:case 22 /* GenericTraitInstance */:return true;default:return false;}/*switch end*/
+ 
+}()){
 this->error_with_hint(__jakt_format(StringView::from_string_literal("Invalid use of trait in return type ‘{}’"sv),TRY((this->type_name(function_return_type_id,false)))),parsed_function.return_type_span,ByteString::from_utf8_without_validation("Return type must either be a concrete type, or be explicitly generic"sv),parsed_function.return_type_span);
 }
 {
@@ -7154,23 +6657,11 @@ break;
 Jakt::types::CheckedParameter param = _magic_value.value();
 {
 Jakt::ids::TypeId const type_id = param.variable->type_id;
-if (({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, ErrorOr<void>>{
-auto&& __jakt_match_variant = *this->get_type(type_id);
+if ([&]() -> bool { auto&& __jakt_match_variant = *this->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 26 /* Trait */:case 22 /* GenericTraitInstance */:return JaktInternal::ExplicitValue(true);
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-})){
+case 26 /* Trait */:case 22 /* GenericTraitInstance */:return true;default:return false;}/*switch end*/
+ 
+}()){
 this->error_with_hint(__jakt_format(StringView::from_string_literal("Invalid use of trait in parameter type ‘{}’"sv),TRY((this->type_name(type_id,false)))),param.variable->type_span.value_or_lazy_evaluated([&] { return param.variable->definition_span; }),ByteString::from_utf8_without_validation("Parameter type must either be a concrete type, or be explicitly generic"sv),param.variable->type_span.value_or_lazy_evaluated([&] { return param.variable->definition_span; }));
 }
 if (this->get_type(type_id)->__jakt_init_index() == 16 /* Unknown */){
@@ -7221,7 +6712,7 @@ if (parsed_function.params.size() < static_cast<size_t>(1ULL)){
 this->error(ByteString::from_utf8_without_validation("raw_constructor class must take at least `this'"sv),parsed_function.name_span);
 return {};
 }
-Jakt::parser::ParsedParameter const this_param = parsed_function.params.operator[](static_cast<i64>(0LL));
+Jakt::parser::ParsedParameter const this_param = parsed_function.params[static_cast<i64>(0LL)];
 if ([](ByteString const& self, ByteString rhs) -> bool {{
 return !(self == rhs);
 }
@@ -7357,16 +6848,14 @@ if (rhs.impl->equals(lhs.impl)){
 return true;
 }
 NonnullRefPtr<Jakt::interpreter::Interpreter> const interpreter = this->interpreter();
-this->error(__jakt_format(StringView::from_string_literal("Literal type value mismatch: expected '{}', found '{}'"sv),TRY((Jakt::types::comptime_format_impl(ByteString::from_utf8_without_validation("{}"sv),DynamicArray<Jakt::types::Value>::create_with({lhs}).operator[](JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}),this->program))),TRY((Jakt::types::comptime_format_impl(ByteString::from_utf8_without_validation("{}"sv),DynamicArray<Jakt::types::Value>::create_with({rhs}).operator[](JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}),this->program)))),span);
+this->error(__jakt_format(StringView::from_string_literal("Literal type value mismatch: expected '{}', found '{}'"sv),TRY((Jakt::types::comptime_format_impl(ByteString::from_utf8_without_validation("{}"sv),DynamicArray<Jakt::types::Value>::create_with({lhs})[JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}],this->program))),TRY((Jakt::types::comptime_format_impl(ByteString::from_utf8_without_validation("{}"sv),DynamicArray<Jakt::types::Value>::create_with({rhs})[JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}],this->program)))),span);
 return false;
 }
 }
 Jakt::ids::StructId const optional_struct_id = TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv))));
 Jakt::ids::StructId const weakptr_struct_id = TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("WeakPtr"sv))));
 Jakt::ids::StructId const array_struct_id = TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("Array"sv))));
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<bool>>{
-auto&& __jakt_match_variant = *lhs_type;
+{auto&& __jakt_match_variant = *lhs_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 18 /* TypeVariable */:{
 JaktInternal::Optional<Jakt::ids::TypeId> const maybe_resolved_inference = generic_inferences.get(lhs_type_id);
@@ -7380,8 +6869,7 @@ generic_inferences.set(lhs_type_id,rhs_type_id);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-case 19 /* Dependent */: {
+goto __jakt_label_124;case 19 /* Dependent */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dependent;Jakt::ids::TypeId const& namespace_type = __jakt_match_value.namespace_type;
 ByteString const& name = __jakt_match_value.name;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -7413,7 +6901,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (!TRY((this->check_types_for_compat(args.operator[](i),rhs_args.operator[](i),generic_inferences,span)))){
+if (!TRY((this->check_types_for_compat(args[i],rhs_args[i],generic_inferences,span)))){
 return false;
 }
 }
@@ -7423,8 +6911,7 @@ return false;
 
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_124;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& lhs_enum_id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& lhs_args = __jakt_match_value.args;
@@ -7438,7 +6925,7 @@ Jakt::types::CheckedEnum const lhs_enum = this->get_enum(lhs_enum_id);
 if (lhs_args.size() == rhs_args.size()){
 size_t idx = static_cast<size_t>(0ULL);
 while (idx < lhs_args.size()){
-if (!TRY((this->check_types_for_compat(lhs_args.operator[](idx),rhs_args.operator[](idx),generic_inferences,span)))){
+if (!TRY((this->check_types_for_compat(lhs_args[idx],rhs_args[idx],generic_inferences,span)))){
 return false;
 }
 ++idx;
@@ -7459,8 +6946,7 @@ return false;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_124;};/*case end*/
 case 29 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& lhs_params = __jakt_match_value.params;
 bool const& lhs_can_throw = __jakt_match_value.can_throw;
@@ -7472,27 +6958,13 @@ JaktInternal::DynamicArray<Jakt::ids::TypeId> const rhs_params = __jakt_tmp130->
 bool const rhs_can_throw = __jakt_tmp130->as.Function.can_throw;
 Jakt::ids::TypeId const rhs_return_type_id = __jakt_tmp130->as.Function.return_type_id;
 if (!(lhs_can_throw == rhs_can_throw)){
-ByteString const lhs_throw = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<bool>> {
-auto __jakt_enum_value = (lhs_can_throw);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Yes"sv));
-}else {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("No"sv));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-ByteString const rhs_throw = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<bool>> {
-auto __jakt_enum_value = (rhs_can_throw);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Yes"sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("No"sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ByteString const lhs_throw = [&]() -> ByteString { auto __jakt_enum_value = lhs_can_throw;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation("Yes"sv);}else {return ByteString::from_utf8_without_validation("No"sv);} 
+}();
+ByteString const rhs_throw = [&]() -> ByteString { auto __jakt_enum_value = rhs_can_throw;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation("Yes"sv);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation("No"sv);}VERIFY_NOT_REACHED();
+ 
+}();
 this->error(__jakt_format(StringView::from_string_literal("Function can throw mismatch: expected ‘{}’, but got ‘{}’"sv),lhs_throw,rhs_throw),span);
 }
 if (!(lhs_params.size() == rhs_params.size())){
@@ -7512,8 +6984,8 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (!TRY((this->check_types_for_compat(lhs_params.operator[](i),rhs_params.operator[](i),generic_inferences,span)))){
-this->error_with_hint(__jakt_format(StringView::from_string_literal("Function type mismatch: expected ‘{}’, but got ‘{}’"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("The parameter types differ at argument {}: expected ‘{}’, but got ‘{}’"sv),JaktInternal::checked_add(i,static_cast<size_t>(1ULL)),TRY((this->type_name(lhs_params.operator[](i),false))),TRY((this->type_name(rhs_params.operator[](i),false)))),span);
+if (!TRY((this->check_types_for_compat(lhs_params[i],rhs_params[i],generic_inferences,span)))){
+this->error_with_hint(__jakt_format(StringView::from_string_literal("Function type mismatch: expected ‘{}’, but got ‘{}’"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("The parameter types differ at argument {}: expected ‘{}’, but got ‘{}’"sv),JaktInternal::checked_add(i,static_cast<size_t>(1ULL)),TRY((this->type_name(lhs_params[i],false))),TRY((this->type_name(rhs_params[i],false)))),span);
 return false;
 }
 }
@@ -7528,8 +7000,7 @@ return false;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_124;};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -7538,7 +7009,7 @@ Jakt::ids::StructId const lhs_struct_id = id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> lhs_args = args;
 if (lhs_struct_id.equals(optional_struct_id) || lhs_struct_id.equals(weakptr_struct_id)){
 if (lhs_args.size() > static_cast<size_t>(0ULL)){
-Jakt::ids::TypeId const inner_lhs_type_id = lhs_args.operator[](static_cast<i64>(0LL));
+Jakt::ids::TypeId const inner_lhs_type_id = lhs_args[static_cast<i64>(0LL)];
 if (inner_lhs_type_id.equals(rhs_type_id) || this->is_subclass_of(inner_lhs_type_id,rhs_type_id)){
 return true;
 }
@@ -7556,19 +7027,19 @@ JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::i
 if (__jakt_tmp132.has_value()){
 JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>> const defaults = __jakt_tmp132.value();
 if (lhs_args.size() < defaults.size()){
-JaktInternal::DynamicArray<Jakt::ids::TypeId> new_args = lhs_args.operator[](JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}).to_array();
+JaktInternal::DynamicArray<Jakt::ids::TypeId> new_args = lhs_args[JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}].to_array();
 size_t idx = lhs_args.size();
-while ((idx < defaults.size()) && defaults.operator[](idx).has_value()){
-new_args.push(defaults.operator[](idx).value());
+while ((idx < defaults.size()) && defaults[idx].has_value()){
+new_args.push(defaults[idx].value());
 ++idx;
 }
 lhs_args = new_args;
 }
 if (rhs_args.size() < defaults.size()){
-JaktInternal::DynamicArray<Jakt::ids::TypeId> new_args = rhs_args.operator[](JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}).to_array();
+JaktInternal::DynamicArray<Jakt::ids::TypeId> new_args = rhs_args[JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}].to_array();
 size_t idx = rhs_args.size();
-while ((idx < defaults.size()) && defaults.operator[](idx).has_value()){
-new_args.push(defaults.operator[](idx).value());
+while ((idx < defaults.size()) && defaults[idx].has_value()){
+new_args.push(defaults[idx].value());
 ++idx;
 }
 rhs_args = new_args;
@@ -7577,7 +7048,7 @@ rhs_args = new_args;
 if (lhs_args.size() == rhs_args.size()){
 size_t idx = static_cast<size_t>(0ULL);
 while (idx < args.size()){
-if (!TRY((this->check_types_for_compat(lhs_args.operator[](idx),rhs_args.operator[](idx),generic_inferences,span)))){
+if (!TRY((this->check_types_for_compat(lhs_args[idx],rhs_args[idx],generic_inferences,span)))){
 return false;
 }
 ++idx;
@@ -7590,7 +7061,7 @@ return false;
 
 }
 else if (lhs_struct_id.equals(array_struct_id)){
-Jakt::ids::TypeId const array_value_type_id = args.operator[](static_cast<i64>(0LL));
+Jakt::ids::TypeId const array_value_type_id = args[static_cast<i64>(0LL)];
 if (array_value_type_id.equals(Jakt::types::unknown_type_id())){
 return true;
 }
@@ -7611,17 +7082,14 @@ return false;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_124;};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
 {
 if (lhs_type_id.equals(rhs_type_id)){
 return true;
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<bool>>{
-auto&& __jakt_match_variant = *rhs_type;
+{auto&& __jakt_match_variant = *rhs_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
@@ -7635,15 +7103,14 @@ return false;
 }
 size_t idx = static_cast<size_t>(0ULL);
 while (idx < args.size()){
-if (!TRY((this->check_types_for_compat(lhs_enum.generic_parameters.operator[](idx).type_id,args.operator[](idx),generic_inferences,span)))){
+if (!TRY((this->check_types_for_compat(lhs_enum.generic_parameters[idx].type_id,args[idx],generic_inferences,span)))){
 return false;
 }
 ++idx;
 }
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_125;};/*case end*/
 case 18 /* TypeVariable */:{
 JaktInternal::Optional<Jakt::ids::TypeId> const maybe_seen_type_id = generic_inferences.get(rhs_type_id);
 if (maybe_seen_type_id.has_value()){
@@ -7661,33 +7128,23 @@ generic_inferences.set(lhs_type_id,rhs_type_id);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_125;default:{
 if (!rhs_type_id.equals(lhs_type_id)){
 this->error(__jakt_format(StringView::from_string_literal("Type mismatch: expected ‘{}’, but got ‘{}’"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span);
 return false;
 }
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_125;}/*switch end*/
+}goto __jakt_label_125; __jakt_label_125:;;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_124;};/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& lhs_struct_id = __jakt_match_value.value;
 {
 if (lhs_type_id.equals(rhs_type_id)){
 return true;
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<bool>>{
-auto&& __jakt_match_variant = *rhs_type;
+{auto&& __jakt_match_variant = *rhs_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
@@ -7704,14 +7161,13 @@ return false;
 }
 size_t idx = static_cast<size_t>(0ULL);
 while (idx < args.size()){
-if (!TRY((this->check_types_for_compat(lhs_struct.generic_parameters.operator[](idx).type_id,args.operator[](idx),generic_inferences,span)))){
+if (!TRY((this->check_types_for_compat(lhs_struct.generic_parameters[idx].type_id,args[idx],generic_inferences,span)))){
 return false;
 }
 ++idx;
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_126;};/*case end*/
 case 18 /* TypeVariable */:{
 JaktInternal::Optional<Jakt::ids::TypeId> const seen_type_id = generic_inferences.get(rhs_type_id);
 if (seen_type_id.has_value()){
@@ -7729,8 +7185,7 @@ generic_inferences.set(lhs_type_id,rhs_type_id);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_126;default:{
 if (this->is_subclass_of(lhs_type_id,rhs_type_id)){
 return true;
 }
@@ -7739,17 +7194,10 @@ this->error(__jakt_format(StringView::from_string_literal("Type mismatch: expect
 return false;
 }
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_126;}/*switch end*/
+}goto __jakt_label_126; __jakt_label_126:;;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_124;};/*case end*/
 case 25 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;Jakt::ids::TypeId const& lhs_rawptr_type_id = __jakt_match_value.value;
 {
@@ -7771,8 +7219,7 @@ return false;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_124;};/*case end*/
 case 27 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;Jakt::ids::TypeId const& lhs_inner_type_id = __jakt_match_value.value;
 {
@@ -7789,8 +7236,7 @@ return false;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_124;};/*case end*/
 case 28 /* MutableReference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MutableReference;Jakt::ids::TypeId const& lhs_inner_type_id = __jakt_match_value.value;
 {
@@ -7807,8 +7253,7 @@ return false;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_124;};/*case end*/
 default:{
 if ([](Jakt::ids::TypeId const& self, Jakt::ids::TypeId rhs) -> bool {{
 return !self.equals(rhs);
@@ -7819,14 +7264,8 @@ this->error(__jakt_format(StringView::from_string_literal("Type mismatch: expect
 return false;
 }
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_124;}/*switch end*/
+}goto __jakt_label_124; __jakt_label_124:;;
 return true;
 }
 }
@@ -7899,69 +7338,33 @@ this->error(ByteString::from_utf8_without_validation("Unreachable code"sv),parse
 }
 NonnullRefPtr<typename Jakt::types::CheckedStatement> const checked_statement = TRY((this->typecheck_statement(parsed_statement,block_scope_id,safety_mode,yield_type_hint)));
 this->current_block.control_flow = this->current_block.control_flow.updated(checked_statement->control_flow());
-JaktInternal::Optional<Jakt::utility::Span> const yield_span = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::utility::Span>, ErrorOr<Jakt::types::CheckedBlock>>{
-auto&& __jakt_match_variant = *parsed_statement;
+JaktInternal::Optional<Jakt::utility::Span> const yield_span = [&]() -> JaktInternal::Optional<Jakt::utility::Span> { auto&& __jakt_match_variant = *parsed_statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 14 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::utility::Span>,ErrorOr<Jakt::types::CheckedBlock>> {
-auto __jakt_enum_value = (expr.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(expr.value()->span());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}));
-};/*case end*/
+{auto __jakt_enum_value = expr.has_value();
+if (__jakt_enum_value) {return expr.value()->span();}else if (!__jakt_enum_value) {return JaktInternal::OptionalNone();}VERIFY_NOT_REACHED();
+}};/*case end*/
 case 16 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<Jakt::utility::Span>>(expr->span()));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+return static_cast<JaktInternal::Optional<Jakt::utility::Span>>(expr->span());};/*case end*/
+default:return JaktInternal::OptionalNone();}/*switch end*/
+ 
+}();
 bool yield_present = false;
-JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const checked_yield_expression = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>>, ErrorOr<Jakt::types::CheckedBlock>>{
-auto&& __jakt_match_variant = *checked_statement;
+JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const checked_yield_expression = [&]() -> JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> { auto&& __jakt_match_variant = *checked_statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& expr = __jakt_match_value.expr;
 {
 yield_present = true;
-return JaktInternal::ExplicitValue<JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>(expr);
+return expr;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+default:return JaktInternal::OptionalNone();}/*switch end*/
+ 
+}();
 if (yield_present){
 if (yield_span.has_value() && checked_yield_expression.has_value()){
 Jakt::ids::TypeId const type_var_type_id = checked_yield_expression.value()->type();
@@ -8176,8 +7579,8 @@ return this->with_qualifiers(this->typecheck_type_qualifiers(parsed_type->common
 }
 }
 return JaktInternal::ExplicitValue<Jakt::ids::TypeId>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId,ErrorOr<Jakt::ids::TypeId>> {
-auto __jakt_enum_value = (name);
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId, ErrorOr<Jakt::ids::TypeId>>{
+auto __jakt_enum_value = name;
 if (__jakt_enum_value == ByteString::from_utf8_without_validation("i8"sv)) {return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::I8()));
 }else if (__jakt_enum_value == ByteString::from_utf8_without_validation("i16"sv)) {return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::I16()));
 }else if (__jakt_enum_value == ByteString::from_utf8_without_validation("i32"sv)) {return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::I32()));
@@ -8205,7 +7608,8 @@ this->error(__jakt_format(StringView::from_string_literal("Unknown type ‘{}’
 return JaktInternal::ExplicitValue<Jakt::ids::TypeId>(Jakt::types::unknown_type_id());
 }
 VERIFY_NOT_REACHED();
-}}());
+}}()
+);
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
@@ -8339,19 +7743,12 @@ bool const& can_throw = __jakt_match_value.can_throw;
 NonnullRefPtr<typename Jakt::parser::ParsedType> const& return_type = __jakt_match_value.return_type;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
-ByteString const function_name = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<Jakt::ids::TypeId>> {
-auto __jakt_enum_value = (name.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(name.value());
-}else {return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_69;
+ByteString const function_name = [&]() -> ByteString { auto __jakt_enum_value = name.has_value();
+if (__jakt_enum_value) {return name.value();}else {return ({ Optional<ByteString> __jakt_var_69;
 auto __jakt_var_70 = [&]() -> ErrorOr<ByteString> { return __jakt_format(StringView::from_string_literal("lambda{}"sv),this->lambda_count++); }();
 if (!__jakt_var_70.is_error()) __jakt_var_69 = __jakt_var_70.release_value();
-__jakt_var_69; }).value_or_lazy_evaluated([&] { return ByteString::from_utf8_without_validation(""sv); }));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+__jakt_var_69; }).value_or_lazy_evaluated([&] { return ByteString::from_utf8_without_validation(""sv); });} 
+}();
 JaktInternal::DynamicArray<Jakt::types::CheckedParameter> checked_params = DynamicArray<Jakt::types::CheckedParameter>::create_with({});
 bool first = true;
 JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> const old_generic_inferences = this->generic_inferences.perform_checkpoint(false);
@@ -8442,7 +7839,7 @@ NonnullRefPtr<Jakt::types::Scope> const scope = this->get_scope(mixin.scope_id);
 if (!scope->explicitly_specialized_types.contains(name)){
 return Jakt::utility::IterationDecision<bool>::Continue();
 }
-Jakt::types::SpecializedType const specialized_type = scope->explicitly_specialized_types.operator[](name);
+Jakt::types::SpecializedType const specialized_type = scope->explicitly_specialized_types[name];
 JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> const checkpoint = this->generic_inferences.perform_checkpoint(false);
 ScopeGuard __jakt_var_72([&] {
 this->generic_inferences.restore(checkpoint);
@@ -8460,8 +7857,8 @@ size_t i = _magic_value.value();
 if (arguments.size() <= i){
 break;
 }
-Jakt::ids::TypeId const given_arg = arguments.operator[](i);
-Jakt::ids::TypeId const specialized_arg = specialized_type.arguments.operator[](i);
+Jakt::ids::TypeId const given_arg = arguments[i];
+Jakt::ids::TypeId const specialized_arg = specialized_type.arguments[i];
 JaktInternal::Tuple<bool,bool> const snapshot = this->enter_ignore_error_mode(true);
 ScopeGuard __jakt_var_73([&] {
 this->exit_ignore_error_mode(snapshot);
@@ -8540,7 +7937,7 @@ return Jakt::types::StructLikeId::from_type_id(explicitly_specialized_type.value
 JaktInternal::Optional<Jakt::ids::StructId> const struct_id = TRY((this->find_struct_in_scope(scope_id,name,JaktInternal::OptionalNone())));
 if (struct_id.has_value()){
 Jakt::types::CheckedStruct const struct_ = this->get_struct(struct_id.value());
-JaktInternal::DynamicArray<Jakt::ids::TypeId> effective_inner_types = checked_inner_types.operator[](JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}).to_array();
+JaktInternal::DynamicArray<Jakt::ids::TypeId> effective_inner_types = checked_inner_types[JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}].to_array();
 JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>> __jakt_tmp141 = struct_.generic_parameter_defaults;
 if (__jakt_tmp141.has_value()){
 JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>> const defaults = __jakt_tmp141.value();
@@ -8557,7 +7954,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-JaktInternal::Optional<Jakt::ids::TypeId> __jakt_tmp142 = defaults.operator[](i);
+JaktInternal::Optional<Jakt::ids::TypeId> __jakt_tmp142 = defaults[i];
 if (__jakt_tmp142.has_value()){
 Jakt::ids::TypeId const default_ = __jakt_tmp142.value();
 effective_inner_types.push(default_);
@@ -8591,9 +7988,7 @@ ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>> Jakt::typechecke
 {
 Jakt::ids::TypeId const expr_type_id = checked_expr->type();
 NonnullRefPtr<typename Jakt::types::Type> const expr_type = this->get_type(expr_type_id);
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = checked_op;
+{auto&& __jakt_match_variant = checked_op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* PreIncrement */:case 1 /* PostIncrement */:case 2 /* PreDecrement */:case 3 /* PostDecrement */:{
 if (this->is_integer(expr_type_id)){
@@ -8606,56 +8001,44 @@ this->error(ByteString::from_utf8_without_validation("Increment/decrement of non
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-case 9 /* LogicalNot */:{
+goto __jakt_label_127;case 9 /* LogicalNot */:{
 if (!TRY((this->check_types_for_compat(Jakt::types::builtin(Jakt::types::BuiltinType::Bool()),checked_expr->type(),this->generic_inferences,span)))){
 this->error(ByteString::from_utf8_without_validation("Cannot use a logical Not on a value of non-boolean type"sv),span);
 }
 return Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,expr_type_id);
 }
-return JaktInternal::ExplicitValue<void>();
-case 10 /* BitwiseNot */:{
+goto __jakt_label_127;case 10 /* BitwiseNot */:{
 return Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,expr_type_id);
 }
-return JaktInternal::ExplicitValue<void>();
-case 11 /* TypeCast */: {
+goto __jakt_label_127;case 11 /* TypeCast */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeCast;Jakt::types::CheckedTypeCast const& cast = __jakt_match_value.value;
 {
 return Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,cast.type_id());
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_127;};/*case end*/
 case 4 /* Negate */:{
 return this->typecheck_unary_negate(checked_expr,span,expr_type_id);
 }
-return JaktInternal::ExplicitValue<void>();
-case 12 /* Is */:case 13 /* IsEnumVariant */:case 14 /* IsSome */:case 15 /* IsNone */:{
+goto __jakt_label_127;case 12 /* Is */:case 13 /* IsEnumVariant */:case 14 /* IsSome */:case 15 /* IsNone */:{
 return Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,Jakt::types::builtin(Jakt::types::BuiltinType::Bool()));
 }
-return JaktInternal::ExplicitValue<void>();
-case 16 /* Sizeof */:{
+goto __jakt_label_127;case 16 /* Sizeof */:{
 return Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,Jakt::types::builtin(Jakt::types::BuiltinType::Usize()));
 }
-return JaktInternal::ExplicitValue<void>();
-case 6 /* RawAddress */:{
+goto __jakt_label_127;case 6 /* RawAddress */:{
 return Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,this->find_or_add_type_id(Jakt::types::Type::RawPtr(Jakt::parser::CheckedQualifiers(false),expr_type_id)));
 }
-return JaktInternal::ExplicitValue<void>();
-case 7 /* Reference */:{
+goto __jakt_label_127;case 7 /* Reference */:{
 return Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,this->find_or_add_type_id(Jakt::types::Type::Reference(Jakt::parser::CheckedQualifiers(false),expr_type_id)));
 }
-return JaktInternal::ExplicitValue<void>();
-case 8 /* MutableReference */:{
+goto __jakt_label_127;case 8 /* MutableReference */:{
 if (!checked_expr->is_mutable(this->program)){
 this->error(ByteString::from_utf8_without_validation("Cannot make mutable reference to immutable value"sv),span);
 }
 return Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,this->find_or_add_type_id(Jakt::types::Type::MutableReference(Jakt::parser::CheckedQualifiers(false),expr_type_id)));
 }
-return JaktInternal::ExplicitValue<void>();
-case 5 /* Dereference */:{
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *expr_type;
+goto __jakt_label_127;case 5 /* Dereference */:{
+{auto&& __jakt_match_variant = *expr_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 25 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
@@ -8665,42 +8048,27 @@ this->error(ByteString::from_utf8_without_validation("Dereference of raw pointer
 }
 return Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,type_id);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_128;};/*case end*/
 case 27 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
 {
 return Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,type_id);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_128;};/*case end*/
 case 28 /* MutableReference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MutableReference;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
 {
 return Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,type_id);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_128;};/*case end*/
 default:{
 this->error(__jakt_format(StringView::from_string_literal("Dereference of a non-pointer type ‘{}’"sv),TRY((this->type_name(expr_type_id,false)))),span);
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_128;}/*switch end*/
+}goto __jakt_label_128; __jakt_label_128:;;
 }
-return JaktInternal::ExplicitValue<void>();
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_127;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_127; __jakt_label_127:;;
 return Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,expr_type_id);
 }
 }
@@ -8744,24 +8112,14 @@ if ((raw_number > JaktInternal::checked_add(max_signed,static_cast<size_t>(1ULL)
 this->error(__jakt_format(StringView::from_string_literal("Negative literal -{} too small for type ‘{}’"sv),raw_number,TRY((this->type_name(flipped_sign_type,false)))),span);
 return Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),expr,Jakt::types::CheckedUnaryOperator::Negate(),span,type_id);
 }
-Jakt::types::CheckedNumericConstant const new_constant = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::CheckedNumericConstant, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *this->get_type(flipped_sign_type);
+Jakt::types::CheckedNumericConstant const new_constant = [&]() -> Jakt::types::CheckedNumericConstant { auto&& __jakt_match_variant = *this->get_type(flipped_sign_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 6 /* I8 */:return JaktInternal::ExplicitValue(Jakt::types::CheckedNumericConstant::I8(infallible_integer_cast<i8>(negated_number)));
-case 7 /* I16 */:return JaktInternal::ExplicitValue(Jakt::types::CheckedNumericConstant::I16(infallible_integer_cast<i16>(negated_number)));
-case 8 /* I32 */:return JaktInternal::ExplicitValue(Jakt::types::CheckedNumericConstant::I32(infallible_integer_cast<i32>(negated_number)));
-case 9 /* I64 */:return JaktInternal::ExplicitValue(Jakt::types::CheckedNumericConstant::I64(static_cast<i64>(negated_number)));
-default:{
+case 6 /* I8 */:return Jakt::types::CheckedNumericConstant::I8(infallible_integer_cast<i8>(negated_number));case 7 /* I16 */:return Jakt::types::CheckedNumericConstant::I16(infallible_integer_cast<i16>(negated_number));case 8 /* I32 */:return Jakt::types::CheckedNumericConstant::I32(infallible_integer_cast<i32>(negated_number));case 9 /* I64 */:return Jakt::types::CheckedNumericConstant::I64(static_cast<i64>(negated_number));default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Unreachable"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 return Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),new_constant,span,type_id),Jakt::types::CheckedUnaryOperator::Negate(),span,flipped_sign_type);
 }
 }
@@ -8775,16 +8133,14 @@ Jakt::utility::Span const rhs_span = checked_rhs->span();
 Jakt::ids::TypeId type_id = checked_lhs->type();
 NonnullRefPtr<Jakt::types::Scope> const scope = this->get_scope(scope_id);
 Jakt::types::CheckedBinaryOperator checked_operator = Jakt::types::CheckedBinaryOperator(op,JaktInternal::OptionalNone());
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Tuple<Jakt::types::CheckedBinaryOperator,Jakt::ids::TypeId>>>{
-auto&& __jakt_match_variant = op;
+{auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* NoneCoalescing */:case 32 /* NoneCoalescingAssign */:{
 if (op.__jakt_init_index() == 32 /* NoneCoalescingAssign */){
-NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp145 = checked_lhs;
-if (__jakt_tmp145->__jakt_init_index() == 24 /* Var */){
-NonnullRefPtr<Jakt::types::CheckedVariable> const var = __jakt_tmp145->as.Var.var;
-Jakt::utility::Span const span = __jakt_tmp145->as.Var.span;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp143 = checked_lhs;
+if (__jakt_tmp143->__jakt_init_index() == 24 /* Var */){
+NonnullRefPtr<Jakt::types::CheckedVariable> const var = __jakt_tmp143->as.Var.var;
+Jakt::utility::Span const span = __jakt_tmp143->as.Var.span;
 if (!var->is_mutable){
 this->error_with_hint(ByteString::from_utf8_without_validation("left-hand side of ??= must be a mutable variable"sv),span,ByteString::from_utf8_without_validation("This variable isn't marked as mutable"sv),var->definition_span);
 return Tuple{checked_operator, Jakt::types::unknown_type_id()};
@@ -8796,15 +8152,15 @@ return Tuple{checked_operator, Jakt::types::unknown_type_id()};
 }
 
 }
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp146 = this->get_type(lhs_type_id);
-if (__jakt_tmp146->__jakt_init_index() == 20 /* GenericInstance */){
-Jakt::ids::StructId const id = __jakt_tmp146->as.GenericInstance.id;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp146->as.GenericInstance.args;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp144 = this->get_type(lhs_type_id);
+if (__jakt_tmp144->__jakt_init_index() == 20 /* GenericInstance */){
+Jakt::ids::StructId const id = __jakt_tmp144->as.GenericInstance.id;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp144->as.GenericInstance.args;
 if (id.equals(TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv)))))){
 if (lhs_type_id.equals(rhs_type_id)){
 return Tuple{checked_operator, lhs_type_id};
 }
-Jakt::ids::TypeId const inner_type_id = args.operator[](static_cast<i64>(0LL));
+Jakt::ids::TypeId const inner_type_id = args[static_cast<i64>(0LL)];
 if (inner_type_id.equals(rhs_type_id)){
 return Tuple{checked_operator, inner_type_id};
 }
@@ -8821,8 +8177,7 @@ this->error_with_hint(__jakt_format(StringView::from_string_literal("None coales
 this->error(__jakt_format(StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span);
 return Tuple{checked_operator, lhs_type_id};
 }
-return JaktInternal::ExplicitValue<void>();
-case 18 /* LogicalAnd */:case 19 /* LogicalOr */:{
+goto __jakt_label_129;case 18 /* LogicalAnd */:case 19 /* LogicalOr */:{
 if (!lhs_type_id.equals(Jakt::types::builtin(Jakt::types::BuiltinType::Bool()))){
 this->error(ByteString::from_utf8_without_validation("left side of logical binary operation is not a boolean"sv),lhs_span);
 }
@@ -8831,20 +8186,19 @@ this->error(ByteString::from_utf8_without_validation("right side of logical bina
 }
 type_id = Jakt::types::builtin(Jakt::types::BuiltinType::Bool());
 }
-return JaktInternal::ExplicitValue<void>();
-case 21 /* Assign */:{
+goto __jakt_label_129;case 21 /* Assign */:{
 if (!checked_lhs->is_mutable(this->program)){
 this->error(ByteString::from_utf8_without_validation("Assignment to immutable variable"sv),checked_lhs->span());
 return Tuple{checked_operator, lhs_type_id};
 }
-NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp147 = checked_rhs;
-if (__jakt_tmp147->__jakt_init_index() == 25 /* OptionalNone */){
-Jakt::utility::Span const span = __jakt_tmp147->as.OptionalNone.span;
-Jakt::ids::TypeId const type_id = __jakt_tmp147->as.OptionalNone.type_id;
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp148 = this->get_type(lhs_type_id);
-if (__jakt_tmp148->__jakt_init_index() == 20 /* GenericInstance */){
-Jakt::ids::StructId const id = __jakt_tmp148->as.GenericInstance.id;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp148->as.GenericInstance.args;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp145 = checked_rhs;
+if (__jakt_tmp145->__jakt_init_index() == 25 /* OptionalNone */){
+Jakt::utility::Span const span = __jakt_tmp145->as.OptionalNone.span;
+Jakt::ids::TypeId const type_id = __jakt_tmp145->as.OptionalNone.type_id;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp146 = this->get_type(lhs_type_id);
+if (__jakt_tmp146->__jakt_init_index() == 20 /* GenericInstance */){
+Jakt::ids::StructId const id = __jakt_tmp146->as.GenericInstance.id;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp146->as.GenericInstance.args;
 if (id.equals(TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv)))))){
 return Tuple{checked_operator, lhs_type_id};
 }
@@ -8858,12 +8212,12 @@ this->error(ByteString::from_utf8_without_validation("Cannot assign None to a no
 
 }
 NonnullRefPtr<typename Jakt::types::Type> const lhs_type = TRY((this->unwrap_type_from_optional_if_needed(this->get_type(lhs_type_id))));
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp149 = lhs_type;
-if (__jakt_tmp149->__jakt_init_index() == 20 /* GenericInstance */){
-Jakt::ids::StructId const id = __jakt_tmp149->as.GenericInstance.id;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp149->as.GenericInstance.args;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp147 = lhs_type;
+if (__jakt_tmp147->__jakt_init_index() == 20 /* GenericInstance */){
+Jakt::ids::StructId const id = __jakt_tmp147->as.GenericInstance.id;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp147->as.GenericInstance.args;
 if ((this->program->get_struct(id).name == ByteString::from_utf8_without_validation("WeakPtr"sv)) && (!lhs_type_id.equals(rhs_type_id))){
-JaktInternal::Optional<Jakt::ids::TypeId> const unified_type = TRY((this->unify(args.operator[](static_cast<i64>(0LL)),lhs_span,checked_rhs->type(),rhs_span)));
+JaktInternal::Optional<Jakt::ids::TypeId> const unified_type = TRY((this->unify(args[static_cast<i64>(0LL)],lhs_span,checked_rhs->type(),rhs_span)));
 if (unified_type.has_value()){
 return Tuple{checked_operator, unified_type.value()};
 }
@@ -8881,78 +8235,25 @@ this->error(__jakt_format(StringView::from_string_literal("Assignment between in
 }
 return Tuple{checked_operator, result.value_or(lhs_type_id)};
 }
-return JaktInternal::ExplicitValue<void>();
-case 27 /* AddAssign */:case 28 /* SubtractAssign */:case 29 /* MultiplyAssign */:case 31 /* DivideAssign */:case 30 /* ModuloAssign */:case 22 /* BitwiseAndAssign */:case 23 /* BitwiseOrAssign */:case 24 /* BitwiseXorAssign */:case 25 /* BitwiseLeftShiftAssign */:case 26 /* BitwiseRightShiftAssign */:case 0 /* Add */:case 1 /* Subtract */:case 2 /* Multiply */:case 3 /* Divide */:case 4 /* Modulo */:case 5 /* LessThan */:case 6 /* LessThanOrEqual */:case 7 /* GreaterThan */:case 8 /* GreaterThanOrEqual */:case 9 /* Equal */:case 10 /* NotEqual */:{
+goto __jakt_label_129;case 27 /* AddAssign */:case 28 /* SubtractAssign */:case 29 /* MultiplyAssign */:case 31 /* DivideAssign */:case 30 /* ModuloAssign */:case 22 /* BitwiseAndAssign */:case 23 /* BitwiseOrAssign */:case 24 /* BitwiseXorAssign */:case 25 /* BitwiseLeftShiftAssign */:case 26 /* BitwiseRightShiftAssign */:case 0 /* Add */:case 1 /* Subtract */:case 2 /* Multiply */:case 3 /* Divide */:case 4 /* Modulo */:case 5 /* LessThan */:case 6 /* LessThanOrEqual */:case 7 /* GreaterThan */:case 8 /* GreaterThanOrEqual */:case 9 /* Equal */:case 10 /* NotEqual */:{
 JaktInternal::DynamicArray<ByteString> const empty_array = DynamicArray<ByteString>::create_with({});
-JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_names_is_assignment_ = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool>, ErrorOr<JaktInternal::Tuple<Jakt::types::CheckedBinaryOperator,Jakt::ids::TypeId>>>{
-auto&& __jakt_match_variant = op;
+JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_names_is_assignment_ = [&]() -> JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> { auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Add */:return JaktInternal::ExplicitValue(Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("Add"sv), ByteString::from_utf8_without_validation("ThrowingAdd"sv)}), false});
-case 1 /* Subtract */:return JaktInternal::ExplicitValue(Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("Subtract"sv), ByteString::from_utf8_without_validation("ThrowingSubtract"sv)}), false});
-case 2 /* Multiply */:return JaktInternal::ExplicitValue(Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("Multiply"sv), ByteString::from_utf8_without_validation("ThrowingMultiply"sv)}), false});
-case 3 /* Divide */:return JaktInternal::ExplicitValue(Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("Divide"sv), ByteString::from_utf8_without_validation("ThrowingDivide"sv)}), false});
-case 4 /* Modulo */:return JaktInternal::ExplicitValue(Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("Modulo"sv), ByteString::from_utf8_without_validation("ThrowingModulo"sv)}), false});
-case 5 /* LessThan */:case 6 /* LessThanOrEqual */:case 7 /* GreaterThan */:case 8 /* GreaterThanOrEqual */:return JaktInternal::ExplicitValue(Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("Compare"sv), ByteString::from_utf8_without_validation("ThrowingCompare"sv)}), false});
-case 9 /* Equal */:case 10 /* NotEqual */:return JaktInternal::ExplicitValue(Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("Equal"sv), ByteString::from_utf8_without_validation("ThrowingEqual"sv)}), false});
-case 27 /* AddAssign */:return JaktInternal::ExplicitValue(Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("AddAssign"sv), ByteString::from_utf8_without_validation("ThrowingAddAssign"sv)}), true});
-case 28 /* SubtractAssign */:return JaktInternal::ExplicitValue(Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("SubtractAssign"sv), ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv)}), true});
-case 29 /* MultiplyAssign */:return JaktInternal::ExplicitValue(Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("MultiplyAssign"sv), ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv)}), true});
-case 31 /* DivideAssign */:return JaktInternal::ExplicitValue(Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("DivideAssign"sv), ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv)}), true});
-case 30 /* ModuloAssign */:return JaktInternal::ExplicitValue(Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("ModuloAssign"sv), ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv)}), true});
-case 22 /* BitwiseAndAssign */:return JaktInternal::ExplicitValue(Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("BitwiseAndAssign"sv), ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv)}), true});
-case 23 /* BitwiseOrAssign */:return JaktInternal::ExplicitValue(Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("BitwiseOrAssign"sv), ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv)}), true});
-case 24 /* BitwiseXorAssign */:return JaktInternal::ExplicitValue(Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("BitwiseXorAssign"sv), ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv)}), true});
-case 25 /* BitwiseLeftShiftAssign */:return JaktInternal::ExplicitValue(Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv), ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv)}), true});
-case 26 /* BitwiseRightShiftAssign */:return JaktInternal::ExplicitValue(Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv), ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv)}), true});
-default:return JaktInternal::ExplicitValue(Tuple{empty_array, false});
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 0 /* Add */:return Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("Add"sv), ByteString::from_utf8_without_validation("ThrowingAdd"sv)}), false};case 1 /* Subtract */:return Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("Subtract"sv), ByteString::from_utf8_without_validation("ThrowingSubtract"sv)}), false};case 2 /* Multiply */:return Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("Multiply"sv), ByteString::from_utf8_without_validation("ThrowingMultiply"sv)}), false};case 3 /* Divide */:return Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("Divide"sv), ByteString::from_utf8_without_validation("ThrowingDivide"sv)}), false};case 4 /* Modulo */:return Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("Modulo"sv), ByteString::from_utf8_without_validation("ThrowingModulo"sv)}), false};case 5 /* LessThan */:case 6 /* LessThanOrEqual */:case 7 /* GreaterThan */:case 8 /* GreaterThanOrEqual */:return Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("Compare"sv), ByteString::from_utf8_without_validation("ThrowingCompare"sv)}), false};case 9 /* Equal */:case 10 /* NotEqual */:return Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("Equal"sv), ByteString::from_utf8_without_validation("ThrowingEqual"sv)}), false};case 27 /* AddAssign */:return Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("AddAssign"sv), ByteString::from_utf8_without_validation("ThrowingAddAssign"sv)}), true};case 28 /* SubtractAssign */:return Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("SubtractAssign"sv), ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv)}), true};case 29 /* MultiplyAssign */:return Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("MultiplyAssign"sv), ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv)}), true};case 31 /* DivideAssign */:return Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("DivideAssign"sv), ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv)}), true};case 30 /* ModuloAssign */:return Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("ModuloAssign"sv), ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv)}), true};case 22 /* BitwiseAndAssign */:return Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("BitwiseAndAssign"sv), ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv)}), true};case 23 /* BitwiseOrAssign */:return Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("BitwiseOrAssign"sv), ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv)}), true};case 24 /* BitwiseXorAssign */:return Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("BitwiseXorAssign"sv), ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv)}), true};case 25 /* BitwiseLeftShiftAssign */:return Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv), ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv)}), true};case 26 /* BitwiseRightShiftAssign */:return Tuple{DynamicArray<ByteString>::create_with({ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv), ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv)}), true};default:return Tuple{empty_array, false};}/*switch end*/
+ 
+}();
 JaktInternal::DynamicArray<ByteString> const trait_names = trait_names_is_assignment_.template get<0>();
 bool const is_assignment = trait_names_is_assignment_.template get<1>();
 
-ByteString const function_name = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<JaktInternal::Tuple<Jakt::types::CheckedBinaryOperator,Jakt::ids::TypeId>>>{
-auto&& __jakt_match_variant = op;
+ByteString const function_name = [&]() -> ByteString { auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Add */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("add"sv));
-case 1 /* Subtract */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("subtract"sv));
-case 2 /* Multiply */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("multiply"sv));
-case 3 /* Divide */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("divide"sv));
-case 4 /* Modulo */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("modulo"sv));
-case 5 /* LessThan */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("less_than"sv));
-case 6 /* LessThanOrEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("less_than_or_equal"sv));
-case 7 /* GreaterThan */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("greater_than"sv));
-case 8 /* GreaterThanOrEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("greater_than_or_equal"sv));
-case 9 /* Equal */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("equals"sv));
-case 10 /* NotEqual */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("not_equals"sv));
-case 27 /* AddAssign */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("add_assign"sv));
-case 28 /* SubtractAssign */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("subtract_assign"sv));
-case 29 /* MultiplyAssign */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("multiply_assign"sv));
-case 31 /* DivideAssign */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("divide_assign"sv));
-case 30 /* ModuloAssign */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("modulo_assign"sv));
-case 22 /* BitwiseAndAssign */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("bitwise_and_assign"sv));
-case 23 /* BitwiseOrAssign */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("bitwise_or_assign"sv));
-case 24 /* BitwiseXorAssign */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("bitwise_xor_assign"sv));
-case 25 /* BitwiseLeftShiftAssign */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv));
-case 26 /* BitwiseRightShiftAssign */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv));
-default:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 0 /* Add */:return ByteString::from_utf8_without_validation("add"sv);case 1 /* Subtract */:return ByteString::from_utf8_without_validation("subtract"sv);case 2 /* Multiply */:return ByteString::from_utf8_without_validation("multiply"sv);case 3 /* Divide */:return ByteString::from_utf8_without_validation("divide"sv);case 4 /* Modulo */:return ByteString::from_utf8_without_validation("modulo"sv);case 5 /* LessThan */:return ByteString::from_utf8_without_validation("less_than"sv);case 6 /* LessThanOrEqual */:return ByteString::from_utf8_without_validation("less_than_or_equal"sv);case 7 /* GreaterThan */:return ByteString::from_utf8_without_validation("greater_than"sv);case 8 /* GreaterThanOrEqual */:return ByteString::from_utf8_without_validation("greater_than_or_equal"sv);case 9 /* Equal */:return ByteString::from_utf8_without_validation("equals"sv);case 10 /* NotEqual */:return ByteString::from_utf8_without_validation("not_equals"sv);case 27 /* AddAssign */:return ByteString::from_utf8_without_validation("add_assign"sv);case 28 /* SubtractAssign */:return ByteString::from_utf8_without_validation("subtract_assign"sv);case 29 /* MultiplyAssign */:return ByteString::from_utf8_without_validation("multiply_assign"sv);case 31 /* DivideAssign */:return ByteString::from_utf8_without_validation("divide_assign"sv);case 30 /* ModuloAssign */:return ByteString::from_utf8_without_validation("modulo_assign"sv);case 22 /* BitwiseAndAssign */:return ByteString::from_utf8_without_validation("bitwise_and_assign"sv);case 23 /* BitwiseOrAssign */:return ByteString::from_utf8_without_validation("bitwise_or_assign"sv);case 24 /* BitwiseXorAssign */:return ByteString::from_utf8_without_validation("bitwise_xor_assign"sv);case 25 /* BitwiseLeftShiftAssign */:return ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv);case 26 /* BitwiseRightShiftAssign */:return ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv);default:return ByteString::from_utf8_without_validation(""sv);}/*switch end*/
+ 
+}();
 JaktInternal::Optional<Jakt::typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((this->find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<Jakt::ids::TypeId>::create_with({rhs_type_id}))));
-JaktInternal::Optional<Jakt::typechecker::TraitImplementationDescriptor> __jakt_tmp290 = add_trait_implementation;
-if (__jakt_tmp290.has_value()){
-Jakt::typechecker::TraitImplementationDescriptor const implementation = __jakt_tmp290.value();
+JaktInternal::Optional<Jakt::typechecker::TraitImplementationDescriptor> __jakt_tmp148 = add_trait_implementation;
+if (__jakt_tmp148.has_value()){
+Jakt::typechecker::TraitImplementationDescriptor const implementation = __jakt_tmp148.value();
 if (implementation.trait_name.starts_with(ByteString::from_utf8_without_validation("Throwing"sv)) && (!scope->can_throw)){
 this->error(ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv),span);
 }
@@ -8983,190 +8284,165 @@ type_id = Jakt::types::unknown_type_id();
 
 }
 else if (!is_assignment){
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp292 = this->get_type(lhs_type_id);
-if (__jakt_tmp292->__jakt_init_index() == 25 /* RawPtr */){
-Jakt::ids::TypeId const lhs_deref_type_id = __jakt_tmp292->as.RawPtr.value;
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp291 = this->get_type(rhs_type_id);
-if (__jakt_tmp291->__jakt_init_index() == 25 /* RawPtr */){
-Jakt::ids::TypeId const rhs_deref_type_id = __jakt_tmp291->as.RawPtr.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp150 = this->get_type(lhs_type_id);
+if (__jakt_tmp150->__jakt_init_index() == 25 /* RawPtr */){
+Jakt::ids::TypeId const lhs_deref_type_id = __jakt_tmp150->as.RawPtr.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp149 = this->get_type(rhs_type_id);
+if (__jakt_tmp149->__jakt_init_index() == 25 /* RawPtr */){
+Jakt::ids::TypeId const rhs_deref_type_id = __jakt_tmp149->as.RawPtr.value;
 if (lhs_deref_type_id.equals(rhs_deref_type_id)){
 type_id = Jakt::types::builtin(Jakt::types::BuiltinType::Bool());
 }
 else {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp293 = this->get_type(lhs_type_id);
-if (__jakt_tmp293->__jakt_init_index() == 18 /* TypeVariable */){
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const trait_implementations = __jakt_tmp293->as.TypeVariable.trait_implementations;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp151 = this->get_type(lhs_type_id);
+if (__jakt_tmp151->__jakt_init_index() == 18 /* TypeVariable */){
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const trait_implementations = __jakt_tmp151->as.TypeVariable.trait_implementations;
 if (trait_implementations.is_empty()){
 }
 else {
-this->error_with_hint(__jakt_format(StringView::from_string_literal("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("Consider implementing ‘(Throwing){}<{}, ...>’ for the type of this expression (‘{}’)"sv),trait_names.operator[](static_cast<i64>(0LL)),TRY((this->type_name(rhs_type_id,false))),TRY((this->type_name(lhs_type_id,false)))),lhs_span);
+this->error_with_hint(__jakt_format(StringView::from_string_literal("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("Consider implementing ‘(Throwing){}<{}, ...>’ for the type of this expression (‘{}’)"sv),trait_names[static_cast<i64>(0LL)],TRY((this->type_name(rhs_type_id,false))),TRY((this->type_name(lhs_type_id,false)))),lhs_span);
 }
 
 }
 else {
-this->error_with_hint(__jakt_format(StringView::from_string_literal("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("Consider implementing ‘(Throwing){}<{}, ...>’ for the type of this expression (‘{}’)"sv),trait_names.operator[](static_cast<i64>(0LL)),TRY((this->type_name(rhs_type_id,false))),TRY((this->type_name(lhs_type_id,false)))),lhs_span);
+this->error_with_hint(__jakt_format(StringView::from_string_literal("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("Consider implementing ‘(Throwing){}<{}, ...>’ for the type of this expression (‘{}’)"sv),trait_names[static_cast<i64>(0LL)],TRY((this->type_name(rhs_type_id,false))),TRY((this->type_name(lhs_type_id,false)))),lhs_span);
 }
 
 }
 
 }
 else {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp294 = this->get_type(lhs_type_id);
-if (__jakt_tmp294->__jakt_init_index() == 18 /* TypeVariable */){
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const trait_implementations = __jakt_tmp294->as.TypeVariable.trait_implementations;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp152 = this->get_type(lhs_type_id);
+if (__jakt_tmp152->__jakt_init_index() == 18 /* TypeVariable */){
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const trait_implementations = __jakt_tmp152->as.TypeVariable.trait_implementations;
 if (trait_implementations.is_empty()){
 }
 else {
-this->error_with_hint(__jakt_format(StringView::from_string_literal("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("Consider implementing ‘(Throwing){}<{}, ...>’ for the type of this expression (‘{}’)"sv),trait_names.operator[](static_cast<i64>(0LL)),TRY((this->type_name(rhs_type_id,false))),TRY((this->type_name(lhs_type_id,false)))),lhs_span);
+this->error_with_hint(__jakt_format(StringView::from_string_literal("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("Consider implementing ‘(Throwing){}<{}, ...>’ for the type of this expression (‘{}’)"sv),trait_names[static_cast<i64>(0LL)],TRY((this->type_name(rhs_type_id,false))),TRY((this->type_name(lhs_type_id,false)))),lhs_span);
 }
 
 }
 else {
-this->error_with_hint(__jakt_format(StringView::from_string_literal("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("Consider implementing ‘(Throwing){}<{}, ...>’ for the type of this expression (‘{}’)"sv),trait_names.operator[](static_cast<i64>(0LL)),TRY((this->type_name(rhs_type_id,false))),TRY((this->type_name(lhs_type_id,false)))),lhs_span);
+this->error_with_hint(__jakt_format(StringView::from_string_literal("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("Consider implementing ‘(Throwing){}<{}, ...>’ for the type of this expression (‘{}’)"sv),trait_names[static_cast<i64>(0LL)],TRY((this->type_name(rhs_type_id,false))),TRY((this->type_name(lhs_type_id,false)))),lhs_span);
 }
 
 }
 
 }
 else {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp295 = this->get_type(lhs_type_id);
-if (__jakt_tmp295->__jakt_init_index() == 18 /* TypeVariable */){
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const trait_implementations = __jakt_tmp295->as.TypeVariable.trait_implementations;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp153 = this->get_type(lhs_type_id);
+if (__jakt_tmp153->__jakt_init_index() == 18 /* TypeVariable */){
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const trait_implementations = __jakt_tmp153->as.TypeVariable.trait_implementations;
 if (trait_implementations.is_empty()){
 }
 else {
-this->error_with_hint(__jakt_format(StringView::from_string_literal("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("Consider implementing ‘(Throwing){}<{}, ...>’ for the type of this expression (‘{}’)"sv),trait_names.operator[](static_cast<i64>(0LL)),TRY((this->type_name(rhs_type_id,false))),TRY((this->type_name(lhs_type_id,false)))),lhs_span);
+this->error_with_hint(__jakt_format(StringView::from_string_literal("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("Consider implementing ‘(Throwing){}<{}, ...>’ for the type of this expression (‘{}’)"sv),trait_names[static_cast<i64>(0LL)],TRY((this->type_name(rhs_type_id,false))),TRY((this->type_name(lhs_type_id,false)))),lhs_span);
 }
 
 }
 else {
-this->error_with_hint(__jakt_format(StringView::from_string_literal("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("Consider implementing ‘(Throwing){}<{}, ...>’ for the type of this expression (‘{}’)"sv),trait_names.operator[](static_cast<i64>(0LL)),TRY((this->type_name(rhs_type_id,false))),TRY((this->type_name(lhs_type_id,false)))),lhs_span);
+this->error_with_hint(__jakt_format(StringView::from_string_literal("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("Consider implementing ‘(Throwing){}<{}, ...>’ for the type of this expression (‘{}’)"sv),trait_names[static_cast<i64>(0LL)],TRY((this->type_name(rhs_type_id,false))),TRY((this->type_name(lhs_type_id,false)))),lhs_span);
 }
 
 }
 
 }
 else {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp296 = this->get_type(lhs_type_id);
-if (__jakt_tmp296->__jakt_init_index() == 18 /* TypeVariable */){
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const trait_implementations = __jakt_tmp296->as.TypeVariable.trait_implementations;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp154 = this->get_type(lhs_type_id);
+if (__jakt_tmp154->__jakt_init_index() == 18 /* TypeVariable */){
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const trait_implementations = __jakt_tmp154->as.TypeVariable.trait_implementations;
 if (trait_implementations.is_empty()){
 }
 else {
-this->error_with_hint(__jakt_format(StringView::from_string_literal("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("Consider implementing ‘(Throwing){}<{}, ...>’ for the type of this expression (‘{}’)"sv),trait_names.operator[](static_cast<i64>(0LL)),TRY((this->type_name(rhs_type_id,false))),TRY((this->type_name(lhs_type_id,false)))),lhs_span);
+this->error_with_hint(__jakt_format(StringView::from_string_literal("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("Consider implementing ‘(Throwing){}<{}, ...>’ for the type of this expression (‘{}’)"sv),trait_names[static_cast<i64>(0LL)],TRY((this->type_name(rhs_type_id,false))),TRY((this->type_name(lhs_type_id,false)))),lhs_span);
 }
 
 }
 else {
-this->error_with_hint(__jakt_format(StringView::from_string_literal("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("Consider implementing ‘(Throwing){}<{}, ...>’ for the type of this expression (‘{}’)"sv),trait_names.operator[](static_cast<i64>(0LL)),TRY((this->type_name(rhs_type_id,false))),TRY((this->type_name(lhs_type_id,false)))),lhs_span);
+this->error_with_hint(__jakt_format(StringView::from_string_literal("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),span,__jakt_format(StringView::from_string_literal("Consider implementing ‘(Throwing){}<{}, ...>’ for the type of this expression (‘{}’)"sv),trait_names[static_cast<i64>(0LL)],TRY((this->type_name(rhs_type_id,false))),TRY((this->type_name(lhs_type_id,false)))),lhs_span);
 }
 
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_129;default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_129;}/*switch end*/
+}goto __jakt_label_129; __jakt_label_129:;;
 return Tuple{checked_operator, type_id};
 }
 }
 
 ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedStatement>> Jakt::typechecker::Typechecker::typecheck_statement(NonnullRefPtr<typename Jakt::parser::ParsedStatement> const statement,Jakt::ids::ScopeId const scope_id,Jakt::types::SafetyMode const safety_mode,JaktInternal::Optional<Jakt::typechecker::TypeHint> const type_hint) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedStatement>, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedStatement>>>{
-auto&& __jakt_match_variant = *statement;
+{auto&& __jakt_match_variant = *statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expr = __jakt_match_value.expr;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedStatement::Expression(TRY((this->typecheck_expression(expr,scope_id,safety_mode,JaktInternal::OptionalNone()))),span));
-};/*case end*/
+return Jakt::types::CheckedStatement::Expression(TRY((this->typecheck_expression(expr,scope_id,safety_mode,JaktInternal::OptionalNone()))),span);};/*case end*/
 case 2 /* UnsafeBlock */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnsafeBlock;Jakt::parser::ParsedBlock const& block = __jakt_match_value.block;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedStatement::Block(TRY((this->typecheck_block(block,scope_id,Jakt::types::SafetyMode::Unsafe(),JaktInternal::OptionalNone()))),span));
-};/*case end*/
+return Jakt::types::CheckedStatement::Block(TRY((this->typecheck_block(block,scope_id,Jakt::types::SafetyMode::Unsafe(),JaktInternal::OptionalNone()))),span);};/*case end*/
 case 14 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& expr = __jakt_match_value.expr;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_yield(expr,span,scope_id,safety_mode,type_hint))));
-};/*case end*/
+return this->typecheck_yield(expr,span,scope_id,safety_mode,type_hint);};/*case end*/
 case 12 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& expr = __jakt_match_value.expr;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_return(expr,span,scope_id,safety_mode))));
-};/*case end*/
+return this->typecheck_return(expr,span,scope_id,safety_mode);};/*case end*/
 case 6 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::parser::ParsedBlock const& block = __jakt_match_value.block;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_block_statement(block,scope_id,safety_mode,span))));
-};/*case end*/
+return this->typecheck_block_statement(block,scope_id,safety_mode,span);};/*case end*/
 case 15 /* InlineCpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.InlineCpp;Jakt::parser::ParsedBlock const& block = __jakt_match_value.block;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_inline_cpp(block,span,safety_mode))));
-};/*case end*/
+return this->typecheck_inline_cpp(block,span,safety_mode);};/*case end*/
 case 1 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;NonnullRefPtr<typename Jakt::parser::ParsedStatement> const& statement = __jakt_match_value.statement;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_defer(statement,scope_id,safety_mode,span))));
-};/*case end*/
+return this->typecheck_defer(statement,scope_id,safety_mode,span);};/*case end*/
 case 7 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;Jakt::parser::ParsedBlock const& block = __jakt_match_value.block;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_loop(block,scope_id,safety_mode,span))));
-};/*case end*/
+return this->typecheck_loop(block,scope_id,safety_mode,span);};/*case end*/
 case 13 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expr = __jakt_match_value.expr;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_throw(expr,scope_id,safety_mode,span))));
-};/*case end*/
+return this->typecheck_throw(expr,scope_id,safety_mode,span);};/*case end*/
 case 8 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& condition = __jakt_match_value.condition;
 Jakt::parser::ParsedBlock const& block = __jakt_match_value.block;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_while(condition,block,scope_id,safety_mode,span))));
-};/*case end*/
+return this->typecheck_while(condition,block,scope_id,safety_mode,span);};/*case end*/
 case 11 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->typecheck_continue(span));
-};/*case end*/
+return this->typecheck_continue(span);};/*case end*/
 case 10 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->typecheck_break(span));
-};/*case end*/
+return this->typecheck_break(span);};/*case end*/
 case 4 /* VarDecl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.VarDecl;Jakt::parser::ParsedVarDecl const& var = __jakt_match_value.var;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& init = __jakt_match_value.init;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_var_decl(var,init,scope_id,safety_mode,span))));
-};/*case end*/
+return this->typecheck_and_register_var_decl(var,init,scope_id,safety_mode,span);};/*case end*/
 case 3 /* DestructuringAssignment */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DestructuringAssignment;JaktInternal::DynamicArray<Jakt::parser::ParsedVarDecl> const& vars = __jakt_match_value.vars;
 NonnullRefPtr<typename Jakt::parser::ParsedStatement> const& var_decl = __jakt_match_value.var_decl;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_destructuring_assignment(vars,var_decl,scope_id,safety_mode,span))));
-};/*case end*/
+return this->typecheck_destructuring_assignment(vars,var_decl,scope_id,safety_mode,span);};/*case end*/
 case 5 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& condition = __jakt_match_value.condition;
 Jakt::parser::ParsedBlock const& then_block = __jakt_match_value.then_block;
 JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedStatement>> const& else_statement = __jakt_match_value.else_statement;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_if(condition,then_block,else_statement,scope_id,safety_mode,span))));
-};/*case end*/
+return this->typecheck_if(condition,then_block,else_statement,scope_id,safety_mode,span);};/*case end*/
 case 17 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedStatement::Garbage(span));
-};/*case end*/
+return Jakt::types::CheckedStatement::Garbage(span);};/*case end*/
 case 9 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;ByteString const& iterator_name = __jakt_match_value.iterator_name;
 Jakt::utility::Span const& name_span = __jakt_match_value.name_span;
@@ -9174,22 +8450,15 @@ bool const& is_destructuring = __jakt_match_value.is_destructuring;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& range = __jakt_match_value.range;
 Jakt::parser::ParsedBlock const& block = __jakt_match_value.block;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_for(iterator_name,name_span,is_destructuring,range,block,scope_id,safety_mode,span))));
-};/*case end*/
+return this->typecheck_for(iterator_name,name_span,is_destructuring,range,block,scope_id,safety_mode,span);};/*case end*/
 case 16 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expr = __jakt_match_value.expr;
 Jakt::parser::ParsedBlock const& else_block = __jakt_match_value.else_block;
 Jakt::parser::ParsedBlock const& remaining_code = __jakt_match_value.remaining_code;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_guard(expr,else_block,remaining_code,scope_id,safety_mode,span))));
-};/*case end*/
+return this->typecheck_guard(expr,else_block,remaining_code,scope_id,safety_mode,span);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -9244,29 +8513,16 @@ break;
 }
 NonnullRefPtr<typename Jakt::parser::ParsedStatement> statement = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedStatement>>>{
-auto&& __jakt_match_variant = *statement;
+{auto&& __jakt_match_variant = *statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* Break */:case 11 /* Continue */:case 12 /* Return */:case 13 /* Throw */:{
 seen_scope_exit = true;
-return JaktInternal::LoopBreak{};
+break;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_130;default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_130;}/*switch end*/
+break;}goto __jakt_label_130; __jakt_label_130:;;
 }
 
 }
@@ -9321,7 +8577,7 @@ if (new_else_statement.has_value()){
 checked_else = TRY((this->typecheck_statement(new_else_statement.value(),scope_id,safety_mode,JaktInternal::OptionalNone())));
 }
 if (checked_block.yielded_type.has_value()){
-return Jakt::types::CheckedStatement::Yield(Jakt::types::CheckedExpression::Match(JaktInternal::OptionalNone(),checked_condition,DynamicArray<Jakt::types::CheckedMatchCase>::create_with({Jakt::types::CheckedMatchCase(DynamicArray<Jakt::types::CheckedMatchPattern>::create_with({Jakt::types::CheckedMatchPattern::Expression(DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>>::create_with({}),Jakt::types::CheckedExpression::Boolean(JaktInternal::OptionalNone(),true,span),span)}),Jakt::types::CheckedMatchBody::Expression(Jakt::types::CheckedExpression::Block(JaktInternal::OptionalNone(),checked_block,span,checked_block.yielded_type.value()))), Jakt::types::CheckedMatchCase(DynamicArray<Jakt::types::CheckedMatchPattern>::create_with({Jakt::types::CheckedMatchPattern::CatchAll(DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>>::create_with({}),false,span)}),Jakt::types::CheckedMatchBody::Block(checked_else_block))}),span,checked_block.yielded_type.value(),false),span);
+return Jakt::types::CheckedStatement::Yield(Jakt::types::CheckedExpression::Match(JaktInternal::OptionalNone(),checked_condition,DynamicArray<Jakt::types::CheckedMatchCase>::create_with({Jakt::types::CheckedMatchCase(DynamicArray<Jakt::types::CheckedMatchPattern>::create_with({Jakt::types::CheckedMatchPattern::Expression(Dictionary<ByteString, NonnullRefPtr<typename Jakt::types::CheckedExpression>>::create_with_entries({}),span,Jakt::types::CheckedExpression::Boolean(JaktInternal::OptionalNone(),true,span))}),Jakt::types::CheckedMatchBody::Expression(Jakt::types::CheckedExpression::Block(JaktInternal::OptionalNone(),checked_block,span,checked_block.yielded_type.value())),Dictionary<ByteString, Jakt::ids::VarId>::create_with_entries({})), Jakt::types::CheckedMatchCase(DynamicArray<Jakt::types::CheckedMatchPattern>::create_with({Jakt::types::CheckedMatchPattern::CatchAll(Dictionary<ByteString, NonnullRefPtr<typename Jakt::types::CheckedExpression>>::create_with_entries({}),span,false)}),Jakt::types::CheckedMatchBody::Block(checked_else_block),Dictionary<ByteString, Jakt::ids::VarId>::create_with_entries({}))}),span,checked_block.yielded_type.value(),false),span);
 }
 return Jakt::types::CheckedStatement::If(checked_condition,checked_block,checked_else,span);
 }
@@ -9348,35 +8604,26 @@ if (!into_iterator_trait_implementation.has_value()){
 this->error_with_hint(ByteString::from_utf8_without_validation("Iterable expression is not iterable"sv),range->span(),__jakt_format(StringView::from_string_literal("Consider implementing (Throwing)Iterable<T> or Into(Throwing)Iterator<T> for the type of this expression (‘{}’)"sv),TRY((this->type_name(iterable_expr->type(),false)))),range->span());
 }
 else {
-resolved_iterable_result_type = into_iterator_trait_implementation.value().implemented_type_args.operator[](static_cast<i64>(0LL));
+resolved_iterable_result_type = into_iterator_trait_implementation.value().implemented_type_args[static_cast<i64>(0LL)];
 expression_to_iterate = Jakt::parser::ParsedExpression::MethodCall(range,Jakt::parser::ParsedCall(DynamicArray<ByteString>::create_with({}),ByteString::from_utf8_without_validation("iterator"sv),DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>>>::create_with({}),DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>>::create_with({})),false,name_span);
 }
 
 }
 else {
-resolved_iterable_result_type = iterable_trait_implementation.value().implemented_type_args.operator[](static_cast<i64>(0LL));
+resolved_iterable_result_type = iterable_trait_implementation.value().implemented_type_args[static_cast<i64>(0LL)];
 }
 
-NonnullRefPtr<typename Jakt::parser::ParsedStatement> const rewritten_statement = Jakt::parser::ParsedStatement::Block(Jakt::parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>::create_with({Jakt::parser::ParsedStatement::VarDecl(Jakt::parser::ParsedVarDecl(ByteString::from_utf8_without_validation("_magic"sv),Jakt::parser::ParsedType::Empty(JaktInternal::OptionalNone()),true,JaktInternal::OptionalNone(),name_span,JaktInternal::OptionalNone()),expression_to_iterate,span), Jakt::parser::ParsedStatement::Loop(Jakt::parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>::create_with({Jakt::parser::ParsedStatement::VarDecl(Jakt::parser::ParsedVarDecl(ByteString::from_utf8_without_validation("_magic_value"sv),Jakt::parser::ParsedType::Empty(JaktInternal::OptionalNone()),false,JaktInternal::OptionalNone(),name_span,JaktInternal::OptionalNone()),Jakt::parser::ParsedExpression::MethodCall(Jakt::parser::ParsedExpression::Var(ByteString::from_utf8_without_validation("_magic"sv),name_span),Jakt::parser::ParsedCall(DynamicArray<ByteString>::create_with({}),ByteString::from_utf8_without_validation("next"sv),DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>>>::create_with({}),DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>>::create_with({})),false,name_span),span), Jakt::parser::ParsedStatement::If(Jakt::parser::ParsedExpression::UnaryOp(Jakt::parser::ParsedExpression::MethodCall(Jakt::parser::ParsedExpression::Var(ByteString::from_utf8_without_validation("_magic_value"sv),name_span),Jakt::parser::ParsedCall(DynamicArray<ByteString>::create_with({}),ByteString::from_utf8_without_validation("has_value"sv),DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>>>::create_with({}),DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>>::create_with({})),false,name_span),Jakt::parser::UnaryOperator::LogicalNot(),name_span),Jakt::parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>::create_with({Jakt::parser::ParsedStatement::Break(span)})),JaktInternal::OptionalNone(),span), Jakt::parser::ParsedStatement::VarDecl(Jakt::parser::ParsedVarDecl(iterator_name,Jakt::parser::ParsedType::Empty(JaktInternal::OptionalNone()),true,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::utility::Span>,ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedStatement>>> {
-auto __jakt_enum_value = (is_destructuring);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(name_span);
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),name_span,JaktInternal::OptionalNone()),Jakt::parser::ParsedExpression::ForcedUnwrap(Jakt::parser::ParsedExpression::Var(ByteString::from_utf8_without_validation("_magic_value"sv),name_span),name_span),span), Jakt::parser::ParsedStatement::Block(block,span)})),span)})),span);
+NonnullRefPtr<typename Jakt::parser::ParsedStatement> const rewritten_statement = Jakt::parser::ParsedStatement::Block(Jakt::parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>::create_with({Jakt::parser::ParsedStatement::VarDecl(Jakt::parser::ParsedVarDecl(ByteString::from_utf8_without_validation("_magic"sv),Jakt::parser::ParsedType::Empty(JaktInternal::OptionalNone()),true,JaktInternal::OptionalNone(),name_span,JaktInternal::OptionalNone()),expression_to_iterate,span), Jakt::parser::ParsedStatement::Loop(Jakt::parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>::create_with({Jakt::parser::ParsedStatement::VarDecl(Jakt::parser::ParsedVarDecl(ByteString::from_utf8_without_validation("_magic_value"sv),Jakt::parser::ParsedType::Empty(JaktInternal::OptionalNone()),false,JaktInternal::OptionalNone(),name_span,JaktInternal::OptionalNone()),Jakt::parser::ParsedExpression::MethodCall(Jakt::parser::ParsedExpression::Var(ByteString::from_utf8_without_validation("_magic"sv),name_span),Jakt::parser::ParsedCall(DynamicArray<ByteString>::create_with({}),ByteString::from_utf8_without_validation("next"sv),DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>>>::create_with({}),DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>>::create_with({})),false,name_span),span), Jakt::parser::ParsedStatement::If(Jakt::parser::ParsedExpression::UnaryOp(Jakt::parser::ParsedExpression::MethodCall(Jakt::parser::ParsedExpression::Var(ByteString::from_utf8_without_validation("_magic_value"sv),name_span),Jakt::parser::ParsedCall(DynamicArray<ByteString>::create_with({}),ByteString::from_utf8_without_validation("has_value"sv),DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>>>::create_with({}),DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>>::create_with({})),false,name_span),Jakt::parser::UnaryOperator::LogicalNot(),name_span),Jakt::parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>::create_with({Jakt::parser::ParsedStatement::Break(span)})),JaktInternal::OptionalNone(),span), Jakt::parser::ParsedStatement::VarDecl(Jakt::parser::ParsedVarDecl(iterator_name,Jakt::parser::ParsedType::Empty(JaktInternal::OptionalNone()),true,[&]() -> JaktInternal::Optional<Jakt::utility::Span> { auto __jakt_enum_value = is_destructuring;
+if (__jakt_enum_value) {return JaktInternal::OptionalNone();}else if (!__jakt_enum_value) {return name_span;}VERIFY_NOT_REACHED();
+ 
+}(),name_span,JaktInternal::OptionalNone()),Jakt::parser::ParsedExpression::ForcedUnwrap(Jakt::parser::ParsedExpression::Var(ByteString::from_utf8_without_validation("_magic_value"sv),name_span),name_span),span), Jakt::parser::ParsedStatement::Block(block,span)})),span)})),span);
 return this->typecheck_statement(rewritten_statement,scope_id,safety_mode,JaktInternal::OptionalNone());
 }
 }
 
 ErrorOr<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,JaktInternal::Optional<Jakt::parser::ParsedBlock>,JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>>> Jakt::typechecker::Typechecker::expand_context_for_bindings(NonnullRefPtr<typename Jakt::parser::ParsedExpression> const condition,JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const acc,JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>& pre_condition,JaktInternal::Optional<Jakt::parser::ParsedBlock> const then_block,JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedStatement>> const else_statement,Jakt::ids::ScopeId const scope_id,Jakt::utility::Span const span) {
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,JaktInternal::Optional<Jakt::parser::ParsedBlock>,JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedStatement>>>>>{
-auto&& __jakt_match_variant = *condition;
+{auto&& __jakt_match_variant = *condition;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* BinaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.BinaryOp;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& lhs = __jakt_match_value.lhs;
@@ -9401,16 +8648,15 @@ return this->expand_context_for_bindings(lhs,JaktInternal::OptionalNone(),pre_co
 
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_131;};/*case end*/
 case 11 /* UnaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expr = __jakt_match_value.expr;
 Jakt::parser::UnaryOperator const& op = __jakt_match_value.op;
 {
-Jakt::parser::UnaryOperator __jakt_tmp297 = op;
-if (__jakt_tmp297.__jakt_init_index() == 13 /* IsEnumVariant */){
-NonnullRefPtr<typename Jakt::parser::ParsedType> const inner = __jakt_tmp297.as.IsEnumVariant.inner;
-JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> const bindings = __jakt_tmp297.as.IsEnumVariant.bindings;
+Jakt::parser::UnaryOperator __jakt_tmp155 = op;
+if (__jakt_tmp155.__jakt_init_index() == 13 /* IsEnumVariant */){
+NonnullRefPtr<typename Jakt::parser::ParsedType> const inner = __jakt_tmp155.as.IsEnumVariant.inner;
+JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> const bindings = __jakt_tmp155.as.IsEnumVariant.bindings;
 ByteString const tmp_name = __jakt_format(StringView::from_string_literal("__jakt_tmp{}"sv),this->temp_var_count);
 this->temp_var_count++;
 Jakt::parser::ParsedVarDecl const tmp_decl = Jakt::parser::ParsedVarDecl(tmp_name,Jakt::parser::ParsedType::Empty(JaktInternal::OptionalNone()),true,JaktInternal::OptionalNone(),expr->span(),JaktInternal::OptionalNone());
@@ -9434,9 +8680,9 @@ Jakt::parser::EnumVariantPatternArgument binding = _magic_value.value();
 {
 Jakt::parser::ParsedVarDecl const var = Jakt::parser::ParsedVarDecl(binding.binding,Jakt::parser::ParsedType::Empty(JaktInternal::OptionalNone()),false,JaktInternal::OptionalNone(),binding.span,JaktInternal::OptionalNone());
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const tmp_access = Jakt::parser::ParsedExpression::Var(tmp_name,binding.span);
-NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp298 = pre_checked_unary_op;
-if (__jakt_tmp298->__jakt_init_index() == 6 /* UnaryOp */){
-Jakt::types::CheckedUnaryOperator const op = __jakt_tmp298->as.UnaryOp.op;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp156 = pre_checked_unary_op;
+if (__jakt_tmp156->__jakt_init_index() == 6 /* UnaryOp */){
+Jakt::types::CheckedUnaryOperator const op = __jakt_tmp156->as.UnaryOp.op;
 if (op.__jakt_init_index() == 14 /* IsSome */){
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const init = Jakt::parser::ParsedExpression::ForcedUnwrap(tmp_access,span);
 outer_if_stmts.push(Jakt::parser::ParsedStatement::VarDecl(var,init,span));
@@ -9472,18 +8718,11 @@ Jakt::parser::ParsedBlock const new_then_block = Jakt::parser::ParsedBlock(outer
 return this->expand_context_for_bindings(unary_op_single_condition,JaktInternal::OptionalNone(),pre_condition,new_then_block,else_statement,scope_id,span);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_131;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_131;}/*switch end*/
+}goto __jakt_label_131; __jakt_label_131:;;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> base_condition = condition;
 if (acc.has_value()){
 base_condition = Jakt::parser::ParsedExpression::BinaryOp(condition,Jakt::parser::BinaryOperator::LogicalAnd(),acc.value(),span);
@@ -9552,10 +8791,10 @@ JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>
 NonnullRefPtr<typename Jakt::types::CheckedStatement> const checked_tuple_var_decl = TRY((this->typecheck_statement(var_decl,scope_id,safety_mode,JaktInternal::OptionalNone())));
 Jakt::ids::TypeId expr_type_id = Jakt::types::unknown_type_id();
 Jakt::ids::VarId tuple_var_id = Jakt::ids::VarId(Jakt::ids::ModuleId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL));
-NonnullRefPtr<typename Jakt::types::CheckedStatement> __jakt_tmp299 = checked_tuple_var_decl;
-if (__jakt_tmp299->__jakt_init_index() == 3 /* VarDecl */){
-Jakt::ids::VarId const var_id = __jakt_tmp299->as.VarDecl.var_id;
-NonnullRefPtr<typename Jakt::types::CheckedExpression> const init = __jakt_tmp299->as.VarDecl.init;
+NonnullRefPtr<typename Jakt::types::CheckedStatement> __jakt_tmp157 = checked_tuple_var_decl;
+if (__jakt_tmp157->__jakt_init_index() == 3 /* VarDecl */){
+Jakt::ids::VarId const var_id = __jakt_tmp157->as.VarDecl.var_id;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const init = __jakt_tmp157->as.VarDecl.init;
 expr_type_id = init->type();
 tuple_var_id = var_id;
 }
@@ -9565,9 +8804,9 @@ this->error(ByteString::from_utf8_without_validation("Destructuting assignment s
 
 JaktInternal::DynamicArray<Jakt::ids::TypeId> inner_types = DynamicArray<Jakt::ids::TypeId>::create_with({});
 NonnullRefPtr<typename Jakt::types::Type> const tuple_type = this->get_type(expr_type_id);
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp300 = tuple_type;
-if (__jakt_tmp300->__jakt_init_index() == 20 /* GenericInstance */){
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp300->as.GenericInstance.args;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp158 = tuple_type;
+if (__jakt_tmp158->__jakt_init_index() == 20 /* GenericInstance */){
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp158->as.GenericInstance.args;
 inner_types = args;
 }
 else {
@@ -9585,10 +8824,10 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::parser::ParsedVarDecl new_var = vars.operator[](i);
-new_var.parsed_type = Jakt::parser::ParsedType::Name(JaktInternal::OptionalNone(),TRY((this->type_name(inner_types.operator[](i),false))),span);
+Jakt::parser::ParsedVarDecl new_var = vars[i];
+new_var.parsed_type = Jakt::parser::ParsedType::Name(JaktInternal::OptionalNone(),TRY((this->type_name(inner_types[i],false))),span);
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const init = Jakt::parser::ParsedExpression::IndexedTuple(Jakt::parser::ParsedExpression::Var(tuple_variable->name,span),i,false,span);
-var_decls.push(TRY((this->typecheck_var_decl(vars.operator[](i),init,scope_id,safety_mode,span))));
+var_decls.push(TRY((this->typecheck_and_register_var_decl(vars[i],init,scope_id,safety_mode,span))));
 }
 
 }
@@ -9713,32 +8952,15 @@ return JaktInternal::OptionalNone();
 
 ErrorOr<JaktInternal::Tuple<JaktInternal::Optional<Jakt::ids::ScopeId>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>> Jakt::typechecker::Typechecker::required_scope_id_in_hierarchy_for(NonnullRefPtr<typename Jakt::types::CheckedExpression> const expr,Jakt::ids::ScopeId const current_scope_id) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Optional<Jakt::ids::ScopeId>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>, ErrorOr<JaktInternal::Tuple<JaktInternal::Optional<Jakt::ids::ScopeId>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>>{
-auto&& __jakt_match_variant = *expr;
+{auto&& __jakt_match_variant = *expr;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Boolean */:case 1 /* NumericConstant */:case 2 /* QuotedString */:case 3 /* ByteConstant */:case 4 /* CharacterConstant */:case 5 /* CCharacterConstant */:case 34 /* Reflect */:return JaktInternal::ExplicitValue(Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(this->root_scope_id()), expr});
-case 7 /* BinaryOp */:return JaktInternal::ExplicitValue(Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr});
-case 6 /* UnaryOp */: {
+case 0 /* Boolean */:case 1 /* NumericConstant */:case 2 /* QuotedString */:case 3 /* ByteConstant */:case 4 /* CharacterConstant */:case 5 /* CCharacterConstant */:case 34 /* Reflect */:return Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(this->root_scope_id()), expr};case 7 /* BinaryOp */:return Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr};case 6 /* UnaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;Jakt::types::CheckedUnaryOperator const& op = __jakt_match_value.op;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Optional<Jakt::ids::ScopeId>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>, ErrorOr<JaktInternal::Tuple<JaktInternal::Optional<Jakt::ids::ScopeId>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>>{
-auto&& __jakt_match_variant = op;
+{auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* PreIncrement */:case 2 /* PreDecrement */:return JaktInternal::ExplicitValue(TRY((this->required_scope_id_in_hierarchy_for(expr,current_scope_id))));
-case 5 /* Dereference */:return JaktInternal::ExplicitValue(TRY((this->required_scope_id_in_hierarchy_for(expr,current_scope_id))));
-case 7 /* Reference */:case 8 /* MutableReference */:return JaktInternal::ExplicitValue(TRY((this->required_scope_id_in_hierarchy_for(expr,current_scope_id))));
-case 11 /* TypeCast */:return JaktInternal::ExplicitValue(TRY((this->required_scope_id_in_hierarchy_for(expr,current_scope_id))));
-default:return JaktInternal::ExplicitValue(Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr});
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+case 0 /* PreIncrement */:case 2 /* PreDecrement */:return this->required_scope_id_in_hierarchy_for(expr,current_scope_id);case 5 /* Dereference */:return this->required_scope_id_in_hierarchy_for(expr,current_scope_id);case 7 /* Reference */:case 8 /* MutableReference */:return this->required_scope_id_in_hierarchy_for(expr,current_scope_id);case 11 /* TypeCast */:return this->required_scope_id_in_hierarchy_for(expr,current_scope_id);default:return Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr};}/*switch end*/
+}};/*case end*/
 case 10 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& vals = __jakt_match_value.vals;
 {
@@ -9758,7 +8980,7 @@ final_scope_id = this->scope_lifetime_union(final_scope_id,TRY((this->required_s
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Tuple<JaktInternal::Optional<Jakt::ids::ScopeId>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>(Tuple{final_scope_id, expr});
+return Tuple{final_scope_id, expr};
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -9781,7 +9003,7 @@ final_scope_id = this->scope_lifetime_union(final_scope_id,TRY((this->required_s
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Tuple<JaktInternal::Optional<Jakt::ids::ScopeId>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>(Tuple{final_scope_id, expr});
+return Tuple{final_scope_id, expr};
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -9804,7 +9026,7 @@ final_scope_id = this->scope_lifetime_union(final_scope_id,TRY((this->required_s
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Tuple<JaktInternal::Optional<Jakt::ids::ScopeId>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>(Tuple{final_scope_id, expr});
+return Tuple{final_scope_id, expr};
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -9831,58 +9053,41 @@ final_scope_id = this->scope_lifetime_union(final_scope_id,this->scope_lifetime_
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Tuple<JaktInternal::Optional<Jakt::ids::ScopeId>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>(Tuple{final_scope_id, expr});
+return Tuple{final_scope_id, expr};
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-case 9 /* Range */:return JaktInternal::ExplicitValue(Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr});
-case 13 /* IndexedExpression */: {
+case 9 /* Range */:return Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr};case 13 /* IndexedExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedExpression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(TRY((this->required_scope_id_in_hierarchy_for(expr,current_scope_id))));
-};/*case end*/
+return this->required_scope_id_in_hierarchy_for(expr,current_scope_id);};/*case end*/
 case 14 /* IndexedDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedDictionary;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(TRY((this->required_scope_id_in_hierarchy_for(expr,current_scope_id))));
-};/*case end*/
+return this->required_scope_id_in_hierarchy_for(expr,current_scope_id);};/*case end*/
 case 15 /* IndexedTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedTuple;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(TRY((this->required_scope_id_in_hierarchy_for(expr,current_scope_id))));
-};/*case end*/
+return this->required_scope_id_in_hierarchy_for(expr,current_scope_id);};/*case end*/
 case 16 /* IndexedStruct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedStruct;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(TRY((this->required_scope_id_in_hierarchy_for(expr,current_scope_id))));
-};/*case end*/
+return this->required_scope_id_in_hierarchy_for(expr,current_scope_id);};/*case end*/
 case 17 /* IndexedCommonEnumMember */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedCommonEnumMember;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(TRY((this->required_scope_id_in_hierarchy_for(expr,current_scope_id))));
-};/*case end*/
+return this->required_scope_id_in_hierarchy_for(expr,current_scope_id);};/*case end*/
 case 18 /* ComptimeIndex */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ComptimeIndex;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(TRY((this->required_scope_id_in_hierarchy_for(expr,current_scope_id))));
-};/*case end*/
-case 19 /* Match */:return JaktInternal::ExplicitValue(Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr});
-case 20 /* EnumVariantArg */:return JaktInternal::ExplicitValue(Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr});
-case 21 /* Call */:return JaktInternal::ExplicitValue(Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr});
-case 22 /* MethodCall */: {
+return this->required_scope_id_in_hierarchy_for(expr,current_scope_id);};/*case end*/
+case 19 /* Match */:return Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr};case 20 /* EnumVariantArg */:return Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr};case 21 /* Call */:return Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr};case 22 /* MethodCall */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MethodCall;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(TRY((this->required_scope_id_in_hierarchy_for(expr,current_scope_id))));
-};/*case end*/
+return this->required_scope_id_in_hierarchy_for(expr,current_scope_id);};/*case end*/
 case 24 /* Var */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Var;NonnullRefPtr<Jakt::types::CheckedVariable> const& var = __jakt_match_value.var;
-return JaktInternal::ExplicitValue(Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(var->owner_scope.value_or_lazy_evaluated([&] { return current_scope_id; })), expr});
-};/*case end*/
+return Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(var->owner_scope.value_or_lazy_evaluated([&] { return current_scope_id; })), expr};};/*case end*/
 case 23 /* NamespacedVar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedVar;NonnullRefPtr<Jakt::types::CheckedVariable> const& var = __jakt_match_value.var;
-return JaktInternal::ExplicitValue(Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(var->owner_scope.value_or_lazy_evaluated([&] { return current_scope_id; })), expr});
-};/*case end*/
-case 25 /* OptionalNone */:return JaktInternal::ExplicitValue(Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr});
-case 26 /* OptionalSome */:return JaktInternal::ExplicitValue(Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr});
-case 27 /* ForcedUnwrap */: {
+return Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(var->owner_scope.value_or_lazy_evaluated([&] { return current_scope_id; })), expr};};/*case end*/
+case 25 /* OptionalNone */:return Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr};case 26 /* OptionalSome */:return Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr};case 27 /* ForcedUnwrap */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForcedUnwrap;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(TRY((this->required_scope_id_in_hierarchy_for(expr,current_scope_id))));
-};/*case end*/
-case 28 /* Block */:return JaktInternal::ExplicitValue(Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr});
-case 29 /* Function */: {
+return this->required_scope_id_in_hierarchy_for(expr,current_scope_id);};/*case end*/
+case 28 /* Block */:return Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr};case 29 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<Jakt::types::CheckedCapture> const& captures = __jakt_match_value.captures;
 {
 JaktInternal::Optional<Jakt::ids::ScopeId> final_scope_id = JaktInternal::OptionalNone();
@@ -9905,7 +9110,7 @@ final_scope_id = this->scope_lifetime_union(final_scope_id,scope_id);
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Tuple<JaktInternal::Optional<Jakt::ids::ScopeId>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>(Tuple{final_scope_id, expr});
+return Tuple{final_scope_id, expr};
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -9932,31 +9137,22 @@ final_scope_id = this->scope_lifetime_union(final_scope_id,scope_id);
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Tuple<JaktInternal::Optional<Jakt::ids::ScopeId>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>(Tuple{final_scope_id, expr});
+return Tuple{final_scope_id, expr};
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 31 /* Must */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Must;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(TRY((this->required_scope_id_in_hierarchy_for(expr,current_scope_id))));
-};/*case end*/
-case 32 /* Try */:return JaktInternal::ExplicitValue(Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr});
-case 33 /* TryBlock */:return JaktInternal::ExplicitValue(Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr});
-case 35 /* Garbage */:return JaktInternal::ExplicitValue(Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr});
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return this->required_scope_id_in_hierarchy_for(expr,current_scope_id);};/*case end*/
+case 32 /* Try */:return Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr};case 33 /* TryBlock */:return Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr};case 35 /* Garbage */:return Tuple{static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(JaktInternal::OptionalNone()), expr};default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
-ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedStatement>> Jakt::typechecker::Typechecker::typecheck_var_decl(Jakt::parser::ParsedVarDecl const var,NonnullRefPtr<typename Jakt::parser::ParsedExpression> const init,Jakt::ids::ScopeId const scope_id,Jakt::types::SafetyMode const safety_mode,Jakt::utility::Span const span) {
+ErrorOr<JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<Jakt::types::CheckedVariable>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>> Jakt::typechecker::Typechecker::typecheck_var_decl(Jakt::parser::ParsedVarDecl const var,NonnullRefPtr<typename Jakt::parser::ParsedExpression> const init,Jakt::ids::ScopeId const scope_id,Jakt::types::SafetyMode const safety_mode,Jakt::utility::Span const span) {
 {
 Jakt::ids::TypeId lhs_type_id = TRY((this->typecheck_typename(var.parsed_type,scope_id,var.name,JaktInternal::OptionalNone())));
-NonnullRefPtr<typename Jakt::types::CheckedExpression> checked_expr = TRY((this->typecheck_expression(init,scope_id,safety_mode,Jakt::typechecker::TypeHint::MustBe(lhs_type_id))));
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_expr = TRY((this->typecheck_expression(init,scope_id,safety_mode,Jakt::typechecker::TypeHint::MustBe(lhs_type_id))));
 Jakt::ids::TypeId const rhs_type_id = checked_expr->type();
 if (rhs_type_id.equals(Jakt::types::void_type_id())){
 this->error(ByteString::from_utf8_without_validation("Cannot assign `void` to a variable"sv),checked_expr->span());
@@ -9989,14 +9185,14 @@ this->error_with_hint(ByteString::from_utf8_without_validation("Cannot assign a 
 }
 }
 NonnullRefPtr<typename Jakt::types::Type> const lhs_type = this->get_type(lhs_type_id);
-NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp301 = checked_expr;
-if (__jakt_tmp301->__jakt_init_index() == 25 /* OptionalNone */){
-Jakt::utility::Span const span = __jakt_tmp301->as.OptionalNone.span;
-Jakt::ids::TypeId const type_id = __jakt_tmp301->as.OptionalNone.type_id;
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp302 = lhs_type;
-if (__jakt_tmp302->__jakt_init_index() == 20 /* GenericInstance */){
-Jakt::ids::StructId const id = __jakt_tmp302->as.GenericInstance.id;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp302->as.GenericInstance.args;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp159 = checked_expr;
+if (__jakt_tmp159->__jakt_init_index() == 25 /* OptionalNone */){
+Jakt::utility::Span const span = __jakt_tmp159->as.OptionalNone.span;
+Jakt::ids::TypeId const type_id = __jakt_tmp159->as.OptionalNone.type_id;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp160 = lhs_type;
+if (__jakt_tmp160->__jakt_init_index() == 20 /* GenericInstance */){
+Jakt::ids::StructId const id = __jakt_tmp160->as.GenericInstance.id;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp160->as.GenericInstance.args;
 if (!(id.equals(optional_struct_id) || id.equals(weak_ptr_struct_id))){
 this->error(ByteString::from_utf8_without_validation("Cannot assign None to a non-optional type"sv),span);
 }
@@ -10006,17 +9202,17 @@ this->error(ByteString::from_utf8_without_validation("Cannot assign None to a no
 }
 
 }
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp303 = lhs_type;
-if (__jakt_tmp303->__jakt_init_index() == 20 /* GenericInstance */){
-Jakt::ids::StructId const id = __jakt_tmp303->as.GenericInstance.id;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp303->as.GenericInstance.args;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp161 = lhs_type;
+if (__jakt_tmp161->__jakt_init_index() == 20 /* GenericInstance */){
+Jakt::ids::StructId const id = __jakt_tmp161->as.GenericInstance.id;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp161->as.GenericInstance.args;
 if (id.equals(weak_ptr_struct_id)){
-if ((!lhs_type_id.equals(rhs_type_id)) && ((!args.operator[](static_cast<i64>(0LL)).equals(rhs_type_id)) && ((!rhs_type_id.equals(Jakt::types::unknown_type_id())) && (!this->is_subclass_of(args.operator[](static_cast<i64>(0LL)),rhs_type_id))))){
+if ((!lhs_type_id.equals(rhs_type_id)) && ((!args[static_cast<i64>(0LL)].equals(rhs_type_id)) && ((!rhs_type_id.equals(Jakt::types::unknown_type_id())) && (!this->is_subclass_of(args[static_cast<i64>(0LL)],rhs_type_id))))){
 this->error(__jakt_format(StringView::from_string_literal("Type mismatch: expected ‘{}’, but got ‘{}’"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),checked_expr->span());
 }
 }
 else if (id.equals(optional_struct_id)){
-if ((!lhs_type_id.equals(rhs_type_id)) && ((!args.operator[](static_cast<i64>(0LL)).equals(rhs_type_id)) && ((!rhs_type_id.equals(Jakt::types::unknown_type_id())) && (!this->is_subclass_of(args.operator[](static_cast<i64>(0LL)),rhs_type_id))))){
+if ((!lhs_type_id.equals(rhs_type_id)) && ((!args[static_cast<i64>(0LL)].equals(rhs_type_id)) && ((!rhs_type_id.equals(Jakt::types::unknown_type_id())) && (!this->is_subclass_of(args[static_cast<i64>(0LL)],rhs_type_id))))){
 this->error(__jakt_format(StringView::from_string_literal("Type mismatch: expected ‘{}’, but got ‘{}’"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),checked_expr->span());
 }
 }
@@ -10031,33 +9227,24 @@ else if (lhs_type->is_builtin()){
 JaktInternal::Optional<Jakt::types::NumberConstant> const number_constant = checked_expr->to_number_constant(this->program);
 bool is_rhs_zero = false;
 if (number_constant.has_value()){
-is_rhs_zero = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedStatement>>>{
-auto&& __jakt_match_variant = number_constant.value();
+is_rhs_zero = [&]() -> bool { auto&& __jakt_match_variant = number_constant.value();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Signed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Signed;i64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value == static_cast<i64>(0LL));
-};/*case end*/
+return value == static_cast<i64>(0LL);};/*case end*/
 case 1 /* Unsigned */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsigned;u64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value == static_cast<u64>(0ULL));
-};/*case end*/
+return value == static_cast<u64>(0ULL);};/*case end*/
 case 2 /* Floating */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Floating;f64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value == static_cast<f64>(0));
-};/*case end*/
+return value == static_cast<f64>(0);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 }
 if ((!(this->is_numeric(lhs_type_id) && is_rhs_zero)) && (this->is_integer(lhs_type_id) ^ this->is_integer(rhs_type_id))){
 this->error(__jakt_format(StringView::from_string_literal("Type mismatch: expected ‘{}’, but got ‘{}’"sv),TRY((this->type_name(lhs_type_id,false))),TRY((this->type_name(rhs_type_id,false)))),checked_expr->span());
-return Jakt::types::CheckedStatement::Garbage(span);
+return JaktInternal::OptionalNone();
 }
 }
 else {
@@ -10066,14 +9253,35 @@ this->error(__jakt_format(StringView::from_string_literal("Type mismatch: expect
 }
 }
 
-NonnullRefPtr<Jakt::types::CheckedVariable> const checked_var = Jakt::types::CheckedVariable::__jakt_create(var.name,lhs_type_id,var.is_mutable,var.span,JaktInternal::OptionalNone(),Jakt::types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
-if (this->dump_type_hints && var.inlay_span.has_value()){
-TRY((this->dump_type_hint(lhs_type_id,var.inlay_span.value())));
+if (this->dump_type_hints){
+JaktInternal::Optional<Jakt::utility::Span> __jakt_tmp162 = var.inlay_span;
+if (__jakt_tmp162.has_value()){
+Jakt::utility::Span const inlay_span = __jakt_tmp162.value();
+TRY((this->dump_type_hint(lhs_type_id,inlay_span)));
 }
+}
+return Tuple{Jakt::types::CheckedVariable::__jakt_create(var.name,lhs_type_id,var.is_mutable,var.span,JaktInternal::OptionalNone(),Jakt::types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone()), checked_expr};
+}
+}
+
+ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedStatement>> Jakt::typechecker::Typechecker::typecheck_and_register_var_decl(Jakt::parser::ParsedVarDecl const var,NonnullRefPtr<typename Jakt::parser::ParsedExpression> const init,Jakt::ids::ScopeId const scope_id,Jakt::types::SafetyMode const safety_mode,Jakt::utility::Span const span) {
+{
+JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<Jakt::types::CheckedVariable>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>> __jakt_tmp163 = TRY((this->typecheck_var_decl(var,init,scope_id,safety_mode,span)));
+if (__jakt_tmp163.has_value()){
+JaktInternal::Tuple<NonnullRefPtr<Jakt::types::CheckedVariable>,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const checked_var_and_init = __jakt_tmp163.value();
+JaktInternal::Tuple<NonnullRefPtr<Jakt::types::CheckedVariable>,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const checked_var_checked_expr_ = checked_var_and_init;
+NonnullRefPtr<Jakt::types::CheckedVariable> const checked_var = checked_var_checked_expr_.template get<0>();
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_expr = checked_var_checked_expr_.template get<1>();
+
 NonnullRefPtr<Jakt::types::Module> module = this->current_module();
 Jakt::ids::VarId const var_id = module->add_variable(checked_var);
 this->add_var_to_scope(scope_id,var.name,var_id,checked_var->definition_span);
 return Jakt::types::CheckedStatement::VarDecl(var_id,checked_expr,span);
+}
+else {
+return Jakt::types::CheckedStatement::Garbage(span);
+}
+
 }
 }
 
@@ -10248,9 +9456,9 @@ ScopeGuard __jakt_var_79([&] {
 this->break_continue_tracker = previous_break_continue_tracker;
 });
 NonnullRefPtr<typename Jakt::types::CheckedStatement> const checked_statement = TRY((this->typecheck_statement(statement,scope_id,safety_mode,JaktInternal::OptionalNone())));
-NonnullRefPtr<typename Jakt::types::CheckedStatement> __jakt_tmp304 = checked_statement;
-if (__jakt_tmp304->__jakt_init_index() == 5 /* Block */){
-Jakt::types::CheckedBlock const block = __jakt_tmp304->as.Block.block;
+NonnullRefPtr<typename Jakt::types::CheckedStatement> __jakt_tmp164 = checked_statement;
+if (__jakt_tmp164->__jakt_init_index() == 5 /* Block */){
+Jakt::types::CheckedBlock const block = __jakt_tmp164->as.Block.block;
 if (block.yielded_type.has_value()){
 this->error(ByteString::from_utf8_without_validation("‘yield’ inside ‘defer’ is meaningless"sv),span);
 }
@@ -10284,13 +9492,13 @@ break;
 }
 NonnullRefPtr<typename Jakt::parser::ParsedStatement> statement = _magic_value.value();
 {
-NonnullRefPtr<typename Jakt::parser::ParsedStatement> __jakt_tmp306 = statement;
-if (__jakt_tmp306->__jakt_init_index() == 0 /* Expression */){
-NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = __jakt_tmp306->as.Expression.expr;
-NonnullRefPtr<typename Jakt::parser::ParsedExpression> __jakt_tmp305 = expr;
-if (__jakt_tmp305->__jakt_init_index() == 2 /* QuotedString */){
-ByteString const val = __jakt_tmp305->as.QuotedString.val;
-Jakt::utility::Span const span = __jakt_tmp305->as.QuotedString.span;
+NonnullRefPtr<typename Jakt::parser::ParsedStatement> __jakt_tmp166 = statement;
+if (__jakt_tmp166->__jakt_init_index() == 0 /* Expression */){
+NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = __jakt_tmp166->as.Expression.expr;
+NonnullRefPtr<typename Jakt::parser::ParsedExpression> __jakt_tmp165 = expr;
+if (__jakt_tmp165->__jakt_init_index() == 2 /* QuotedString */){
+ByteString const val = __jakt_tmp165->as.QuotedString.val;
+Jakt::utility::Span const span = __jakt_tmp165->as.QuotedString.span;
 strings.push(val);
 }
 else {
@@ -10374,13 +9582,13 @@ return {};
 ((*this),pre_condition,scope_id,safety_mode,this->current_block)));
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_expr = TRY((this->typecheck_expression_and_dereference_if_needed(new_condition,scope_id,safety_mode,type_hint,span)));
 if (type_hint_id.has_value()){
-NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp307 = checked_expr;
-if (__jakt_tmp307->__jakt_init_index() == 25 /* OptionalNone */){
-Jakt::utility::Span const span = __jakt_tmp307->as.OptionalNone.span;
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp308 = this->get_type(type_hint_id.value());
-if (__jakt_tmp308->__jakt_init_index() == 20 /* GenericInstance */){
-Jakt::ids::StructId const id = __jakt_tmp308->as.GenericInstance.id;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp308->as.GenericInstance.args;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp167 = checked_expr;
+if (__jakt_tmp167->__jakt_init_index() == 25 /* OptionalNone */){
+Jakt::utility::Span const span = __jakt_tmp167->as.OptionalNone.span;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp168 = this->get_type(type_hint_id.value());
+if (__jakt_tmp168->__jakt_init_index() == 20 /* GenericInstance */){
+Jakt::ids::StructId const id = __jakt_tmp168->as.GenericInstance.id;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp168->as.GenericInstance.args;
 if ((!id.equals(TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv)))))) && (!id.equals(TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("WeakPtr"sv))))))){
 this->error(ByteString::from_utf8_without_validation("Cannot assign None to a non-optional type"sv),span);
 }
@@ -10397,49 +9605,39 @@ return Jakt::types::CheckedStatement::Return(checked_expr,span);
 
 ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>> Jakt::typechecker::Typechecker::dereference_if_needed(NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_expr,Jakt::utility::Span const span) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedExpression>, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *this->get_type(checked_expr->type());
+{auto&& __jakt_match_variant = *this->get_type(checked_expr->type());
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 27 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,Jakt::types::CheckedUnaryOperator::Dereference(),span,type_id));
-};/*case end*/
+return Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,Jakt::types::CheckedUnaryOperator::Dereference(),span,type_id);};/*case end*/
 case 28 /* MutableReference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MutableReference;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,Jakt::types::CheckedUnaryOperator::Dereference(),span,type_id));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(checked_expr);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return Jakt::types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,Jakt::types::CheckedUnaryOperator::Dereference(),span,type_id);};/*case end*/
+default:return checked_expr;}/*switch end*/
+}
 }
 }
 
 ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>> Jakt::typechecker::Typechecker::typecheck_expression_and_dereference_if_needed(NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr,Jakt::ids::ScopeId const scope_id,Jakt::types::SafetyMode const safety_mode,JaktInternal::Optional<Jakt::typechecker::TypeHint> const type_hint,Jakt::utility::Span const span) {
 {
 JaktInternal::Optional<Jakt::typechecker::TypeHint> effective_hint = type_hint;
-JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp310 = type_hint;
-if (__jakt_tmp310.has_value()){
-Jakt::typechecker::TypeHint const hint = __jakt_tmp310.value();
-Jakt::typechecker::TypeHint __jakt_tmp309 = hint;
-if (__jakt_tmp309.__jakt_init_index() == 0 /* MustBe */){
-Jakt::ids::TypeId const type_id = __jakt_tmp309.common.init_common.type_id;
+JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp170 = type_hint;
+if (__jakt_tmp170.has_value()){
+Jakt::typechecker::TypeHint const hint = __jakt_tmp170.value();
+Jakt::typechecker::TypeHint __jakt_tmp169 = hint;
+if (__jakt_tmp169.__jakt_init_index() == 0 /* MustBe */){
+Jakt::ids::TypeId const type_id = __jakt_tmp169.common.init_common.type_id;
 effective_hint = Jakt::typechecker::TypeHint::CouldBe(type_id);
 }
 }
 NonnullRefPtr<typename Jakt::types::CheckedExpression> checked_expr = TRY((this->typecheck_expression(expr,scope_id,safety_mode,effective_hint)));
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const result = TRY((this->dereference_if_needed(checked_expr,span)));
-JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp312 = type_hint;
-if (__jakt_tmp312.has_value()){
-Jakt::typechecker::TypeHint const hint = __jakt_tmp312.value();
-Jakt::typechecker::TypeHint __jakt_tmp311 = hint;
-if (__jakt_tmp311.__jakt_init_index() == 0 /* MustBe */){
-Jakt::ids::TypeId const type_id = __jakt_tmp311.common.init_common.type_id;
+JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp172 = type_hint;
+if (__jakt_tmp172.has_value()){
+Jakt::typechecker::TypeHint const hint = __jakt_tmp172.value();
+Jakt::typechecker::TypeHint __jakt_tmp171 = hint;
+if (__jakt_tmp171.__jakt_init_index() == 0 /* MustBe */){
+Jakt::ids::TypeId const type_id = __jakt_tmp171.common.init_common.type_id;
 TRY((this->unify_with_type(result->type(),type_id,span)));
 }
 }
@@ -10449,9 +9647,7 @@ return result;
 
 void Jakt::typechecker::Typechecker::map_generic_arguments(Jakt::ids::TypeId const type_id,JaktInternal::DynamicArray<Jakt::ids::TypeId> const args) {
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, void>{
-auto&& __jakt_match_variant = *this->get_type(type_id);
+{auto&& __jakt_match_variant = *this->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
@@ -10460,8 +9656,7 @@ JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.a
 Jakt::types::CheckedStruct const struct_ = this->get_struct(id);
 this->generic_inferences.set_all(struct_.generic_parameters,args);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_132;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -10469,8 +9664,7 @@ JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.a
 Jakt::types::CheckedEnum const enum_ = this->get_enum(id);
 this->generic_inferences.set_all(enum_.generic_parameters,args);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_132;};/*case end*/
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -10478,18 +9672,11 @@ JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.a
 NonnullRefPtr<Jakt::types::CheckedTrait> const trait_ = this->get_trait(id);
 this->generic_inferences.set_all(trait_->generic_parameters,args);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_132;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_132;}/*switch end*/
+}goto __jakt_label_132; __jakt_label_132:;;
 }
 }
 
@@ -10499,9 +9686,7 @@ NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_expr = TRY(
 Jakt::ids::TypeId const checked_expr_type_id = checked_expr->type();
 NonnullRefPtr<typename Jakt::types::Type> const checked_expr_type = this->get_type(checked_expr_type_id);
 Jakt::ids::StructId const optional_struct_id = TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv))));
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *checked_expr_type;
+{auto&& __jakt_match_variant = *checked_expr_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
@@ -10513,7 +9698,7 @@ if (!id.equals(optional_struct_id)){
 this->error(ByteString::from_utf8_without_validation("Optional chaining is only allowed on optional types"sv),span);
 return Jakt::types::CheckedExpression::IndexedStruct(JaktInternal::OptionalNone(),checked_expr,field_name,JaktInternal::OptionalNone(),span,is_optional,Jakt::types::unknown_type_id());
 }
-type_id = args.operator[](static_cast<i64>(0LL));
+type_id = args[static_cast<i64>(0LL)];
 }
 NonnullRefPtr<typename Jakt::types::Type> const type = this->get_type(type_id);
 JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> const checkpoint = this->generic_inferences.perform_checkpoint(false);
@@ -10521,9 +9706,7 @@ ScopeGuard __jakt_var_80([&] {
 this->generic_inferences.restore(checkpoint);
 });
 this->map_generic_arguments(type_id,args);
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *type;
+{auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& struct_id = __jakt_match_value.id;
@@ -10554,8 +9737,7 @@ return Jakt::types::CheckedExpression::IndexedStruct(JaktInternal::OptionalNone(
 
 this->error(__jakt_format(StringView::from_string_literal("unknown member of struct: {}.{}"sv),structure.name,field_name),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_134;};/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
 {
@@ -10585,8 +9767,7 @@ return Jakt::types::CheckedExpression::IndexedStruct(JaktInternal::OptionalNone(
 
 this->error(__jakt_format(StringView::from_string_literal("unknown member of struct: {}.{}"sv),structure.name,field_name),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_134;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& enum_id = __jakt_match_value.id;
 {
@@ -10616,8 +9797,7 @@ return Jakt::types::CheckedExpression::IndexedCommonEnumMember(JaktInternal::Opt
 
 this->error(__jakt_format(StringView::from_string_literal("unknown common member of enum: {}.{}"sv),enum_.name,field_name),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_134;};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
 {
@@ -10647,19 +9827,11 @@ return Jakt::types::CheckedExpression::IndexedCommonEnumMember(JaktInternal::Opt
 
 this->error(__jakt_format(StringView::from_string_literal("unknown common member of enum: {}.{}"sv),enum_.name,field_name),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-default:return ({this->error(__jakt_format(StringView::from_string_literal("Member field access on value of non-struct type ‘{}’"sv),TRY((this->type_name(checked_expr_type_id,false)))),span);}), JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_134;};/*case end*/
+default:this->error(__jakt_format(StringView::from_string_literal("Member field access on value of non-struct type ‘{}’"sv),TRY((this->type_name(checked_expr_type_id,false)))),span);goto __jakt_label_134;}/*switch end*/
+}goto __jakt_label_134; __jakt_label_134:;;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_133;};/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
 {
@@ -10676,8 +9848,7 @@ return Jakt::types::CheckedExpression::IndexedStruct(JaktInternal::OptionalNone(
 }
 this->error(__jakt_format(StringView::from_string_literal("unknown member of struct: {}.{}"sv),structure.name,field_name),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_133;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& enum_id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -10716,12 +9887,10 @@ return Jakt::types::CheckedExpression::IndexedCommonEnumMember(JaktInternal::Opt
 
 this->error(__jakt_format(StringView::from_string_literal("unknown common member of enum: {}.{}"sv),enum_.name,field_name),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_133;};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});
-{
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});{
 if (is_optional){
 this->error(ByteString::from_utf8_without_validation("Optional chaining is not allowed on non-optional types"sv),span);
 }
@@ -10756,16 +9925,9 @@ return Jakt::types::CheckedExpression::IndexedCommonEnumMember(JaktInternal::Opt
 
 this->error(__jakt_format(StringView::from_string_literal("unknown common member of enum: {}.{}"sv),enum_.name,field_name),span);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-default:return ({this->error(__jakt_format(StringView::from_string_literal("Member field access on value of non-struct type ‘{}’"sv),TRY((this->type_name(checked_expr_type_id,false)))),span);}), JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_133;};/*case end*/
+default:this->error(__jakt_format(StringView::from_string_literal("Member field access on value of non-struct type ‘{}’"sv),TRY((this->type_name(checked_expr_type_id,false)))),span);goto __jakt_label_133;}/*switch end*/
+}goto __jakt_label_133; __jakt_label_133:;;
 return Jakt::types::CheckedExpression::IndexedStruct(JaktInternal::OptionalNone(),checked_expr,field_name,JaktInternal::OptionalNone(),span,is_optional,Jakt::types::unknown_type_id());
 }
 }
@@ -10776,10 +9938,10 @@ NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_expr = TRY(
 Jakt::ids::StructId const tuple_struct_id = TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("Tuple"sv))));
 Jakt::ids::StructId const optional_struct_id = TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv))));
 Jakt::ids::TypeId expr_type_id = Jakt::types::unknown_type_id();
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp313 = this->get_type(checked_expr->type());
-if (__jakt_tmp313->__jakt_init_index() == 20 /* GenericInstance */){
-Jakt::ids::StructId const id = __jakt_tmp313->as.GenericInstance.id;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp313->as.GenericInstance.args;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp173 = this->get_type(checked_expr->type());
+if (__jakt_tmp173->__jakt_init_index() == 20 /* GenericInstance */){
+Jakt::ids::StructId const id = __jakt_tmp173->as.GenericInstance.id;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp173->as.GenericInstance.args;
 if (id.equals(tuple_struct_id)){
 if (is_optional){
 this->error(ByteString::from_utf8_without_validation("Optional chaining is not allowed on a non-optional tuple type"sv),span);
@@ -10788,22 +9950,22 @@ if (index >= args.size()){
 this->error(ByteString::from_utf8_without_validation("Tuple index past the end of the tuple"sv),span);
 }
 else {
-expr_type_id = args.operator[](index);
+expr_type_id = args[index];
 }
 
 }
 else if (is_optional && id.equals(optional_struct_id)){
-Jakt::ids::TypeId const inner_type_id = args.operator[](static_cast<i64>(0LL));
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp314 = this->get_type(inner_type_id);
-if (__jakt_tmp314->__jakt_init_index() == 20 /* GenericInstance */){
-Jakt::ids::StructId const id = __jakt_tmp314->as.GenericInstance.id;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp314->as.GenericInstance.args;
+Jakt::ids::TypeId const inner_type_id = args[static_cast<i64>(0LL)];
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp174 = this->get_type(inner_type_id);
+if (__jakt_tmp174->__jakt_init_index() == 20 /* GenericInstance */){
+Jakt::ids::StructId const id = __jakt_tmp174->as.GenericInstance.id;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp174->as.GenericInstance.args;
 if (id.equals(tuple_struct_id)){
 if (index >= args.size()){
 this->error(ByteString::from_utf8_without_validation("Optional-chained tuple index past the end of the tuple"sv),span);
 }
 else {
-expr_type_id = this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),optional_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({args.operator[](index)})));
+expr_type_id = this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),optional_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({args[index]})));
 }
 
 }
@@ -10868,7 +10030,7 @@ return JaktInternal::ExplicitValue(Jakt::typechecker::NumericOrStringValue::Unsi
 };/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::typechecker::NumericOrStringValue::UnsignedNumericValue(infallible_integer_cast<u64>(val)));
+return JaktInternal::ExplicitValue(Jakt::typechecker::NumericOrStringValue::UnsignedNumericValue(static_cast<u64>(val)));
 };/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& val = __jakt_match_value.value;
@@ -10876,15 +10038,15 @@ return JaktInternal::ExplicitValue(Jakt::typechecker::NumericOrStringValue::Unsi
 };/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::typechecker::NumericOrStringValue::SignedNumericValue(static_cast<i64>(val)));
+return JaktInternal::ExplicitValue(Jakt::typechecker::NumericOrStringValue::SignedNumericValue(infallible_integer_cast<i64>(val)));
 };/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::typechecker::NumericOrStringValue::SignedNumericValue(static_cast<i64>(val)));
+return JaktInternal::ExplicitValue(Jakt::typechecker::NumericOrStringValue::SignedNumericValue(infallible_integer_cast<i64>(val)));
 };/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::typechecker::NumericOrStringValue::SignedNumericValue(static_cast<i64>(val)));
+return JaktInternal::ExplicitValue(Jakt::typechecker::NumericOrStringValue::SignedNumericValue(infallible_integer_cast<i64>(val)));
 };/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& val = __jakt_match_value.value;
@@ -10913,70 +10075,48 @@ return Jakt::types::CheckedExpression::Garbage(JaktInternal::OptionalNone(),span
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedExpression>, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = index_constant;
+{auto&& __jakt_match_variant = index_constant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* StringValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StringValue;ByteString const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_indexed_struct(expr,val,scope_id,is_optional,safety_mode,span))));
-};/*case end*/
+return this->typecheck_indexed_struct(expr,val,scope_id,is_optional,safety_mode,span);};/*case end*/
 case 2 /* UnsignedNumericValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnsignedNumericValue;u64 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_indexed_tuple(expr,infallible_integer_cast<size_t>(val),scope_id,is_optional,safety_mode,span))));
-};/*case end*/
+return this->typecheck_indexed_tuple(expr,infallible_integer_cast<size_t>(val),scope_id,is_optional,safety_mode,span);};/*case end*/
 case 1 /* SignedNumericValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SignedNumericValue;i64 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_indexed_tuple(expr,infallible_integer_cast<size_t>(val),scope_id,is_optional,safety_mode,span))));
-};/*case end*/
+return this->typecheck_indexed_tuple(expr,infallible_integer_cast<size_t>(val),scope_id,is_optional,safety_mode,span);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 ErrorOr<void> Jakt::typechecker::Typechecker::check_member_access(Jakt::ids::ScopeId const accessor,Jakt::ids::ScopeId const accessee,NonnullRefPtr<Jakt::types::CheckedVariable> const member,Jakt::utility::Span const span) {
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = member->visibility;
+{auto&& __jakt_match_variant = member->visibility;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Private */:{
 if (!this->scope_can_access(accessor,accessee)){
 this->error(__jakt_format(StringView::from_string_literal("Can't access field ‘{}’, because it is marked private"sv),member->name),span);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* Restricted */: {
+goto __jakt_label_135;case 2 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::MaybeResolvedScope>> const& scopes = __jakt_match_value.scopes;
 {
 TRY((this->check_restricted_access(accessor,ByteString::from_utf8_without_validation("field"sv),accessee,member->name,scopes,span)));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_135;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_135;}/*switch end*/
+}goto __jakt_label_135; __jakt_label_135:;;
 }
 return {};
 }
 
 ErrorOr<void> Jakt::typechecker::Typechecker::check_method_access(Jakt::ids::ScopeId const accessor,Jakt::ids::ScopeId const accessee,NonnullRefPtr<Jakt::types::CheckedFunction> const method,Jakt::utility::Span const span) {
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
-auto&& __jakt_match_variant = method->visibility;
+{auto&& __jakt_match_variant = method->visibility;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Private */:{
 if (!this->scope_can_access(accessor,accessee)){
@@ -10989,24 +10129,16 @@ this->error(__jakt_format(StringView::from_string_literal("Can't access method �
 
 }
 }
-return JaktInternal::ExplicitValue<void>();
-case 2 /* Restricted */: {
+goto __jakt_label_136;case 2 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::MaybeResolvedScope>> const& scopes = __jakt_match_value.scopes;
 {
 TRY((this->check_restricted_access(accessor,ByteString::from_utf8_without_validation("function"sv),accessee,method->name,scopes,span)));
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_136;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_136;}/*switch end*/
+}goto __jakt_label_136; __jakt_label_136:;;
 }
 return {};
 }
@@ -11014,35 +10146,29 @@ return {};
 ErrorOr<bool> Jakt::typechecker::Typechecker::check_restricted_access(Jakt::ids::ScopeId const accessor,ByteString const accessee_kind,Jakt::ids::ScopeId const accessee,ByteString const name,JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::MaybeResolvedScope>> const whitelist,Jakt::utility::Span const span) {
 {
 Jakt::ids::ScopeId const most_specific_active_scope_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::ScopeId,ErrorOr<bool>> {
-auto __jakt_enum_value = (this->current_function_id.has_value());
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::ScopeId, ErrorOr<bool>>{
+auto __jakt_enum_value = this->current_function_id.has_value();
 if (__jakt_enum_value) {return JaktInternal::ExplicitValue(this->get_function(this->current_function_id.value())->function_scope_id);
 }else {{
 if (!this->current_struct_type_id.has_value()){
 this->error(__jakt_format(StringView::from_string_literal("Can't access {0} ‘{1}’ from this global scope, because ‘{1}’ restricts access to it"sv),accessee_kind,name),span);
 return false;
 }
-return JaktInternal::ExplicitValue<Jakt::ids::ScopeId>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::ScopeId, ErrorOr<bool>>{
-auto&& __jakt_match_variant = *this->get_type(this->current_struct_type_id.value());
+return JaktInternal::ExplicitValue<Jakt::ids::ScopeId>([&]() -> Jakt::ids::ScopeId { auto&& __jakt_match_variant = *this->get_type(this->current_struct_type_id.value());
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->get_struct(id).scope_id);
-};/*case end*/
+return this->get_struct(id).scope_id;};/*case end*/
 default:{
 Jakt::utility::panic(__jakt_format(StringView::from_string_literal("Internal error: current_struct_type_id is not a struct"sv),span));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+ 
+}());
 }
 VERIFY_NOT_REACHED();
-}}());
+}}()
+);
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
@@ -11057,9 +10183,9 @@ break;
 NonnullRefPtr<typename Jakt::types::MaybeResolvedScope> scope = _magic_value.value();
 {
 NonnullRefPtr<typename Jakt::types::MaybeResolvedScope> const resolved_scope = TRY((scope->try_resolve(this->program)));
-NonnullRefPtr<typename Jakt::types::MaybeResolvedScope> __jakt_tmp315 = resolved_scope;
-if (__jakt_tmp315->__jakt_init_index() == 0 /* Resolved */){
-Jakt::ids::ScopeId const scope_id = __jakt_tmp315->as.Resolved.value;
+NonnullRefPtr<typename Jakt::types::MaybeResolvedScope> __jakt_tmp175 = resolved_scope;
+if (__jakt_tmp175->__jakt_init_index() == 0 /* Resolved */){
+Jakt::ids::ScopeId const scope_id = __jakt_tmp175->as.Resolved.value;
 if (this->scope_can_access(most_specific_active_scope_id,scope_id)){
 return true;
 }
@@ -11305,29 +10431,21 @@ return expr;
 
 ErrorOr<Jakt::ids::TypeId> Jakt::typechecker::Typechecker::strip_optional_from_type(Jakt::ids::TypeId const type_id) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId, ErrorOr<Jakt::ids::TypeId>>{
-auto&& __jakt_match_variant = *this->get_type(type_id);
+{auto&& __jakt_match_variant = *this->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
 {
 if (id.equals(TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv)))))){
-return args.operator[](static_cast<i64>(0LL));
+return args[static_cast<i64>(0LL)];
 }
-return JaktInternal::ExplicitValue<Jakt::ids::TypeId>(type_id);
+return type_id;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(type_id);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return type_id;}/*switch end*/
+}
 }
 }
 
@@ -11345,36 +10463,21 @@ ErrorOr<JaktInternal::Tuple<JaktInternal::Optional<Jakt::types::StructLikeId>,bo
 {
 NonnullRefPtr<typename Jakt::types::Type> const type = this->get_type(type_id);
 bool found_optional = false;
-JaktInternal::Optional<Jakt::types::StructLikeId> const parent_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::types::StructLikeId>, ErrorOr<JaktInternal::Tuple<JaktInternal::Optional<Jakt::types::StructLikeId>,bool>>>{
-auto&& __jakt_match_variant = *type;
+JaktInternal::Optional<Jakt::types::StructLikeId> const parent_id = TRY(([&]() -> ErrorOr<JaktInternal::Optional<Jakt::types::StructLikeId>> { auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Struct(JaktInternal::OptionalNone(),id)));
-};/*case end*/
+return static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Struct(JaktInternal::OptionalNone(),id));};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Enum(JaktInternal::OptionalNone(),id)));
-};/*case end*/
-case 13 /* JaktString */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::types::StructLikeId>,ErrorOr<JaktInternal::Tuple<JaktInternal::Optional<Jakt::types::StructLikeId>,bool>>> {
-auto __jakt_enum_value = (treat_string_as_builtin);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::StructLikeId::Struct(JaktInternal::OptionalNone(),this->program->builtin_implementation_struct(type->as_builtin_type(),this->program->prelude_module_id())));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Struct(JaktInternal::OptionalNone(),TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("String"sv)))))));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 20 /* GenericInstance */: {
+return static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Enum(JaktInternal::OptionalNone(),id));};/*case end*/
+case 13 /* JaktString */:{auto __jakt_enum_value = treat_string_as_builtin;
+if (__jakt_enum_value) {return Jakt::types::StructLikeId::Struct(JaktInternal::OptionalNone(),this->program->builtin_implementation_struct(type->as_builtin_type(),this->program->prelude_module_id()));}else if (!__jakt_enum_value) {return static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Struct(JaktInternal::OptionalNone(),TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("String"sv))))));}VERIFY_NOT_REACHED();
+}case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
 {
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::types::StructLikeId>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::types::StructLikeId>,ErrorOr<JaktInternal::Tuple<JaktInternal::Optional<Jakt::types::StructLikeId>,bool>>> {
-auto __jakt_enum_value = (for_optional_chain);
+{auto __jakt_enum_value = for_optional_chain;
 if (__jakt_enum_value) {{
 Jakt::ids::StructId const optional_struct_id = TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv))));
 JaktInternal::Optional<Jakt::types::StructLikeId> struct_id = JaktInternal::OptionalNone();
@@ -11383,131 +10486,80 @@ this->error(__jakt_format(StringView::from_string_literal("Can't use ‘{}’ as
 }
 else {
 found_optional = true;
-struct_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::types::StructLikeId>, ErrorOr<JaktInternal::Tuple<JaktInternal::Optional<Jakt::types::StructLikeId>,bool>>>{
-auto&& __jakt_match_variant = *this->get_type(args.operator[](static_cast<i64>(0LL)));
+struct_id = [&]() -> JaktInternal::Optional<Jakt::types::StructLikeId> { auto&& __jakt_match_variant = *this->get_type(args[static_cast<i64>(0LL)]);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::StructLikeId::Struct(JaktInternal::OptionalNone(),struct_id));
-};/*case end*/
+return Jakt::types::StructLikeId::Struct(JaktInternal::OptionalNone(),struct_id);};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& struct_id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(Jakt::types::StructLikeId::Struct(JaktInternal::OptionalNone(),struct_id));
-};/*case end*/
+return Jakt::types::StructLikeId::Struct(JaktInternal::OptionalNone(),struct_id);};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::StructLikeId::Enum(JaktInternal::OptionalNone(),id));
-};/*case end*/
+return Jakt::types::StructLikeId::Enum(JaktInternal::OptionalNone(),id);};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(Jakt::types::StructLikeId::Enum(JaktInternal::OptionalNone(),id));
-};/*case end*/
+return Jakt::types::StructLikeId::Enum(JaktInternal::OptionalNone(),id);};/*case end*/
 default:{
 this->error(ByteString::from_utf8_without_validation("Can't use non-struct type as an optional type in optional chained call"sv),span);
 found_optional = false;
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Struct(JaktInternal::OptionalNone(),optional_struct_id));
+return Jakt::types::StructLikeId::Struct(JaktInternal::OptionalNone(),optional_struct_id);
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::types::StructLikeId>>(static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(struct_id.value_or_lazy_evaluated([&] { return Jakt::types::StructLikeId::Struct(JaktInternal::OptionalNone(),optional_struct_id); })));
+return static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(struct_id.value_or_lazy_evaluated([&] { return Jakt::types::StructLikeId::Struct(JaktInternal::OptionalNone(),optional_struct_id); }));
 }
 VERIFY_NOT_REACHED();
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Struct(args,id)));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}else if (!__jakt_enum_value) {return static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Struct(args,id));}VERIFY_NOT_REACHED();
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Enum(args,id)));
-};/*case end*/
+return static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Enum(args,id));};/*case end*/
 case 26 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Trait(JaktInternal::OptionalNone(),id)));
-};/*case end*/
+return static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Trait(JaktInternal::OptionalNone(),id));};/*case end*/
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Trait(args,id)));
-};/*case end*/
+return static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Trait(args,id));};/*case end*/
 case 18 /* TypeVariable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeVariable;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& trait_implementations = __jakt_match_value.trait_implementations;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::types::StructLikeId>,ErrorOr<JaktInternal::Tuple<JaktInternal::Optional<Jakt::types::StructLikeId>,bool>>> {
-auto __jakt_enum_value = (trait_implementations.size());
-if (__jakt_enum_value == static_cast<size_t>(0ULL)) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}else {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::types::StructLikeId>, ErrorOr<JaktInternal::Tuple<JaktInternal::Optional<Jakt::types::StructLikeId>,bool>>>{
-auto&& __jakt_match_variant = *this->get_type(trait_implementations.operator[](static_cast<i64>(0LL)));
+{auto __jakt_enum_value = trait_implementations.size();
+if (__jakt_enum_value == static_cast<size_t>(0ULL)) {return JaktInternal::OptionalNone();}else {{auto&& __jakt_match_variant = *this->get_type(trait_implementations[static_cast<i64>(0LL)]);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 26 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Trait(JaktInternal::OptionalNone(),id)));
-};/*case end*/
+return static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Trait(JaktInternal::OptionalNone(),id));};/*case end*/
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Trait(args,id)));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::types::StructLikeId>,ErrorOr<JaktInternal::Tuple<JaktInternal::Optional<Jakt::types::StructLikeId>,bool>>> {
-auto __jakt_enum_value = (type->is_builtin());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::StructLikeId::Struct(JaktInternal::OptionalNone(),this->program->builtin_implementation_struct(type->as_builtin_type(),this->program->prelude_module_id())));
-}else {{
+return static_cast<JaktInternal::Optional<Jakt::types::StructLikeId>>(Jakt::types::StructLikeId::Trait(args,id));};/*case end*/
+default:return JaktInternal::OptionalNone();}/*switch end*/
+}}}};/*case end*/
+default:{auto __jakt_enum_value = type->is_builtin();
+if (__jakt_enum_value) {return Jakt::types::StructLikeId::Struct(JaktInternal::OptionalNone(),this->program->builtin_implementation_struct(type->as_builtin_type(),this->program->prelude_module_id()));}else {{
 this->error(__jakt_format(StringView::from_string_literal("no methods available on value (type: {} {})"sv),this->get_type(type_id)->constructor_name(),TRY((this->type_name(type_id,false)))),span);
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::types::StructLikeId>>(JaktInternal::OptionalNone());
+return JaktInternal::OptionalNone();
 }
 VERIFY_NOT_REACHED();
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}}}/*switch end*/
+ 
+}()));
 return Tuple{parent_id, found_optional};
 }
 }
 
 ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>> Jakt::typechecker::Typechecker::typecheck_expression(NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr,Jakt::ids::ScopeId const scope_id,Jakt::types::SafetyMode const safety_mode,JaktInternal::Optional<Jakt::typechecker::TypeHint> const type_hint) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedExpression>, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *expr;
+{auto&& __jakt_match_variant = *expr;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* IndexedStruct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedStruct;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expr = __jakt_match_value.expr;
@@ -11516,16 +10568,16 @@ Jakt::utility::Span const& span = __jakt_match_value.span;
 bool const& is_optional = __jakt_match_value.is_optional;
 {
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const result = TRY((this->typecheck_indexed_struct(expr,field_name,scope_id,is_optional,safety_mode,span)));
-JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp317 = type_hint;
-if (__jakt_tmp317.has_value()){
-Jakt::typechecker::TypeHint const hint = __jakt_tmp317.value();
-Jakt::typechecker::TypeHint __jakt_tmp316 = hint;
-if (__jakt_tmp316.__jakt_init_index() == 0 /* MustBe */){
-Jakt::ids::TypeId const type_id = __jakt_tmp316.common.init_common.type_id;
+JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp177 = type_hint;
+if (__jakt_tmp177.has_value()){
+Jakt::typechecker::TypeHint const hint = __jakt_tmp177.value();
+Jakt::typechecker::TypeHint __jakt_tmp176 = hint;
+if (__jakt_tmp176.__jakt_init_index() == 0 /* MustBe */){
+Jakt::ids::TypeId const type_id = __jakt_tmp176.common.init_common.type_id;
 TRY((this->unify_with_type(result->type(),type_id,span)));
 }
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -11536,16 +10588,16 @@ Jakt::utility::Span const& span = __jakt_match_value.span;
 bool const& is_optional = __jakt_match_value.is_optional;
 {
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const result = TRY((this->typecheck_comptime_index(expr,index,scope_id,is_optional,safety_mode,span)));
-JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp319 = type_hint;
-if (__jakt_tmp319.has_value()){
-Jakt::typechecker::TypeHint const hint = __jakt_tmp319.value();
-Jakt::typechecker::TypeHint __jakt_tmp318 = hint;
-if (__jakt_tmp318.__jakt_init_index() == 0 /* MustBe */){
-Jakt::ids::TypeId const type_id = __jakt_tmp318.common.init_common.type_id;
+JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp179 = type_hint;
+if (__jakt_tmp179.has_value()){
+Jakt::typechecker::TypeHint const hint = __jakt_tmp179.value();
+Jakt::typechecker::TypeHint __jakt_tmp178 = hint;
+if (__jakt_tmp178.__jakt_init_index() == 0 /* MustBe */){
+Jakt::ids::TypeId const type_id = __jakt_tmp178.common.init_common.type_id;
 TRY((this->unify_with_type(result->type(),type_id,span)));
 }
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -11556,7 +10608,7 @@ Jakt::utility::Span const& span = __jakt_match_value.span;
 if (type_hint.has_value()){
 TRY((this->unify_with_type(Jakt::types::builtin(Jakt::types::BuiltinType::Bool()),type_hint.value().common.init_common.type_id,span)));
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::Boolean(JaktInternal::OptionalNone(),val,span));
+return Jakt::types::CheckedExpression::Boolean(JaktInternal::OptionalNone(),val,span);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -11568,79 +10620,60 @@ JaktInternal::Optional<Jakt::ids::TypeId> type_hint_unwrapped = JaktInternal::Op
 if (type_hint.has_value()){
 type_hint_unwrapped = TRY((this->unwrap_type_id_from_optional_if_needed(type_hint.value().common.init_common.type_id)));
 }
-NonnullRefPtr<typename Jakt::types::CheckedExpression> const result = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedExpression>, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = val;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const result = TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>> { auto&& __jakt_match_variant = val;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I8(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::I8())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I8(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::I8()));};/*case end*/
 case 1 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I16(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::I16())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I16(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::I16()));};/*case end*/
 case 2 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I32(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::I32())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I32(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::I32()));};/*case end*/
 case 3 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I64(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::I64())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::I64(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::I64()));};/*case end*/
 case 4 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::U8(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::U8())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::U8(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::U8()));};/*case end*/
 case 5 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::U16(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::U16())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::U16(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::U16()));};/*case end*/
 case 6 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::U32(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::U32())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::U32(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::U32()));};/*case end*/
 case 7 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::U64(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::U64())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::U64(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::U64()));};/*case end*/
 case 8 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;u64 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::USize(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::Usize())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::USize(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::Usize()));};/*case end*/
 case 9 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::F32(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::F32())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::F32(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::F32()));};/*case end*/
 case 10 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::F64(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::F64())));
-};/*case end*/
+return Jakt::types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),Jakt::types::CheckedNumericConstant::F64(val),span,Jakt::types::builtin(Jakt::types::BuiltinType::F64()));};/*case end*/
 case 11 /* UnknownSigned */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnknownSigned;i64 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((this->infer_signed_int(val,span,type_hint_unwrapped))));
-};/*case end*/
+return this->infer_signed_int(val,span,type_hint_unwrapped);};/*case end*/
 case 12 /* UnknownUnsigned */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnknownUnsigned;u64 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((this->infer_unsigned_int(val,span,type_hint_unwrapped))));
-};/*case end*/
+return this->infer_unsigned_int(val,span,type_hint_unwrapped);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp321 = type_hint;
-if (__jakt_tmp321.has_value()){
-Jakt::typechecker::TypeHint const hint = __jakt_tmp321.value();
-Jakt::typechecker::TypeHint __jakt_tmp320 = hint;
-if (__jakt_tmp320.__jakt_init_index() == 0 /* MustBe */){
-Jakt::ids::TypeId const type_id = __jakt_tmp320.common.init_common.type_id;
+ 
+}()));
+JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp181 = type_hint;
+if (__jakt_tmp181.has_value()){
+Jakt::typechecker::TypeHint const hint = __jakt_tmp181.value();
+Jakt::typechecker::TypeHint __jakt_tmp180 = hint;
+if (__jakt_tmp180.__jakt_init_index() == 0 /* MustBe */){
+Jakt::ids::TypeId const type_id = __jakt_tmp180.common.init_common.type_id;
 TRY((this->unify_with_type(result->type(),type_id,span)));
 }
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -11649,39 +10682,29 @@ auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;ByteStrin
 JaktInternal::Optional<ByteString> const& prefix = __jakt_match_value.prefix;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
-NonnullRefPtr<typename Jakt::types::CheckedExpression> const result = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedExpression>,ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>> {
-auto __jakt_enum_value = (prefix.value_or_lazy_evaluated([&] { return ByteString::from_utf8_without_validation(""sv); }));
-if (__jakt_enum_value == ByteString::from_utf8_without_validation(""sv)) {return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::CharacterConstant(JaktInternal::OptionalNone(),val,span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("b"sv)) {return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::ByteConstant(JaktInternal::OptionalNone(),val,span));
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("c"sv)) {return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::CCharacterConstant(JaktInternal::OptionalNone(),val,span));
-}else {{
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const result = [&]() -> NonnullRefPtr<typename Jakt::types::CheckedExpression> { auto __jakt_enum_value = prefix.value_or_lazy_evaluated([&] { return ByteString::from_utf8_without_validation(""sv); });
+if (__jakt_enum_value == ByteString::from_utf8_without_validation(""sv)) {return Jakt::types::CheckedExpression::CharacterConstant(JaktInternal::OptionalNone(),val,span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("b"sv)) {return Jakt::types::CheckedExpression::ByteConstant(JaktInternal::OptionalNone(),val,span);}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("c"sv)) {return Jakt::types::CheckedExpression::CCharacterConstant(JaktInternal::OptionalNone(),val,span);}else {{
 this->compiler->panic(__jakt_format(StringView::from_string_literal("Unknown string prefix {}"sv),prefix));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp323 = type_hint;
-if (__jakt_tmp323.has_value()){
-Jakt::typechecker::TypeHint const hint = __jakt_tmp323.value();
-Jakt::typechecker::TypeHint __jakt_tmp322 = hint;
-if (__jakt_tmp322.__jakt_init_index() == 0 /* MustBe */){
-Jakt::ids::TypeId const type_id = __jakt_tmp322.common.init_common.type_id;
+} 
+}();
+JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp183 = type_hint;
+if (__jakt_tmp183.has_value()){
+Jakt::typechecker::TypeHint const hint = __jakt_tmp183.value();
+Jakt::typechecker::TypeHint __jakt_tmp182 = hint;
+if (__jakt_tmp182.__jakt_init_index() == 0 /* MustBe */){
+Jakt::ids::TypeId const type_id = __jakt_tmp182.common.init_common.type_id;
 TRY((this->unify_with_type(result->type(),type_id,span)));
 }
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 2 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;ByteString const& val = __jakt_match_value.val;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedExpression>,ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>> {
-auto __jakt_enum_value = (type_hint.has_value() && (!type_hint.value().common.init_common.type_id.equals(Jakt::types::unknown_type_id())));
+{auto __jakt_enum_value = type_hint.has_value() && (!type_hint.value().common.init_common.type_id.equals(Jakt::types::unknown_type_id()));
 if (__jakt_enum_value) {{
 Jakt::ids::TypeId type_id = TRY((this->strip_optional_from_type(this->generic_inferences.map(type_hint.value().common.init_common.type_id))));
 Jakt::ids::TypeId const prelude_string_type_id = TRY((this->prelude_struct_type_named(ByteString::from_utf8_without_validation("String"sv))));
@@ -11707,34 +10730,28 @@ TRY((this->unify(type_hint.value().common.init_common.type_id,span,type_id,span)
 if (may_throw && (!this->get_scope(scope_id)->can_throw)){
 this->error(ByteString::from_utf8_without_validation("Operation that may throw needs to be in a try statement or a function marked as throws"sv),span);
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),Jakt::types::CheckedStringLiteral(Jakt::types::StringLiteral::Static(val),type_id,may_throw),span));
+return Jakt::types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),Jakt::types::CheckedStringLiteral(Jakt::types::StringLiteral::Static(val),type_id,may_throw),span);
 }
 VERIFY_NOT_REACHED();
 }else {{
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const result = Jakt::types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),Jakt::types::CheckedStringLiteral(Jakt::types::StringLiteral::Static(val),TRY((this->prelude_struct_type_named(ByteString::from_utf8_without_validation("String"sv)))),false),span);
-JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp325 = type_hint;
-if (__jakt_tmp325.has_value()){
-Jakt::typechecker::TypeHint const hint = __jakt_tmp325.value();
-Jakt::typechecker::TypeHint __jakt_tmp324 = hint;
-if (__jakt_tmp324.__jakt_init_index() == 0 /* MustBe */){
-Jakt::ids::TypeId const type_id = __jakt_tmp324.common.init_common.type_id;
+JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp185 = type_hint;
+if (__jakt_tmp185.has_value()){
+Jakt::typechecker::TypeHint const hint = __jakt_tmp185.value();
+Jakt::typechecker::TypeHint __jakt_tmp184 = hint;
+if (__jakt_tmp184.__jakt_init_index() == 0 /* MustBe */){
+Jakt::ids::TypeId const type_id = __jakt_tmp184.common.init_common.type_id;
 TRY((this->unify_with_type(result->type(),type_id,span)));
 }
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}}};/*case end*/
 case 4 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::parser::ParsedCall const& call = __jakt_match_value.call;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_call(call,scope_id,span,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),safety_mode,type_hint,false))));
-};/*case end*/
+return this->typecheck_call(call,scope_id,span,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),safety_mode,type_hint,false);};/*case end*/
 case 5 /* MethodCall */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MethodCall;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expr = __jakt_match_value.expr;
 Jakt::parser::ParsedCall const& call = __jakt_match_value.call;
@@ -11754,9 +10771,7 @@ this->error(__jakt_format(StringView::from_string_literal("Optional chain mismat
 }
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_call_expr = TRY((this->typecheck_call(call,scope_id,span,checked_expr,parent_id,safety_mode,type_hint,false)));
 Jakt::ids::TypeId const type_id = checked_call_expr->type();
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedExpression>, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *checked_call_expr;
+{auto&& __jakt_match_variant = *checked_call_expr;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::types::CheckedCall const& call = __jakt_match_value.call;
@@ -11766,7 +10781,7 @@ if (is_optional){
 Jakt::ids::StructId const optional_struct_id = TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv))));
 result_type = this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),optional_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({result_type})));
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::MethodCall(JaktInternal::OptionalNone(),checked_expr,call,span,is_optional,result_type));
+return Jakt::types::CheckedExpression::MethodCall(JaktInternal::OptionalNone(),checked_expr,call,span,is_optional,result_type);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -11774,12 +10789,7 @@ default:{
 this->compiler->panic(ByteString::from_utf8_without_validation("typecheck_call should return `CheckedExpression::Call()`"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -11829,16 +10839,16 @@ values_type_id = to_type;
 Jakt::ids::StructId const range_struct_id = TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("Range"sv))));
 NonnullRefPtr<typename Jakt::types::Type> const range_type = Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),range_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({values_type_id.value_or(Jakt::types::builtin(Jakt::types::BuiltinType::I64()))}));
 Jakt::ids::TypeId const type_id = this->find_or_add_type_id(range_type);
-JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp327 = type_hint;
-if (__jakt_tmp327.has_value()){
-Jakt::typechecker::TypeHint const hint = __jakt_tmp327.value();
-Jakt::typechecker::TypeHint __jakt_tmp326 = hint;
-if (__jakt_tmp326.__jakt_init_index() == 0 /* MustBe */){
-Jakt::ids::TypeId const hint_id = __jakt_tmp326.common.init_common.type_id;
+JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp187 = type_hint;
+if (__jakt_tmp187.has_value()){
+Jakt::typechecker::TypeHint const hint = __jakt_tmp187.value();
+Jakt::typechecker::TypeHint __jakt_tmp186 = hint;
+if (__jakt_tmp186.__jakt_init_index() == 0 /* MustBe */){
+Jakt::ids::TypeId const hint_id = __jakt_tmp186.common.init_common.type_id;
 TRY((this->unify_with_type(type_id,hint_id,span)));
 }
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::Range(JaktInternal::OptionalNone(),checked_from,checked_to,span,type_id));
+return Jakt::types::CheckedExpression::Range(JaktInternal::OptionalNone(),checked_from,checked_to,span,type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -11846,26 +10856,19 @@ case 29 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;NonnullRefPtr<typename Jakt::parser::ParsedType> const& type = __jakt_match_value.type;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
-Jakt::ids::EnumId const reflected_type_enum_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::EnumId, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Type"sv))));
+Jakt::ids::EnumId const reflected_type_enum_id = TRY(([&]() -> ErrorOr<Jakt::ids::EnumId> { auto&& __jakt_match_variant = TRY((this->program->find_reflected_primitive(ByteString::from_utf8_without_validation("Type"sv))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(id);
-};/*case end*/
+return id;};/*case end*/
 default:{
 this->compiler->panic(ByteString::from_utf8_without_validation("unreachable"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 Jakt::ids::TypeId const reflected_type = TRY((this->typecheck_typename(type,scope_id,JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::Reflect(JaktInternal::OptionalNone(),reflected_type,span,this->find_or_add_type_id(Jakt::types::Type::Enum(Jakt::parser::CheckedQualifiers(false),reflected_type_enum_id))));
+return Jakt::types::CheckedExpression::Reflect(JaktInternal::OptionalNone(),reflected_type,span,this->find_or_add_type_id(Jakt::types::Type::Enum(Jakt::parser::CheckedQualifiers(false),reflected_type_enum_id)));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -11874,83 +10877,45 @@ auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;NonnullRefPtr<typena
 Jakt::parser::UnaryOperator const& op = __jakt_match_value.op;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
-NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_expr = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedExpression>, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = op;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_expr = TRY(([&]() -> ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>> { auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 5 /* Dereference */:return JaktInternal::ExplicitValue(TRY((this->typecheck_expression(expr,scope_id,safety_mode,JaktInternal::OptionalNone()))));
-case 4 /* Negate */:return JaktInternal::ExplicitValue(TRY((this->typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,type_hint,span))));
-case 11 /* TypeCast */: {
+case 5 /* Dereference */:return this->typecheck_expression(expr,scope_id,safety_mode,JaktInternal::OptionalNone());case 4 /* Negate */:return this->typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,type_hint,span);case 11 /* TypeCast */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeCast;Jakt::parser::TypeCast const& cast = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedExpression>, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = cast;
+{auto&& __jakt_match_variant = cast;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Infallible */:{
 Jakt::typechecker::TypeHint const type_hint = Jakt::typechecker::TypeHint::CouldBe(TRY((this->typecheck_typename(cast.parsed_type(),scope_id,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()))));
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(TRY((this->typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,type_hint,span))));
+return this->typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,type_hint,span);
 }
 VERIFY_NOT_REACHED();
-default:return JaktInternal::ExplicitValue(TRY((this->typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(TRY((this->typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-Jakt::types::CheckedUnaryOperator const checked_op = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::CheckedUnaryOperator, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = op;
+default:return this->typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span);}/*switch end*/
+}};/*case end*/
+default:return this->typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span);}/*switch end*/
+ 
+}()));
+Jakt::types::CheckedUnaryOperator const checked_op = TRY(([&]() -> ErrorOr<Jakt::types::CheckedUnaryOperator> { auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* PreIncrement */:return JaktInternal::ExplicitValue(Jakt::types::CheckedUnaryOperator::PreIncrement());
-case 1 /* PostIncrement */:return JaktInternal::ExplicitValue(Jakt::types::CheckedUnaryOperator::PostIncrement());
-case 2 /* PreDecrement */:return JaktInternal::ExplicitValue(Jakt::types::CheckedUnaryOperator::PreDecrement());
-case 3 /* PostDecrement */:return JaktInternal::ExplicitValue(Jakt::types::CheckedUnaryOperator::PostDecrement());
-case 4 /* Negate */:return JaktInternal::ExplicitValue(Jakt::types::CheckedUnaryOperator::Negate());
-case 5 /* Dereference */:return JaktInternal::ExplicitValue(Jakt::types::CheckedUnaryOperator::Dereference());
-case 6 /* RawAddress */:return JaktInternal::ExplicitValue(Jakt::types::CheckedUnaryOperator::RawAddress());
-case 7 /* Reference */:return JaktInternal::ExplicitValue(Jakt::types::CheckedUnaryOperator::Reference());
-case 8 /* MutableReference */:return JaktInternal::ExplicitValue(Jakt::types::CheckedUnaryOperator::MutableReference());
-case 9 /* LogicalNot */:return JaktInternal::ExplicitValue(Jakt::types::CheckedUnaryOperator::LogicalNot());
-case 10 /* BitwiseNot */:return JaktInternal::ExplicitValue(Jakt::types::CheckedUnaryOperator::BitwiseNot());
-case 11 /* TypeCast */: {
+case 0 /* PreIncrement */:return Jakt::types::CheckedUnaryOperator::PreIncrement();case 1 /* PostIncrement */:return Jakt::types::CheckedUnaryOperator::PostIncrement();case 2 /* PreDecrement */:return Jakt::types::CheckedUnaryOperator::PreDecrement();case 3 /* PostDecrement */:return Jakt::types::CheckedUnaryOperator::PostDecrement();case 4 /* Negate */:return Jakt::types::CheckedUnaryOperator::Negate();case 5 /* Dereference */:return Jakt::types::CheckedUnaryOperator::Dereference();case 6 /* RawAddress */:return Jakt::types::CheckedUnaryOperator::RawAddress();case 7 /* Reference */:return Jakt::types::CheckedUnaryOperator::Reference();case 8 /* MutableReference */:return Jakt::types::CheckedUnaryOperator::MutableReference();case 9 /* LogicalNot */:return Jakt::types::CheckedUnaryOperator::LogicalNot();case 10 /* BitwiseNot */:return Jakt::types::CheckedUnaryOperator::BitwiseNot();case 11 /* TypeCast */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeCast;Jakt::parser::TypeCast const& cast = __jakt_match_value.value;
 {
 Jakt::ids::TypeId const type_id = TRY((this->typecheck_typename(cast.parsed_type(),scope_id,JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
-Jakt::types::CheckedTypeCast const checked_cast = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::CheckedTypeCast, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = cast;
+Jakt::types::CheckedTypeCast const checked_cast = TRY(([&]() -> ErrorOr<Jakt::types::CheckedTypeCast> { auto&& __jakt_match_variant = cast;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Fallible */:{
 Jakt::ids::StructId const optional_struct_id = TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv))));
 NonnullRefPtr<typename Jakt::types::Type> const optional_type = Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),optional_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({type_id}));
 Jakt::ids::TypeId const optional_type_id = this->find_or_add_type_id(optional_type);
-return JaktInternal::ExplicitValue<Jakt::types::CheckedTypeCast>(Jakt::types::CheckedTypeCast::Fallible(optional_type_id));
+return Jakt::types::CheckedTypeCast::Fallible(optional_type_id);
 }
 VERIFY_NOT_REACHED();
-case 1 /* Infallible */:return JaktInternal::ExplicitValue(Jakt::types::CheckedTypeCast::Infallible(type_id));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 1 /* Infallible */:return Jakt::types::CheckedTypeCast::Infallible(type_id);default: VERIFY_NOT_REACHED();}/*switch end*/
+ 
+}()));
 Jakt::types::CheckedUnaryOperator result = Jakt::types::CheckedUnaryOperator::TypeCast(checked_cast);
 if (checked_cast.type_id().equals(checked_expr->type())){
 result = Jakt::types::CheckedUnaryOperator::TypeCast(Jakt::types::CheckedTypeCast::Identity(type_id));
 }
-return JaktInternal::ExplicitValue<Jakt::types::CheckedUnaryOperator>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -11958,7 +10923,7 @@ case 14 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;NonnullRefPtr<typename Jakt::parser::ParsedType> const& unchecked_type = __jakt_match_value.value;
 {
 Jakt::ids::TypeId const type_id = TRY((this->typecheck_typename(unchecked_type,scope_id,JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
-return JaktInternal::ExplicitValue<Jakt::types::CheckedUnaryOperator>(Jakt::types::CheckedUnaryOperator::Sizeof(type_id));
+return Jakt::types::CheckedUnaryOperator::Sizeof(type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -11969,13 +10934,13 @@ JaktInternal::Tuple<bool,bool> const snapshot = this->enter_ignore_error_mode(tr
 Jakt::ids::TypeId const type_id = TRY((this->typecheck_typename(unchecked_type,scope_id,JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
 this->exit_ignore_error_mode(snapshot);
 Jakt::types::CheckedUnaryOperator operator_is = Jakt::types::CheckedUnaryOperator::Is(type_id);
-NonnullRefPtr<typename Jakt::parser::ParsedType> __jakt_tmp328 = unchecked_type;
-if (__jakt_tmp328->__jakt_init_index() == 0 /* Name */){
-ByteString const name = __jakt_tmp328->as.Name.name;
+NonnullRefPtr<typename Jakt::parser::ParsedType> __jakt_tmp188 = unchecked_type;
+if (__jakt_tmp188->__jakt_init_index() == 0 /* Name */){
+ByteString const name = __jakt_tmp188->as.Name.name;
 Jakt::ids::TypeId const expr_type_id = checked_expr->type();
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp329 = this->get_type(expr_type_id);
-if (__jakt_tmp329->__jakt_init_index() == 24 /* Enum */){
-Jakt::ids::EnumId const enum_id = __jakt_tmp329->as.Enum.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp189 = this->get_type(expr_type_id);
+if (__jakt_tmp189->__jakt_init_index() == 24 /* Enum */){
+Jakt::ids::EnumId const enum_id = __jakt_tmp189->as.Enum.value;
 Jakt::types::CheckedEnum const enum_ = this->get_enum(enum_id);
 bool exists = false;
 {
@@ -11987,37 +10952,23 @@ break;
 }
 Jakt::types::CheckedEnumVariant variant = _magic_value.value();
 {
-exists = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = variant;
+exists = [&]() -> bool { auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;ByteString const& var_name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(var_name == name);
-};/*case end*/
+return var_name == name;};/*case end*/
 case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;ByteString const& var_name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(var_name == name);
-};/*case end*/
+return var_name == name;};/*case end*/
 case 0 /* Untyped */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Untyped;ByteString const& var_name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(var_name == name);
-};/*case end*/
+return var_name == name;};/*case end*/
 case 2 /* WithValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.WithValue;ByteString const& var_name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(var_name == name);
-};/*case end*/
+return var_name == name;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}();
 if (exists){
 operator_is = Jakt::types::CheckedUnaryOperator::IsEnumVariant(variant,DynamicArray<Jakt::types::CheckedEnumVariantBinding>::create_with({}),expr_type_id);
 break;
@@ -12037,19 +10988,12 @@ NonnullRefPtr<typename Jakt::types::Type> const checked_expr_type = this->get_ty
 if (!(checked_expr_type->__jakt_init_index() == 20 /* GenericInstance */)){
 this->error(__jakt_format(StringView::from_string_literal("The left-hand side of an `is {}` statement must have a {} variant"sv),name,name),checked_expr->span());
 }
-operator_is = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::CheckedUnaryOperator,ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>> {
-auto __jakt_enum_value = (name);
-if (__jakt_enum_value == ByteString::from_utf8_without_validation("Some"sv)) {return JaktInternal::ExplicitValue(Jakt::types::CheckedUnaryOperator::IsSome());
-}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("None"sv)) {return JaktInternal::ExplicitValue(Jakt::types::CheckedUnaryOperator::IsNone());
-}else {{
+operator_is = [&]() -> Jakt::types::CheckedUnaryOperator { auto __jakt_enum_value = name;
+if (__jakt_enum_value == ByteString::from_utf8_without_validation("Some"sv)) {return Jakt::types::CheckedUnaryOperator::IsSome();}else if (__jakt_enum_value == ByteString::from_utf8_without_validation("None"sv)) {return Jakt::types::CheckedUnaryOperator::IsNone();}else {{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("unreachable"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+} 
+}();
 }
 else if (type_id.equals(Jakt::types::unknown_type_id())){
 this->error(__jakt_format(StringView::from_string_literal("Unknown type or invalid type name: {}"sv),name),span);
@@ -12059,33 +11003,28 @@ else {
 this->error(ByteString::from_utf8_without_validation("The right-hand side of an `is` operator must be a type name or enum variant"sv),span);
 }
 
-return JaktInternal::ExplicitValue<Jakt::types::CheckedUnaryOperator>(operator_is);
+return operator_is;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 13 /* IsEnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IsEnumVariant;NonnullRefPtr<typename Jakt::parser::ParsedType> const& inner = __jakt_match_value.inner;
 JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> const& bindings = __jakt_match_value.bindings;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_is_enum_variant(checked_expr,inner,bindings,scope_id))));
-};/*case end*/
+return this->typecheck_is_enum_variant(checked_expr,inner,bindings,scope_id);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const result = TRY((this->typecheck_unary_operation(checked_expr,checked_op,span,scope_id,safety_mode)));
-JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp331 = type_hint;
-if (__jakt_tmp331.has_value()){
-Jakt::typechecker::TypeHint const hint = __jakt_tmp331.value();
-Jakt::typechecker::TypeHint __jakt_tmp330 = hint;
-if (__jakt_tmp330.__jakt_init_index() == 0 /* MustBe */){
-Jakt::ids::TypeId const type_id = __jakt_tmp330.common.init_common.type_id;
+JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp191 = type_hint;
+if (__jakt_tmp191.has_value()){
+Jakt::typechecker::TypeHint const hint = __jakt_tmp191.value();
+Jakt::typechecker::TypeHint __jakt_tmp190 = hint;
+if (__jakt_tmp190.__jakt_init_index() == 0 /* MustBe */){
+Jakt::ids::TypeId const type_id = __jakt_tmp190.common.init_common.type_id;
 TRY((this->unify_with_type(result->type(),type_id,span)));
 }
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -12099,9 +11038,9 @@ JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> o
 JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> original_checked_rhs = JaktInternal::OptionalNone();
 JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> checked_lhs = JaktInternal::OptionalNone();
 JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> checked_rhs = JaktInternal::OptionalNone();
-NonnullRefPtr<typename Jakt::parser::ParsedExpression> __jakt_tmp332 = lhs;
-if (__jakt_tmp332->__jakt_init_index() == 1 /* NumericConstant */){
-Jakt::parser::NumericConstant const val = __jakt_tmp332->as.NumericConstant.val;
+NonnullRefPtr<typename Jakt::parser::ParsedExpression> __jakt_tmp192 = lhs;
+if (__jakt_tmp192->__jakt_init_index() == 1 /* NumericConstant */){
+Jakt::parser::NumericConstant const val = __jakt_tmp192->as.NumericConstant.val;
 if ((val.__jakt_init_index() == 11 /* UnknownSigned */) || (val.__jakt_init_index() == 12 /* UnknownUnsigned */)){
 original_checked_rhs = TRY((this->typecheck_expression(rhs,scope_id,safety_mode,JaktInternal::OptionalNone())));
 checked_rhs = TRY((this->dereference_if_needed(original_checked_rhs.value(),span)));
@@ -12127,9 +11066,9 @@ checked_rhs = TRY((this->dereference_if_needed(original_checked_rhs.value(),span
 }
 
 if (this->type_contains_reference(original_checked_lhs.value()->type())){
-NonnullRefPtr<typename Jakt::parser::ParsedExpression> __jakt_tmp333 = rhs;
-if (__jakt_tmp333->__jakt_init_index() == 11 /* UnaryOp */){
-Jakt::parser::UnaryOperator const op = __jakt_tmp333->as.UnaryOp.op;
+NonnullRefPtr<typename Jakt::parser::ParsedExpression> __jakt_tmp193 = rhs;
+if (__jakt_tmp193->__jakt_init_index() == 11 /* UnaryOp */){
+Jakt::parser::UnaryOperator const op = __jakt_tmp193->as.UnaryOp.op;
 if ((op.__jakt_init_index() == 7 /* Reference */) || (op.__jakt_init_index() == 8 /* MutableReference */)){
 this->error_with_hint(ByteString::from_utf8_without_validation("Attempt to rebind a reference will result in write-through"sv),span,ByteString::from_utf8_without_validation("This reference will be immediately dereferenced and then assigned"sv),rhs->span());
 }
@@ -12139,16 +11078,16 @@ JaktInternal::Tuple<Jakt::types::CheckedBinaryOperator,Jakt::ids::TypeId> const 
 Jakt::types::CheckedBinaryOperator const checked_operator = checked_operator_output_type_.template get<0>();
 Jakt::ids::TypeId const output_type = checked_operator_output_type_.template get<1>();
 
-JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp335 = type_hint;
-if (__jakt_tmp335.has_value()){
-Jakt::typechecker::TypeHint const hint = __jakt_tmp335.value();
-Jakt::typechecker::TypeHint __jakt_tmp334 = hint;
-if (__jakt_tmp334.__jakt_init_index() == 0 /* MustBe */){
-Jakt::ids::TypeId const type_id = __jakt_tmp334.common.init_common.type_id;
+JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp195 = type_hint;
+if (__jakt_tmp195.has_value()){
+Jakt::typechecker::TypeHint const hint = __jakt_tmp195.value();
+Jakt::typechecker::TypeHint __jakt_tmp194 = hint;
+if (__jakt_tmp194.__jakt_init_index() == 0 /* MustBe */){
+Jakt::ids::TypeId const type_id = __jakt_tmp194.common.init_common.type_id;
 TRY((this->unify_with_type(output_type,type_id,span)));
 }
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::BinaryOp(JaktInternal::OptionalNone(),checked_lhs.value(),checked_operator,checked_rhs.value(),span,output_type));
+return Jakt::types::CheckedExpression::BinaryOp(JaktInternal::OptionalNone(),checked_lhs.value(),checked_operator,checked_rhs.value(),span,output_type);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -12159,16 +11098,16 @@ JaktInternal::Optional<Jakt::ids::TypeId> type_hint_unwrapped = JaktInternal::Op
 if (type_hint.has_value()){
 type_hint_unwrapped = TRY((this->unwrap_type_id_from_optional_if_needed(type_hint.value().common.init_common.type_id)));
 }
-JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp337 = type_hint;
-if (__jakt_tmp337.has_value()){
-Jakt::typechecker::TypeHint const hint = __jakt_tmp337.value();
-Jakt::typechecker::TypeHint __jakt_tmp336 = hint;
-if (__jakt_tmp336.__jakt_init_index() == 0 /* MustBe */){
-Jakt::ids::TypeId const type_id = __jakt_tmp336.common.init_common.type_id;
+JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp197 = type_hint;
+if (__jakt_tmp197.has_value()){
+Jakt::typechecker::TypeHint const hint = __jakt_tmp197.value();
+Jakt::typechecker::TypeHint __jakt_tmp196 = hint;
+if (__jakt_tmp196.__jakt_init_index() == 0 /* MustBe */){
+Jakt::ids::TypeId const type_id = __jakt_tmp196.common.init_common.type_id;
 TRY((this->unify_with_type(type_hint_unwrapped.value_or_lazy_evaluated([&] { return Jakt::types::unknown_type_id(); }),type_id,span)));
 }
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::OptionalNone(JaktInternal::OptionalNone(),span,type_hint_unwrapped.value_or_lazy_evaluated([&] { return Jakt::types::unknown_type_id(); })));
+return Jakt::types::CheckedExpression::OptionalNone(JaktInternal::OptionalNone(),span,type_hint_unwrapped.value_or_lazy_evaluated([&] { return Jakt::types::unknown_type_id(); }));
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -12190,16 +11129,16 @@ type_id = TRY((this->choose_broader_type_id(type_id,type_hint_unwrapped_id,this-
 Jakt::ids::StructId const optional_struct_id = TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv))));
 NonnullRefPtr<typename Jakt::types::Type> const optional_type = Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),optional_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({type_id}));
 Jakt::ids::TypeId const optional_type_id = this->find_or_add_type_id(optional_type);
-JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp339 = type_hint;
-if (__jakt_tmp339.has_value()){
-Jakt::typechecker::TypeHint const hint = __jakt_tmp339.value();
-Jakt::typechecker::TypeHint __jakt_tmp338 = hint;
-if (__jakt_tmp338.__jakt_init_index() == 0 /* MustBe */){
-Jakt::ids::TypeId const type_id = __jakt_tmp338.common.init_common.type_id;
+JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp199 = type_hint;
+if (__jakt_tmp199.has_value()){
+Jakt::typechecker::TypeHint const hint = __jakt_tmp199.value();
+Jakt::typechecker::TypeHint __jakt_tmp198 = hint;
+if (__jakt_tmp198.__jakt_init_index() == 0 /* MustBe */){
+Jakt::ids::TypeId const type_id = __jakt_tmp198.common.init_common.type_id;
 TRY((this->unify_with_type(optional_type_id,type_id,span)));
 }
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::OptionalSome(JaktInternal::OptionalNone(),checked_expr,span,optional_type_id));
+return Jakt::types::CheckedExpression::OptionalSome(JaktInternal::OptionalNone(),checked_expr,span,optional_type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -12208,34 +11147,28 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Var;ByteString const& name =
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedVariable>> const var = TRY((this->find_var_in_scope(scope_id,name,JaktInternal::OptionalNone())));
-NonnullRefPtr<typename Jakt::types::CheckedExpression> const result = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedExpression>,ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>> {
-auto __jakt_enum_value = (var.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::Var(JaktInternal::OptionalNone(),var.value(),span));
-}else {{
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const result = [&]() -> NonnullRefPtr<typename Jakt::types::CheckedExpression> { auto __jakt_enum_value = var.has_value();
+if (__jakt_enum_value) {return Jakt::types::CheckedExpression::Var(JaktInternal::OptionalNone(),var.value(),span);}else {{
 this->error(__jakt_format(StringView::from_string_literal("Variable '{}' not found"sv),name),span);
 JaktInternal::Optional<Jakt::ids::TypeId> type_id = JaktInternal::OptionalNone();
 if (type_hint.has_value()){
 type_id = type_hint.value().common.init_common.type_id;
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::Var(JaktInternal::OptionalNone(),Jakt::types::CheckedVariable::__jakt_create(name,type_id.value_or(Jakt::types::unknown_type_id()),false,span,JaktInternal::OptionalNone(),Jakt::types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone()),span));
+return Jakt::types::CheckedExpression::Var(JaktInternal::OptionalNone(),Jakt::types::CheckedVariable::__jakt_create(name,type_id.value_or(Jakt::types::unknown_type_id()),false,span,JaktInternal::OptionalNone(),Jakt::types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone()),span);
 }
 VERIFY_NOT_REACHED();
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp341 = type_hint;
-if (__jakt_tmp341.has_value()){
-Jakt::typechecker::TypeHint const hint = __jakt_tmp341.value();
-Jakt::typechecker::TypeHint __jakt_tmp340 = hint;
-if (__jakt_tmp340.__jakt_init_index() == 0 /* MustBe */){
-Jakt::ids::TypeId const type_id = __jakt_tmp340.common.init_common.type_id;
+} 
+}();
+JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp201 = type_hint;
+if (__jakt_tmp201.has_value()){
+Jakt::typechecker::TypeHint const hint = __jakt_tmp201.value();
+Jakt::typechecker::TypeHint __jakt_tmp200 = hint;
+if (__jakt_tmp200.__jakt_init_index() == 0 /* MustBe */){
+Jakt::ids::TypeId const type_id = __jakt_tmp200.common.init_common.type_id;
 TRY((this->unify_with_type(result->type(),type_id,span)));
 }
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -12247,9 +11180,7 @@ NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_expr = TRY(
 NonnullRefPtr<typename Jakt::types::Type> const type = this->get_type(checked_expr->type());
 Jakt::ids::StructId const optional_struct_id = TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv))));
 Jakt::ids::StructId const weakptr_struct_id = TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("WeakPtr"sv))));
-Jakt::ids::TypeId const type_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *type;
+Jakt::ids::TypeId const type_id = [&]() -> Jakt::ids::TypeId { auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
@@ -12257,38 +11188,34 @@ JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.a
 {
 Jakt::ids::TypeId inner_type_id = Jakt::types::unknown_type_id();
 if (id.equals(optional_struct_id) || id.equals(weakptr_struct_id)){
-inner_type_id = args.operator[](static_cast<i64>(0LL));
+inner_type_id = args[static_cast<i64>(0LL)];
 }
 else {
 this->error(ByteString::from_utf8_without_validation("Forced unwrap only works on Optional"sv),span);
 }
 
-return JaktInternal::ExplicitValue<Jakt::ids::TypeId>(inner_type_id);
+return inner_type_id;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default:{
 this->error(ByteString::from_utf8_without_validation("Forced unwrap only works on Optional"sv),span);
-return JaktInternal::ExplicitValue<Jakt::ids::TypeId>(Jakt::types::unknown_type_id());
+return Jakt::types::unknown_type_id();
 }
 VERIFY_NOT_REACHED();
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp343 = type_hint;
-if (__jakt_tmp343.has_value()){
-Jakt::typechecker::TypeHint const hint = __jakt_tmp343.value();
-Jakt::typechecker::TypeHint __jakt_tmp342 = hint;
-if (__jakt_tmp342.__jakt_init_index() == 0 /* MustBe */){
-Jakt::ids::TypeId const hint_id = __jakt_tmp342.common.init_common.type_id;
+ 
+}();
+JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp203 = type_hint;
+if (__jakt_tmp203.has_value()){
+Jakt::typechecker::TypeHint const hint = __jakt_tmp203.value();
+Jakt::typechecker::TypeHint __jakt_tmp202 = hint;
+if (__jakt_tmp202.__jakt_init_index() == 0 /* MustBe */){
+Jakt::ids::TypeId const hint_id = __jakt_tmp202.common.init_common.type_id;
 TRY((this->unify_with_type(type_id,hint_id,span)));
 }
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::ForcedUnwrap(JaktInternal::OptionalNone(),checked_expr,span,type_id));
+return Jakt::types::CheckedExpression::ForcedUnwrap(JaktInternal::OptionalNone(),checked_expr,span,type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -12296,8 +11223,7 @@ case 16 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& values = __jakt_match_value.values;
 JaktInternal::Optional<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& fill_size = __jakt_match_value.fill_size;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_array(scope_id,values,fill_size,span,safety_mode,type_hint))));
-};/*case end*/
+return this->typecheck_array(scope_id,values,fill_size,span,safety_mode,type_hint);};/*case end*/
 case 19 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& values = __jakt_match_value.values;
 Jakt::utility::Span const& span = __jakt_match_value.span;
@@ -12328,10 +11254,10 @@ checked_values.push(checked_value);
 }
 
 if (type_hint.has_value()){
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp344 = this->get_type(type_hint.value().common.init_common.type_id);
-if (__jakt_tmp344->__jakt_init_index() == 20 /* GenericInstance */){
-Jakt::ids::StructId const id = __jakt_tmp344->as.GenericInstance.id;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp344->as.GenericInstance.args;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp204 = this->get_type(type_hint.value().common.init_common.type_id);
+if (__jakt_tmp204->__jakt_init_index() == 20 /* GenericInstance */){
+Jakt::ids::StructId const id = __jakt_tmp204->as.GenericInstance.id;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp204->as.GenericInstance.args;
 if (checked_types.size() == args.size()){
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(args.size())};
@@ -12342,38 +11268,38 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::ids::TypeId value_type = checked_types.operator[](i);
-JaktInternal::Optional<Jakt::ids::TypeId> const unified = TRY((this->unify(args.operator[](i),span,value_type,span)));
+Jakt::ids::TypeId value_type = checked_types[i];
+JaktInternal::Optional<Jakt::ids::TypeId> const unified = TRY((this->unify(args[i],span,value_type,span)));
 if (unified.has_value()){
 bool type_optional = false;
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp345 = this->get_type(unified.value());
-if (__jakt_tmp345->__jakt_init_index() == 20 /* GenericInstance */){
-Jakt::ids::StructId const id = __jakt_tmp345->as.GenericInstance.id;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp205 = this->get_type(unified.value());
+if (__jakt_tmp205->__jakt_init_index() == 20 /* GenericInstance */){
+Jakt::ids::StructId const id = __jakt_tmp205->as.GenericInstance.id;
 if (id.equals(optional_struct_id)){
 type_optional = true;
 }
 }
 bool value_optional = false;
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp346 = this->get_type(value_type);
-if (__jakt_tmp346->__jakt_init_index() == 20 /* GenericInstance */){
-Jakt::ids::StructId const id = __jakt_tmp346->as.GenericInstance.id;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp206 = this->get_type(value_type);
+if (__jakt_tmp206->__jakt_init_index() == 20 /* GenericInstance */){
+Jakt::ids::StructId const id = __jakt_tmp206->as.GenericInstance.id;
 if (id.equals(optional_struct_id)){
 value_optional = true;
 }
 }
-checked_types.operator[](i) = unified.value();
-if (type_optional && ((!value_optional) && (!(checked_values.operator[](i)->__jakt_init_index() == 26 /* OptionalSome */)))){
-if (checked_values.operator[](i)->__jakt_init_index() == 25 /* OptionalNone */){
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp347 = this->get_type(unified.value());
-if (__jakt_tmp347->__jakt_init_index() == 20 /* GenericInstance */){
-Jakt::ids::StructId const id = __jakt_tmp347->as.GenericInstance.id;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp347->as.GenericInstance.args;
-value_type = args.operator[](static_cast<i64>(0LL));
+checked_types[i] = unified.value();
+if (type_optional && ((!value_optional) && (!(checked_values[i]->__jakt_init_index() == 26 /* OptionalSome */)))){
+if (checked_values[i]->__jakt_init_index() == 25 /* OptionalNone */){
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp207 = this->get_type(unified.value());
+if (__jakt_tmp207->__jakt_init_index() == 20 /* GenericInstance */){
+Jakt::ids::StructId const id = __jakt_tmp207->as.GenericInstance.id;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp207->as.GenericInstance.args;
+value_type = args[static_cast<i64>(0LL)];
 }
 }
 NonnullRefPtr<typename Jakt::types::Type> const optional_type = Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),optional_struct_id,DynamicArray<Jakt::ids::TypeId>::create_with({value_type}));
 Jakt::ids::TypeId const optional_type_id = this->find_or_add_type_id(optional_type);
-checked_values.operator[](i) = Jakt::types::CheckedExpression::OptionalSome(JaktInternal::OptionalNone(),checked_values.operator[](i),span,optional_type_id);
+checked_values[i] = Jakt::types::CheckedExpression::OptionalSome(JaktInternal::OptionalNone(),checked_values[i],span,optional_type_id);
 }
 }
 }
@@ -12389,7 +11315,7 @@ Jakt::ids::TypeId const type_id = this->find_or_add_type_id(Jakt::types::Type::G
 if (type_hint.has_value()){
 TRY((this->check_types_for_compat(type_hint.value(),type_id,this->generic_inferences,span)));
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(Jakt::types::CheckedExpression::JaktTuple(JaktInternal::OptionalNone(),checked_values,span,type_id));
+return Jakt::types::CheckedExpression::JaktTuple(JaktInternal::OptionalNone(),checked_values,span,type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -12407,9 +11333,7 @@ this->generic_inferences.restore(checkpoint);
 });
 bool is_dictionary = false;
 JaktInternal::Optional<Jakt::typechecker::TypeHint> index_type_hint = JaktInternal::OptionalNone();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *checked_base_type;
+{auto&& __jakt_match_variant = *checked_base_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
@@ -12419,8 +11343,7 @@ is_dictionary = id.equals(dictionary_struct_id);
 JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> const generic_parameters = this->get_struct(id).generic_parameters;
 this->generic_inferences.set_all(generic_parameters,args);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_137;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -12428,8 +11351,7 @@ JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.a
 JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> const generic_parameters = this->get_enum(id).generic_parameters;
 this->generic_inferences.set_all(generic_parameters,args);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_137;};/*case end*/
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -12437,18 +11359,11 @@ JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.a
 JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> const generic_parameters = this->get_trait(id)->generic_parameters;
 this->generic_inferences.set_all(generic_parameters,args);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_137;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_137;}/*switch end*/
+}goto __jakt_label_137; __jakt_label_137:;;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> result = Jakt::types::CheckedExpression::Garbage(JaktInternal::OptionalNone(),span,Jakt::types::builtin(Jakt::types::BuiltinType::Void()));
 JaktInternal::Optional<Jakt::types::OperatorTraitImplementation> trait_implementation = JaktInternal::OptionalNone();
 Jakt::ids::TypeId type_id = Jakt::types::builtin(Jakt::types::BuiltinType::Void());
@@ -12470,7 +11385,7 @@ JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> const inner_checkp
 ScopeGuard __jakt_var_86([&] {
 this->generic_inferences.restore(inner_checkpoint);
 });
-expected_index_type = TRY((this->substitute_typevars_in_type(implementation.implemented_type_args.operator[](static_cast<i64>(0LL)),this->generic_inferences)));
+expected_index_type = TRY((this->substitute_typevars_in_type(implementation.implemented_type_args[static_cast<i64>(0LL)],this->generic_inferences)));
 JaktInternal::Tuple<bool,bool> const snapshot = this->enter_ignore_error_mode(true);
 ScopeGuard __jakt_var_87([&] {
 this->exit_ignore_error_mode(snapshot);
@@ -12489,9 +11404,9 @@ if (accepted_implementations.size() > static_cast<size_t>(1ULL)){
 this->error(__jakt_format(StringView::from_string_literal("Ambiguous trait implementations for indexing operation on type {}"sv),TRY((this->type_name(checked_base->type(),false)))),span);
 }
 JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>,Jakt::typechecker::TraitImplementationDescriptor>> const add_trait_implementation = accepted_implementations.first();
-JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>,Jakt::typechecker::TraitImplementationDescriptor>> __jakt_tmp348 = add_trait_implementation;
-if (__jakt_tmp348.has_value()){
-JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>,Jakt::typechecker::TraitImplementationDescriptor> const impl = __jakt_tmp348.value();
+JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>,Jakt::typechecker::TraitImplementationDescriptor>> __jakt_tmp208 = add_trait_implementation;
+if (__jakt_tmp208.has_value()){
+JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>,Jakt::typechecker::TraitImplementationDescriptor> const impl = __jakt_tmp208.value();
 JaktInternal::Tuple<NonnullRefPtr<typename Jakt::types::CheckedExpression>,JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId>,Jakt::typechecker::TraitImplementationDescriptor> const checked_index_checkpoint_implementation_ = impl;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_index = checked_index_checkpoint_implementation_.template get<0>();
 JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> const checkpoint = checked_index_checkpoint_implementation_.template get<1>();
@@ -12534,16 +11449,16 @@ this->error(__jakt_format(StringView::from_string_literal("Type ‘{}’ cannot 
 result = Jakt::types::CheckedExpression::Garbage(JaktInternal::OptionalNone(),span,Jakt::types::builtin(Jakt::types::BuiltinType::Void()));
 }
 
-JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp350 = type_hint;
-if (__jakt_tmp350.has_value()){
-Jakt::typechecker::TypeHint const hint = __jakt_tmp350.value();
-Jakt::typechecker::TypeHint __jakt_tmp349 = hint;
-if (__jakt_tmp349.__jakt_init_index() == 0 /* MustBe */){
-Jakt::ids::TypeId const type_id = __jakt_tmp349.common.init_common.type_id;
+JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp210 = type_hint;
+if (__jakt_tmp210.has_value()){
+Jakt::typechecker::TypeHint const hint = __jakt_tmp210.value();
+Jakt::typechecker::TypeHint __jakt_tmp209 = hint;
+if (__jakt_tmp209.__jakt_init_index() == 0 /* MustBe */){
+Jakt::ids::TypeId const type_id = __jakt_tmp209.common.init_common.type_id;
 TRY((this->unify_with_type(result->type(),type_id,span)));
 }
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -12554,35 +11469,32 @@ bool const& is_optional = __jakt_match_value.is_optional;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const result = TRY((this->typecheck_indexed_tuple(expr,index,scope_id,is_optional,safety_mode,span)));
-JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp352 = type_hint;
-if (__jakt_tmp352.has_value()){
-Jakt::typechecker::TypeHint const hint = __jakt_tmp352.value();
-Jakt::typechecker::TypeHint __jakt_tmp351 = hint;
-if (__jakt_tmp351.__jakt_init_index() == 0 /* MustBe */){
-Jakt::ids::TypeId const type_id = __jakt_tmp351.common.init_common.type_id;
+JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp212 = type_hint;
+if (__jakt_tmp212.has_value()){
+Jakt::typechecker::TypeHint const hint = __jakt_tmp212.value();
+Jakt::typechecker::TypeHint __jakt_tmp211 = hint;
+if (__jakt_tmp211.__jakt_init_index() == 0 /* MustBe */){
+Jakt::ids::TypeId const type_id = __jakt_tmp211.common.init_common.type_id;
 TRY((this->unify_with_type(result->type(),type_id,span)));
 }
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 30 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::CheckedExpression::Garbage(JaktInternal::OptionalNone(),span,Jakt::types::builtin(Jakt::types::BuiltinType::Void())));
-};/*case end*/
+return Jakt::types::CheckedExpression::Garbage(JaktInternal::OptionalNone(),span,Jakt::types::builtin(Jakt::types::BuiltinType::Void()));};/*case end*/
 case 24 /* NamespacedVar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedVar;ByteString const& name = __jakt_match_value.name;
 JaktInternal::DynamicArray<ByteString> const& namespace_ = __jakt_match_value.namespace_;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_namespaced_var_or_simple_enum_constructor_call(name,namespace_,scope_id,safety_mode,type_hint,span))));
-};/*case end*/
+return this->typecheck_namespaced_var_or_simple_enum_constructor_call(name,namespace_,scope_id,safety_mode,type_hint,span);};/*case end*/
 case 22 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expr = __jakt_match_value.expr;
 JaktInternal::DynamicArray<Jakt::parser::ParsedMatchCase> const& cases = __jakt_match_value.cases;
 Jakt::utility::Span const& marker_span = __jakt_match_value.marker_span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_match(expr,cases,marker_span,scope_id,safety_mode,type_hint))));
-};/*case end*/
+return this->typecheck_match(expr,cases,marker_span,scope_id,safety_mode,type_hint);};/*case end*/
 case 23 /* EnumVariantArg */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariantArg;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& inner_expr = __jakt_match_value.expr;
 Jakt::parser::EnumVariantPatternArgument const& arg = __jakt_match_value.arg;
@@ -12592,16 +11504,12 @@ Jakt::utility::Span const& span = __jakt_match_value.span;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_expr = TRY((this->typecheck_expression_and_dereference_if_needed(inner_expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span)));
 Jakt::types::CheckedEnumVariantBinding checked_binding = Jakt::types::CheckedEnumVariantBinding(ByteString::from_utf8_without_validation(""sv),ByteString::from_utf8_without_validation(""sv),Jakt::types::unknown_type_id(),span);
 JaktInternal::Optional<Jakt::types::CheckedEnumVariant> checked_enum_variant = JaktInternal::OptionalNone();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *enum_variant;
+{auto&& __jakt_match_variant = *enum_variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* NamespacedName */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedName;ByteString const& variant_name = __jakt_match_value.name;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return ({({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *this->get_type(checked_expr->type());
+{auto&& __jakt_match_variant = *this->get_type(checked_expr->type());
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
@@ -12613,7 +11521,7 @@ checked_enum_variant = variant;
 JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedEnumVariantBinding>> const checked_bindings = TRY((this->typecheck_enum_variant_bindings(variant.value(),DynamicArray<Jakt::parser::EnumVariantPatternArgument>::create_with({arg}),span)));
 if (checked_bindings.has_value()){
 JaktInternal::DynamicArray<Jakt::types::CheckedEnumVariantBinding> const bindings = checked_bindings.value();
-checked_binding = bindings.operator[](static_cast<i64>(0LL));
+checked_binding = bindings[static_cast<i64>(0LL)];
 }
 }
 else {
@@ -12621,26 +11529,16 @@ this->error(__jakt_format(StringView::from_string_literal("Enum variant {} does 
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_139;};/*case end*/
 default:{
 this->error(__jakt_format(StringView::from_string_literal("Unknown type or invalid type name: {}"sv),variant_name),span);
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_139;}/*switch end*/
+}goto __jakt_label_139; __jakt_label_139:;;goto __jakt_label_138;};/*case end*/
 case 0 /* Name */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Name;ByteString const& variant_name = __jakt_match_value.name;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return ({({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *this->get_type(checked_expr->type());
+{auto&& __jakt_match_variant = *this->get_type(checked_expr->type());
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
@@ -12652,7 +11550,7 @@ checked_enum_variant = variant;
 JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedEnumVariantBinding>> const checked_bindings = TRY((this->typecheck_enum_variant_bindings(variant.value(),DynamicArray<Jakt::parser::EnumVariantPatternArgument>::create_with({arg}),span)));
 if (checked_bindings.has_value()){
 JaktInternal::DynamicArray<Jakt::types::CheckedEnumVariantBinding> const bindings = checked_bindings.value();
-checked_binding = bindings.operator[](static_cast<i64>(0LL));
+checked_binding = bindings[static_cast<i64>(0LL)];
 }
 }
 else {
@@ -12660,57 +11558,41 @@ this->error(__jakt_format(StringView::from_string_literal("Enum variant {} does 
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_140;};/*case end*/
 default:{
 this->error(__jakt_format(StringView::from_string_literal("Unknown type or invalid type name: {}"sv),variant_name),span);
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});}), JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_140;}/*switch end*/
+}goto __jakt_label_140; __jakt_label_140:;;goto __jakt_label_138;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_138;}/*switch end*/
+}goto __jakt_label_138; __jakt_label_138:;;
 NonnullRefPtr<typename Jakt::types::CheckedExpression> output = Jakt::types::CheckedExpression::Garbage(JaktInternal::OptionalNone(),span,Jakt::types::builtin(Jakt::types::BuiltinType::Void()));
 if (checked_enum_variant.has_value()){
 output = Jakt::types::CheckedExpression::EnumVariantArg(JaktInternal::OptionalNone(),checked_expr,checked_binding,checked_enum_variant.value(),span);
 }
-JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp354 = type_hint;
-if (__jakt_tmp354.has_value()){
-Jakt::typechecker::TypeHint const hint = __jakt_tmp354.value();
-Jakt::typechecker::TypeHint __jakt_tmp353 = hint;
-if (__jakt_tmp353.__jakt_init_index() == 0 /* MustBe */){
-Jakt::ids::TypeId const type_id = __jakt_tmp353.common.init_common.type_id;
+JaktInternal::Optional<Jakt::typechecker::TypeHint> __jakt_tmp214 = type_hint;
+if (__jakt_tmp214.has_value()){
+Jakt::typechecker::TypeHint const hint = __jakt_tmp214.value();
+Jakt::typechecker::TypeHint __jakt_tmp213 = hint;
+if (__jakt_tmp213.__jakt_init_index() == 0 /* MustBe */){
+Jakt::ids::TypeId const type_id = __jakt_tmp213.common.init_common.type_id;
 TRY((this->unify_with_type(output->type(),type_id,span)));
 }
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(output);
+return output;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 17 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,NonnullRefPtr<typename Jakt::parser::ParsedExpression>>> const& values = __jakt_match_value.values;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_dictionary(values,span,scope_id,safety_mode,type_hint))));
-};/*case end*/
+return this->typecheck_dictionary(values,span,scope_id,safety_mode,type_hint);};/*case end*/
 case 18 /* Set */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Set;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const& values = __jakt_match_value.values;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_set(values,span,scope_id,safety_mode,type_hint))));
-};/*case end*/
+return this->typecheck_set(values,span,scope_id,safety_mode,type_hint);};/*case end*/
 case 25 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<Jakt::parser::ParsedCapture> const& captures = __jakt_match_value.captures;
 JaktInternal::DynamicArray<Jakt::parser::ParsedParameter> const& params = __jakt_match_value.params;
@@ -12719,43 +11601,33 @@ bool const& is_fat_arrow = __jakt_match_value.is_fat_arrow;
 NonnullRefPtr<typename Jakt::parser::ParsedType> const& return_type = __jakt_match_value.return_type;
 Jakt::parser::ParsedBlock const& block = __jakt_match_value.block;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_lambda(captures,params,can_throw,is_fat_arrow,return_type,block,span,scope_id,safety_mode))));
-};/*case end*/
+return this->typecheck_lambda(captures,params,can_throw,is_fat_arrow,return_type,block,span,scope_id,safety_mode);};/*case end*/
 case 26 /* Must */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Must;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expr = __jakt_match_value.expr;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_must(expr,span,scope_id,safety_mode,type_hint))));
-};/*case end*/
+return this->typecheck_must(expr,span,scope_id,safety_mode,type_hint);};/*case end*/
 case 27 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expr = __jakt_match_value.expr;
 JaktInternal::Optional<Jakt::parser::ParsedBlock> const& catch_block = __jakt_match_value.catch_block;
 JaktInternal::Optional<Jakt::utility::Span> const& catch_span = __jakt_match_value.catch_span;
 JaktInternal::Optional<ByteString> const& catch_name = __jakt_match_value.catch_name;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_try(expr,catch_block,catch_span,catch_name,scope_id,safety_mode,span,type_hint))));
-};/*case end*/
+return this->typecheck_try(expr,catch_block,catch_span,catch_name,scope_id,safety_mode,span,type_hint);};/*case end*/
 case 28 /* TryBlock */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TryBlock;NonnullRefPtr<typename Jakt::parser::ParsedStatement> const& stmt = __jakt_match_value.stmt;
 Jakt::parser::ParsedBlock const& catch_block = __jakt_match_value.catch_block;
 ByteString const& error_name = __jakt_match_value.error_name;
 Jakt::utility::Span const& error_span = __jakt_match_value.error_span;
 Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_try_block(stmt,error_name,error_span,catch_block,scope_id,safety_mode,span))));
-};/*case end*/
+return this->typecheck_try_block(stmt,error_name,error_span,catch_block,scope_id,safety_mode,span);};/*case end*/
 case 31 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(TRY((this->typecheck_expression(expr,scope_id,Jakt::types::SafetyMode::Unsafe(),type_hint))));
-};/*case end*/
+return this->typecheck_expression(expr,scope_id,Jakt::types::SafetyMode::Unsafe(),type_hint);};/*case end*/
 case 13 /* Operator */:{
 this->compiler->panic(ByteString::from_utf8_without_validation("idk how to handle this thing"sv));
 }
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -12777,17 +11649,15 @@ Jakt::ids::TypeId const type_id = TRY((this->typecheck_typename(inner,scope_id,J
 this->exit_ignore_error_mode(snapshot);
 Jakt::types::CheckedUnaryOperator checked_op = Jakt::types::CheckedUnaryOperator::Is(type_id);
 Jakt::ids::TypeId const expr_type_id = checked_expr->type();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::types::CheckedUnaryOperator>>{
-auto&& __jakt_match_variant = *inner;
+{auto&& __jakt_match_variant = *inner;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* NamespacedName */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedName;ByteString const& variant_name = __jakt_match_value.name;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp356 = this->get_type(expr_type_id);
-if (__jakt_tmp356->__jakt_init_index() == 24 /* Enum */){
-Jakt::ids::EnumId const enum_id = __jakt_tmp356->as.Enum.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp215 = this->get_type(expr_type_id);
+if (__jakt_tmp215->__jakt_init_index() == 24 /* Enum */){
+Jakt::ids::EnumId const enum_id = __jakt_tmp215->as.Enum.value;
 Jakt::types::CheckedEnum const enum_ = this->get_enum(enum_id);
 JaktInternal::Optional<Jakt::types::CheckedEnumVariant> const variant = this->get_enum_variant(enum_,variant_name);
 if (variant.has_value()){
@@ -12806,15 +11676,14 @@ return checked_op;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_141;};/*case end*/
 case 0 /* Name */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Name;ByteString const& variant_name = __jakt_match_value.name;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp356 = this->get_type(expr_type_id);
-if (__jakt_tmp356->__jakt_init_index() == 24 /* Enum */){
-Jakt::ids::EnumId const enum_id = __jakt_tmp356->as.Enum.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp215 = this->get_type(expr_type_id);
+if (__jakt_tmp215->__jakt_init_index() == 24 /* Enum */){
+Jakt::ids::EnumId const enum_id = __jakt_tmp215->as.Enum.value;
 Jakt::types::CheckedEnum const enum_ = this->get_enum(enum_id);
 JaktInternal::Optional<Jakt::types::CheckedEnumVariant> const variant = this->get_enum_variant(enum_,variant_name);
 if (variant.has_value()){
@@ -12833,18 +11702,11 @@ return checked_op;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_141;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_141;}/*switch end*/
+}goto __jakt_label_141; __jakt_label_141:;;
 return checked_op;
 }
 }
@@ -12874,23 +11736,23 @@ return JaktInternal::OptionalNone();
 
 ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedEnumVariantBinding>>> Jakt::typechecker::Typechecker::typecheck_enum_variant_bindings(Jakt::types::CheckedEnumVariant const variant,JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> const bindings,Jakt::utility::Span const span) {
 {
-Jakt::types::CheckedEnumVariant __jakt_tmp357 = variant;
-if (__jakt_tmp357.__jakt_init_index() == 1 /* Typed */){
-Jakt::ids::TypeId const type_id = __jakt_tmp357.as.Typed.type_id;
+Jakt::types::CheckedEnumVariant __jakt_tmp216 = variant;
+if (__jakt_tmp216.__jakt_init_index() == 1 /* Typed */){
+Jakt::ids::TypeId const type_id = __jakt_tmp216.as.Typed.type_id;
 if (bindings.size() != static_cast<size_t>(1ULL)){
 this->error(__jakt_format(StringView::from_string_literal("Enum variant ‘{}’ must have exactly one argument"sv),variant.name()),span);
 return JaktInternal::OptionalNone();
 }
 if (this->dump_type_hints){
-TRY((this->dump_type_hint(type_id,bindings.operator[](static_cast<i64>(0LL)).span)));
+TRY((this->dump_type_hint(type_id,bindings[static_cast<i64>(0LL)].span)));
 }
-return DynamicArray<Jakt::types::CheckedEnumVariantBinding>::create_with({Jakt::types::CheckedEnumVariantBinding(JaktInternal::OptionalNone(),bindings.operator[](static_cast<i64>(0LL)).binding,type_id,span)});
+return DynamicArray<Jakt::types::CheckedEnumVariantBinding>::create_with({Jakt::types::CheckedEnumVariantBinding(JaktInternal::OptionalNone(),bindings[static_cast<i64>(0LL)].binding,type_id,span)});
 }
 JaktInternal::DynamicArray<NonnullRefPtr<Jakt::types::CheckedVariable>> checked_vars = DynamicArray<NonnullRefPtr<Jakt::types::CheckedVariable>>::create_with({});
 JaktInternal::DynamicArray<Jakt::types::CheckedEnumVariantBinding> checked_enum_variant_bindings = DynamicArray<Jakt::types::CheckedEnumVariantBinding>::create_with({});
-Jakt::types::CheckedEnumVariant __jakt_tmp358 = variant;
-if (__jakt_tmp358.__jakt_init_index() == 3 /* StructLike */){
-JaktInternal::DynamicArray<Jakt::ids::VarId> const fields = __jakt_tmp358.as.StructLike.fields;
+Jakt::types::CheckedEnumVariant __jakt_tmp217 = variant;
+if (__jakt_tmp217.__jakt_init_index() == 3 /* StructLike */){
+JaktInternal::DynamicArray<Jakt::ids::VarId> const fields = __jakt_tmp217.as.StructLike.fields;
 {
 JaktInternal::ArrayIterator<Jakt::ids::VarId> _magic = fields.iterator();
 for (;;){
@@ -12990,25 +11852,18 @@ this->generic_inferences.restore(old_generic_inferences);
 
 });
 Jakt::ids::TypeId type_id = TRY((this->typecheck_typename(synthetic_type,scope_id,JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
-JaktInternal::Tuple<Jakt::ids::TypeId,Jakt::ids::FunctionId> return_type_id_pseudo_function_id_ = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<Jakt::ids::TypeId,Jakt::ids::FunctionId>, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *this->get_type(type_id);
+JaktInternal::Tuple<Jakt::ids::TypeId,Jakt::ids::FunctionId> return_type_id_pseudo_function_id_ = [&]() -> JaktInternal::Tuple<Jakt::ids::TypeId,Jakt::ids::FunctionId> { auto&& __jakt_match_variant = *this->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 29 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;Jakt::ids::TypeId const& return_type_id = __jakt_match_value.return_type_id;
 Jakt::ids::FunctionId const& pseudo_function_id = __jakt_match_value.pseudo_function_id;
-return JaktInternal::ExplicitValue(Tuple{return_type_id, pseudo_function_id});
-};/*case end*/
+return Tuple{return_type_id, pseudo_function_id};};/*case end*/
 default:{
 this->compiler->panic(ByteString::from_utf8_without_validation("Expected the just-checked function to be of a function type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 Jakt::ids::TypeId return_type_id = return_type_id_pseudo_function_id_.template get<0>();
 Jakt::ids::FunctionId pseudo_function_id = return_type_id_pseudo_function_id_.template get<1>();
 
@@ -13042,35 +11897,22 @@ lambda_scope_id = this->create_scope(scope_id,can_throw,ByteString::from_utf8_wi
 else if (TRY((this->find_var_in_scope(scope_id,capture.common.init_common.name,JaktInternal::OptionalNone()))).has_value()){
 ByteString const name = capture.common.init_common.name;
 Jakt::utility::Span const span = capture.common.init_common.span;
-checked_captures.push(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::CheckedCapture, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = capture;
+checked_captures.push([&]() -> Jakt::types::CheckedCapture { auto&& __jakt_match_variant = capture;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* ByValue */:return JaktInternal::ExplicitValue(Jakt::types::CheckedCapture::ByValue(name,span));
-case 1 /* ByReference */:return JaktInternal::ExplicitValue(Jakt::types::CheckedCapture::ByReference(name,span));
-case 2 /* ByMutableReference */:return JaktInternal::ExplicitValue(Jakt::types::CheckedCapture::ByMutableReference(name,span));
-case 3 /* ByComptimeDependency */:{
+case 0 /* ByValue */:return Jakt::types::CheckedCapture::ByValue(name,span);case 1 /* ByReference */:return Jakt::types::CheckedCapture::ByReference(name,span);case 2 /* ByMutableReference */:return Jakt::types::CheckedCapture::ByMutableReference(name,span);case 3 /* ByComptimeDependency */:{
 has_dependent_capture = true;
 if (!this->in_comptime_function_call){
 this->error(__jakt_format(StringView::from_string_literal("Comptime dependency capture ‘{}’ is only allowed in comptime function calls"sv),name),span);
 }
-return JaktInternal::ExplicitValue<Jakt::types::CheckedCapture>(Jakt::types::CheckedCapture::ByComptimeDependency(name,span));
+return Jakt::types::CheckedCapture::ByComptimeDependency(name,span);
 }
 VERIFY_NOT_REACHED();
 case 4 /* AllByReference */:{
 this->compiler->panic(ByteString::from_utf8_without_validation("AllByReference capture should not be looked up by name"sv));
 }
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-}));
+ 
+}());
 if (!is_capturing_everything){
 NonnullRefPtr<Jakt::types::CheckedVariable> const var = TRY((this->find_var_in_scope(scope_id,capture.common.init_common.name,JaktInternal::OptionalNone()))).value();
 bool const is_this = var->name == ByteString::from_utf8_without_validation("this"sv);
@@ -13136,9 +11978,9 @@ return_type_id = Jakt::types::void_type_id();
 return_type_updated = true;
 }
 else if (is_fat_arrow && (!checked_block.statements.is_empty())){
-NonnullRefPtr<typename Jakt::types::CheckedStatement> __jakt_tmp359 = checked_block.statements.last().value();
-if (__jakt_tmp359->__jakt_init_index() == 8 /* Return */){
-JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const val = __jakt_tmp359->as.Return.val;
+NonnullRefPtr<typename Jakt::types::CheckedStatement> __jakt_tmp218 = checked_block.statements.last().value();
+if (__jakt_tmp218->__jakt_init_index() == 8 /* Return */){
+JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const val = __jakt_tmp218->as.Return.val;
 if (val.has_value()){
 return_type_id = TRY((this->resolve_type_var(val.value()->type(),lambda_scope_id)));
 return_type_updated = true;
@@ -13148,26 +11990,19 @@ return_type_updated = true;
 if (return_type_updated){
 NonnullRefPtr<Jakt::types::CheckedFunction> f = this->get_function(pseudo_function_id);
 f->return_type_id = return_type_id;
-type_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *this->get_type(type_id);
+type_id = [&]() -> Jakt::ids::TypeId { auto&& __jakt_match_variant = *this->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 29 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& params = __jakt_match_value.params;
 bool const& can_throw = __jakt_match_value.can_throw;
 Jakt::ids::FunctionId const& pseudo_function_id = __jakt_match_value.pseudo_function_id;
-return JaktInternal::ExplicitValue(this->find_or_add_type_id(Jakt::types::Type::Function(Jakt::parser::CheckedQualifiers(false),params,can_throw,return_type_id,pseudo_function_id)));
-};/*case end*/
+return this->find_or_add_type_id(Jakt::types::Type::Function(Jakt::parser::CheckedQualifiers(false),params,can_throw,return_type_id,pseudo_function_id));};/*case end*/
 default:{
 this->compiler->panic(ByteString::from_utf8_without_validation("Expected the just-checked function to be of a function type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 }
 }
 return Jakt::types::CheckedExpression::Function(JaktInternal::OptionalNone(),checked_captures,checked_params,can_throw,return_type_id,checked_block,span,type_id,pseudo_function_id,lambda_scope_id);
@@ -13186,7 +12021,7 @@ break;
 }
 ByteString ns = _magic_value.value();
 {
-Jakt::ids::ScopeId const scope = scopes.operator[](JaktInternal::checked_sub(scopes.size(),static_cast<size_t>(1ULL)));
+Jakt::ids::ScopeId const scope = scopes[JaktInternal::checked_sub(scopes.size(),static_cast<size_t>(1ULL))];
 JaktInternal::Optional<JaktInternal::Tuple<Jakt::ids::ScopeId,bool>> const ns_in_scope = TRY((this->find_namespace_in_scope(scope,ns,false,JaktInternal::OptionalNone())));
 JaktInternal::Optional<Jakt::ids::EnumId> const enum_in_scope = TRY((this->program->find_enum_in_scope(scope,ns,false,JaktInternal::OptionalNone())));
 Jakt::ids::ScopeId next_scope = scope;
@@ -13208,19 +12043,12 @@ scopes.push(next_scope);
 
 Jakt::ids::ScopeId const scope = scopes.last().value();
 size_t i = static_cast<size_t>(0ULL);
-size_t const min_length = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>> {
-auto __jakt_enum_value = (scopes.size() <= namespace_.size());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(scopes.size());
-}else {return JaktInternal::ExplicitValue(namespace_.size());
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+size_t const min_length = [&]() -> size_t { auto __jakt_enum_value = scopes.size() <= namespace_.size();
+if (__jakt_enum_value) {return scopes.size();}else {return namespace_.size();} 
+}();
 JaktInternal::DynamicArray<Jakt::types::CheckedNamespace> checked_namespaces = DynamicArray<Jakt::types::CheckedNamespace>::create_with({});
 while (i < min_length){
-checked_namespaces.push(Jakt::types::CheckedNamespace(namespace_.operator[](i),scope));
+checked_namespaces.push(Jakt::types::CheckedNamespace(namespace_[i],scope));
 i++;
 }
 JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedVariable>> const var = TRY((this->find_var_in_scope(scope,name,JaktInternal::OptionalNone())));
@@ -13230,24 +12058,17 @@ return Jakt::types::CheckedExpression::NamespacedVar(JaktInternal::OptionalNone(
 Jakt::parser::ParsedCall const implicit_constructor_call = Jakt::parser::ParsedCall(namespace_,name,DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>>>::create_with({}),DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>>::create_with({}));
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const call_expression = TRY((this->typecheck_call(implicit_constructor_call,scope_id,span,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),safety_mode,type_hint,true)));
 Jakt::ids::TypeId const type_id = call_expression->type();
-Jakt::types::CheckedCall const call = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::CheckedCall, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *call_expression;
+Jakt::types::CheckedCall const call = [&]() -> Jakt::types::CheckedCall { auto&& __jakt_match_variant = *call_expression;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::types::CheckedCall const& call = __jakt_match_value.call;
-return JaktInternal::ExplicitValue(call);
-};/*case end*/
+return call;};/*case end*/
 default:{
 this->compiler->panic(ByteString::from_utf8_without_validation("typecheck_call returned something other than a CheckedCall"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 if (call.function_id.has_value()){
 return Jakt::types::CheckedExpression::Call(JaktInternal::OptionalNone(),call,span,type_id);
 }
@@ -13277,7 +12098,7 @@ if (type_hint.has_value()){
 type_hint_ids = TRY((this->get_type_ids_from_type_hint_if_struct_ids_match(type_hint.value().common.init_common.type_id,array_struct_id)));
 }
 if (type_hint_ids.has_value()){
-inner_hint_id = type_hint_ids.value().operator[](static_cast<i64>(0LL));
+inner_hint_id = type_hint_ids.value()[static_cast<i64>(0LL)];
 }
 JaktInternal::Optional<Jakt::typechecker::TypeHint> value_type_hint = JaktInternal::OptionalNone();
 if (inner_hint_id.has_value()){
@@ -13342,7 +12163,7 @@ if (type_hint.has_value()){
 type_hint_ids = TRY((this->get_type_ids_from_type_hint_if_struct_ids_match(type_hint.value().common.init_common.type_id,set_struct_id)));
 }
 if (type_hint_ids.has_value()){
-inner_hint_id = type_hint_ids.value().operator[](static_cast<i64>(0LL));
+inner_hint_id = type_hint_ids.value()[static_cast<i64>(0LL)];
 }
 JaktInternal::Optional<Jakt::typechecker::TypeHint> value_type_hint = JaktInternal::OptionalNone();
 if (inner_hint_id.has_value()){
@@ -13442,14 +12263,53 @@ return Jakt::types::CheckedExpression::MethodCall(JaktInternal::OptionalNone(),c
 }
 }
 
-ErrorOr<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::types::CheckedMatchPattern,Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool>> Jakt::typechecker::Typechecker::typecheck_match_variant(Jakt::parser::ParsedMatchCase const& case_,Jakt::ids::TypeId const subject_type_id,size_t const variant_index,JaktInternal::Optional<Jakt::ids::TypeId> const final_result_type,Jakt::types::CheckedEnumVariant const variant,JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> const variant_arguments,JaktInternal::Dictionary<ByteString,Jakt::parser::ParsedPatternDefault> const default_bindings,Jakt::utility::Span const arguments_span,Jakt::ids::ScopeId const scope_id,Jakt::types::SafetyMode const safety_mode) {
+ErrorOr<JaktInternal::Tuple<JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>,Jakt::typechecker::BindingKey>> Jakt::typechecker::Typechecker::typecheck_pattern_defaults(JaktInternal::Dictionary<ByteString,Jakt::parser::ParsedPatternDefault> const& default_bindings,Jakt::ids::ScopeId const scope_id,Jakt::types::SafetyMode const safety_mode,Jakt::typechecker::BindingKeyBuilder key_builder) {
+{
+JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> defaults = Dictionary<ByteString, NonnullRefPtr<typename Jakt::types::CheckedExpression>>::create_with_entries({});
+defaults.ensure_capacity(default_bindings.size());
+NonnullRefPtr<Jakt::types::Module> module = this->current_module();
+{
+JaktInternal::DictionaryIterator<ByteString,Jakt::parser::ParsedPatternDefault> _magic = default_bindings.iterator();
+for (;;){
+JaktInternal::Optional<JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault>> const _magic_value = _magic.next();
+if (!_magic_value.has_value()){
+break;
+}
+JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault> name__default___ = _magic_value.value();
+{
+JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault> const jakt__name__default___ = name__default___;
+ByteString const name = jakt__name__default___.template get<0>();
+Jakt::parser::ParsedPatternDefault const default_ = jakt__name__default___.template get<1>();
+
+JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<Jakt::types::CheckedVariable>,NonnullRefPtr<typename Jakt::types::CheckedExpression>>> __jakt_tmp219 = TRY((this->typecheck_var_decl(default_.variable,default_.value,scope_id,safety_mode,default_.variable.span)));
+if (__jakt_tmp219.has_value()){
+JaktInternal::Tuple<NonnullRefPtr<Jakt::types::CheckedVariable>,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const checked_var_and_init = __jakt_tmp219.value();
+JaktInternal::Tuple<NonnullRefPtr<Jakt::types::CheckedVariable>,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const variable_init_ = checked_var_and_init;
+NonnullRefPtr<Jakt::types::CheckedVariable> const variable = variable_init_.template get<0>();
+NonnullRefPtr<typename Jakt::types::CheckedExpression> const init = variable_init_.template get<1>();
+
+Jakt::ids::VarId const var_id = module->add_variable(variable);
+key_builder = key_builder.submit(name,var_id,this->program);
+defaults.set(name, init);
+}
+else {
+continue;
+}
+
+}
+
+}
+}
+
+return Tuple{defaults, key_builder.finish()};
+}
+}
+
+ErrorOr<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::types::CheckedMatchPattern,Jakt::typechecker::BindingKey>> Jakt::typechecker::Typechecker::typecheck_match_variant(Jakt::parser::ParsedMatchCase const& case_,Jakt::ids::TypeId const subject_type_id,size_t const variant_index,Jakt::types::CheckedEnumVariant const variant,JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> const variant_arguments,JaktInternal::Dictionary<ByteString,Jakt::parser::ParsedPatternDefault> const default_bindings,Jakt::utility::Span const arguments_span,Jakt::ids::ScopeId const scope_id,Jakt::types::SafetyMode const safety_mode,Jakt::typechecker::BindingKeyBuilder key_builder) {
 {
 JaktInternal::Optional<ByteString> covered_name = JaktInternal::OptionalNone();
-Jakt::ids::ScopeId const new_scope_id = this->create_scope(scope_id,this->get_scope(scope_id)->can_throw,__jakt_format(StringView::from_string_literal("catch-enum-variant({})"sv),variant.name()),true);
 NonnullRefPtr<Jakt::types::Module> module = this->current_module();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::types::CheckedMatchPattern,Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool>>>{
-auto&& __jakt_match_variant = variant;
+{auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Untyped */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Untyped;ByteString const& name = __jakt_match_value.name;
@@ -13459,8 +12319,7 @@ if (!variant_arguments.is_empty()){
 this->error(__jakt_format(StringView::from_string_literal("Match case '{}' cannot have arguments"sv),name),arguments_span);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_142;};/*case end*/
 case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;ByteString const& name = __jakt_match_value.name;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
@@ -13472,16 +12331,15 @@ if (variant_arguments.size() != static_cast<size_t>(1ULL)){
 this->error(__jakt_format(StringView::from_string_literal("Match case ‘{}’ must have exactly one argument"sv),name),span);
 }
 else {
-Jakt::parser::EnumVariantPatternArgument const variant_argument = variant_arguments.operator[](static_cast<i64>(0LL));
+Jakt::parser::EnumVariantPatternArgument const variant_argument = variant_arguments[static_cast<i64>(0LL)];
 Jakt::ids::TypeId const variable_type_id = TRY((this->substitute_typevars_in_type(type_id,this->generic_inferences)));
 Jakt::ids::VarId const var_id = module->add_variable(Jakt::types::CheckedVariable::__jakt_create(variant_argument.binding,variable_type_id,variant_argument.is_mutable,span,JaktInternal::OptionalNone(),Jakt::types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone()));
-this->add_var_to_scope(new_scope_id,variant_argument.binding,var_id,span);
+key_builder = key_builder.submit(variant_argument.binding,var_id,this->program);
 }
 
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_142;};/*case end*/
 case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;ByteString const& name = __jakt_match_value.name;
 JaktInternal::DynamicArray<Jakt::ids::VarId> const& fields = __jakt_match_value.fields;
@@ -13589,7 +12447,7 @@ if (this->dump_type_hints){
 TRY((this->dump_type_hint(matched_field_variable.value()->type_id,arg.span)));
 }
 Jakt::ids::VarId const var_id = module->add_variable(Jakt::types::CheckedVariable::__jakt_create(arg.binding,substituted_type_id,arg.is_mutable,matched_span,JaktInternal::OptionalNone(),Jakt::types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone()));
-this->add_var_to_scope(new_scope_id,arg.binding,var_id,matched_span);
+key_builder = key_builder.submit(arg.binding,var_id,this->program);
 }
 else {
 this->error(__jakt_format(StringView::from_string_literal("Match case argument '{}' does not exist in struct-like enum variant '{}'"sv),arg_name,name),arg.span);
@@ -13601,50 +12459,21 @@ this->error(__jakt_format(StringView::from_string_literal("Match case argument '
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_142;};/*case end*/
 case 2 /* WithValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.WithValue;ByteString const& name = __jakt_match_value.name;
 {
 covered_name = name;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_142;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> defaults = DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>>::create_with({});
-{
-JaktInternal::DictionaryIterator<ByteString,Jakt::parser::ParsedPatternDefault> _magic = default_bindings.iterator();
-for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault>> const _magic_value = _magic.next();
-if (!_magic_value.has_value()){
-break;
-}
-JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault> ___default___ = _magic_value.value();
-{
-JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault> const jakt_____default___ = ___default___;
-ByteString const _ = jakt_____default___.template get<0>();
-Jakt::parser::ParsedPatternDefault const default_ = jakt_____default___.template get<1>();
+}goto __jakt_label_142; __jakt_label_142:;;
+JaktInternal::Tuple<JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>,Jakt::typechecker::BindingKey> const defaults_key_ = TRY((this->typecheck_pattern_defaults(default_bindings,scope_id,safety_mode,key_builder)));
+JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const defaults = defaults_key_.template get<0>();
+Jakt::typechecker::BindingKey const key = defaults_key_.template get<1>();
 
-NonnullRefPtr<typename Jakt::types::CheckedStatement> const checked_var_decl = TRY((this->typecheck_var_decl(default_.variable,default_.value,new_scope_id,safety_mode,default_.variable.span)));
-defaults.push(checked_var_decl);
-}
-
-}
-}
-
-JaktInternal::Tuple<Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool> const checked_body_result_type_seen_none_ = TRY((this->typecheck_match_body(case_.body,new_scope_id,safety_mode,this->generic_inferences,final_result_type,case_.marker_span)));
-Jakt::types::CheckedMatchBody const checked_body = checked_body_result_type_seen_none_.template get<0>();
-JaktInternal::Optional<Jakt::ids::TypeId> const result_type = checked_body_result_type_seen_none_.template get<1>();
-bool const seen_none = checked_body_result_type_seen_none_.template get<2>();
-
-Jakt::types::CheckedMatchPattern const checked_match_pattern = Jakt::types::CheckedMatchPattern::EnumVariant(defaults,variant.name(),variant_arguments,subject_type_id,variant_index,new_scope_id,case_.marker_span);
-return Tuple{covered_name, checked_match_pattern, checked_body, result_type, seen_none};
+Jakt::types::CheckedMatchPattern const checked_match_pattern = Jakt::types::CheckedMatchPattern::EnumVariant(defaults,case_.marker_span,variant.name(),variant_arguments,subject_type_id,variant_index);
+return Tuple{covered_name, checked_match_pattern, key};
 }
 }
 
@@ -13653,7 +12482,6 @@ ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>> Jakt::typechecke
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_expr = TRY((this->typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span)));
 Jakt::ids::TypeId const subject_type_id = checked_expr->type();
 NonnullRefPtr<typename Jakt::types::Type> const type_to_match_on = this->get_type(subject_type_id);
-JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> checked_cases = DynamicArray<Jakt::types::CheckedMatchCase>::create_with({});
 JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> const old_generic_inferences = this->generic_inferences.perform_checkpoint(false);
 ScopeGuard __jakt_var_91([&] {
 {
@@ -13661,14 +12489,14 @@ this->generic_inferences.restore(old_generic_inferences);
 }
 
 });
-JaktInternal::Optional<Jakt::ids::TypeId> final_result_type = JaktInternal::OptionalNone();
+Jakt::typechecker::MatchBuilder match_builder = Jakt::typechecker::MatchBuilder(DynamicArray<Jakt::types::CheckedMatchCase>::create_with({}),false,JaktInternal::OptionalNone());
 if (type_hint.has_value() && ((!type_hint.value().common.init_common.type_id.equals(Jakt::types::unknown_type_id())) && (!(this->get_type(type_hint.value().common.init_common.type_id)->__jakt_init_index() == 18 /* TypeVariable */)))){
-final_result_type = type_hint.value().common.init_common.type_id;
+match_builder.final_result_type = type_hint.value().common.init_common.type_id;
 }
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp360 = type_to_match_on;
-if (__jakt_tmp360->__jakt_init_index() == 21 /* GenericEnumInstance */){
-Jakt::ids::EnumId const id = __jakt_tmp360->as.GenericEnumInstance.id;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp360->as.GenericEnumInstance.args;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp220 = type_to_match_on;
+if (__jakt_tmp220->__jakt_init_index() == 21 /* GenericEnumInstance */){
+Jakt::ids::EnumId const id = __jakt_tmp220->as.GenericEnumInstance.id;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp220->as.GenericEnumInstance.args;
 Jakt::types::CheckedEnum const enum_ = this->get_enum(id);
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(enum_.generic_parameters.size())};
@@ -13679,8 +12507,8 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::ids::TypeId const generic = enum_.generic_parameters.operator[](i).type_id;
-Jakt::ids::TypeId const argument_type = args.operator[](i);
+Jakt::ids::TypeId const generic = enum_.generic_parameters[i].type_id;
+Jakt::ids::TypeId const argument_type = args[i];
 if ([](Jakt::ids::TypeId const& self, Jakt::ids::TypeId rhs) -> bool {{
 return !self.equals(rhs);
 }
@@ -13694,10 +12522,7 @@ this->generic_inferences.set(generic,argument_type);
 }
 
 }
-bool yielded_none = false;
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *type_to_match_on;
+{auto&& __jakt_match_variant = *type_to_match_on;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
@@ -13718,13 +12543,7 @@ break;
 }
 Jakt::parser::ParsedMatchCase case_ = _magic_value.value();
 {
-JaktInternal::DynamicArray<Jakt::types::CheckedMatchPattern> checked_patterns = DynamicArray<Jakt::types::CheckedMatchPattern>::create_with({});
-JaktInternal::Optional<Jakt::types::CheckedMatchBody> last_checked_body = JaktInternal::OptionalNone();
-ScopeGuard __jakt_var_92([&] {
-if (!checked_patterns.is_empty()){
-checked_cases.push(Jakt::types::CheckedMatchCase(checked_patterns,last_checked_body.value()));
-}
-});
+Jakt::typechecker::CaseStartedProof const case_proof = match_builder.start_case();
 {
 JaktInternal::ArrayIterator<Jakt::parser::ParsedMatchPattern> _magic = case_.patterns.iterator();
 for (;;){
@@ -13734,9 +12553,7 @@ break;
 }
 Jakt::parser::ParsedMatchPattern pattern = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = pattern;
+{auto&& __jakt_match_variant = pattern;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* EnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>> const& variant_names = __jakt_match_value.variant_names;
@@ -13745,63 +12562,65 @@ Jakt::utility::Span const& arguments_span = __jakt_match_value.arguments_span;
 {
 JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>> variant_names_ = variant_names;
 if (variant_names_.size() == static_cast<size_t>(1ULL)){
-JaktInternal::Tuple<ByteString,Jakt::utility::Span> const temp = variant_names_.operator[](static_cast<i64>(0LL));
-variant_names_ = DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>::create_with({Tuple{enum_.name, variant_names_.operator[](static_cast<i64>(0LL)).template get<1>()}, temp});
+JaktInternal::Tuple<ByteString,Jakt::utility::Span> const temp = variant_names_[static_cast<i64>(0LL)];
+variant_names_ = DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>::create_with({Tuple{enum_.name, variant_names_[static_cast<i64>(0LL)].template get<1>()}, temp});
 }
 if (variant_names_.is_empty()){
-return JaktInternal::LoopContinue{};
+continue;
 }
 if ([](ByteString const& self, ByteString rhs) -> bool {{
 return !(self == rhs);
 }
 }
-(variant_names_.operator[](static_cast<i64>(0LL)).template get<0>(),enum_.name)){
-this->error(__jakt_format(StringView::from_string_literal("Match case '{}' does not match enum '{}'"sv),variant_names_.operator[](static_cast<i64>(0LL)).template get<0>(),enum_.name),variant_names_.operator[](static_cast<i64>(0LL)).template get<1>());
-return JaktInternal::LoopContinue{};
+(variant_names_[static_cast<i64>(0LL)].template get<0>(),enum_.name)){
+this->error(__jakt_format(StringView::from_string_literal("Match case '{}' does not match enum '{}'"sv),variant_names_[static_cast<i64>(0LL)].template get<0>(),enum_.name),variant_names_[static_cast<i64>(0LL)].template get<1>());
+continue;
 }
-size_t i = static_cast<size_t>(0ULL);
-JaktInternal::Optional<Jakt::types::CheckedEnumVariant> matched_variant = JaktInternal::OptionalNone();
-JaktInternal::Optional<size_t> variant_index = JaktInternal::OptionalNone();
+JaktInternal::Optional<size_t> maybe_variant_index = JaktInternal::OptionalNone();
 {
-JaktInternal::ArrayIterator<Jakt::types::CheckedEnumVariant> _magic = enum_.variants.iterator();
+JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(enum_.variants.size())};
 for (;;){
-JaktInternal::Optional<Jakt::types::CheckedEnumVariant> const _magic_value = _magic.next();
+JaktInternal::Optional<size_t> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
 break;
 }
-Jakt::types::CheckedEnumVariant v = _magic_value.value();
+size_t i = _magic_value.value();
 {
-if (v.name() == variant_names_.operator[](static_cast<i64>(1LL)).template get<0>()){
-matched_variant = v;
-variant_index = i;
+if (enum_.variants[i].name() == variant_names_[static_cast<i64>(1LL)].template get<0>()){
+maybe_variant_index = i;
 }
-i++;
 }
 
 }
 }
 
-if (!matched_variant.has_value()){
-this->error(__jakt_format(StringView::from_string_literal("Enum '{}' does not contain a variant named '{}'"sv),enum_.name,variant_names_.operator[](static_cast<i64>(1LL)).template get<0>()),case_.marker_span);
+JaktInternal::Optional<size_t> __jakt_tmp221 = maybe_variant_index;
+if (__jakt_tmp221.has_value()){
+size_t const variant_index = __jakt_tmp221.value();
+Jakt::types::CheckedEnumVariant const variant = enum_.variants[variant_index];
+JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::types::CheckedMatchPattern,Jakt::typechecker::BindingKey> const covered_name_pattern_key_ = TRY((this->typecheck_match_variant(case_,subject_type_id,variant_index,variant,variant_arguments,pattern.common.init_common.defaults,arguments_span,scope_id,safety_mode,match_builder.start_pattern(case_proof))));
+JaktInternal::Optional<ByteString> const covered_name = covered_name_pattern_key_.template get<0>();
+Jakt::types::CheckedMatchPattern const pattern = covered_name_pattern_key_.template get<1>();
+Jakt::typechecker::BindingKey const key = covered_name_pattern_key_.template get<2>();
+
+JaktInternal::Optional<ByteString> __jakt_tmp222 = covered_name;
+if (__jakt_tmp222.has_value()){
+ByteString const name = __jakt_tmp222.value();
+covered_variants.add(name);
+}
+TRY((match_builder.register_pattern(case_proof,case_.body,safety_mode,key,scope_id,pattern,*this,[variant]() -> ByteString {{
+return __jakt_format(StringView::from_string_literal("catch-enum-variant({})"sv),variant.name());
+}
+}
+)));
+}
+else {
+this->error(__jakt_format(StringView::from_string_literal("Enum '{}' does not contain a variant named '{}'"sv),enum_.name,variant_names_[static_cast<i64>(1LL)].template get<0>()),case_.marker_span);
 return Jakt::types::CheckedExpression::Match(JaktInternal::OptionalNone(),checked_expr,DynamicArray<Jakt::types::CheckedMatchCase>::create_with({}),span,Jakt::types::unknown_type_id(),false);
 }
-JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::types::CheckedMatchPattern,Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool> const covered_name_checked_match_case_checked_body_result_type_seen_none_ = TRY((this->typecheck_match_variant(case_,subject_type_id,variant_index.value(),final_result_type,matched_variant.value(),variant_arguments,pattern.common.init_common.defaults,arguments_span,scope_id,safety_mode)));
-JaktInternal::Optional<ByteString> const covered_name = covered_name_checked_match_case_checked_body_result_type_seen_none_.template get<0>();
-Jakt::types::CheckedMatchPattern const checked_match_case = covered_name_checked_match_case_checked_body_result_type_seen_none_.template get<1>();
-Jakt::types::CheckedMatchBody const checked_body = covered_name_checked_match_case_checked_body_result_type_seen_none_.template get<2>();
-JaktInternal::Optional<Jakt::ids::TypeId> const result_type = covered_name_checked_match_case_checked_body_result_type_seen_none_.template get<3>();
-bool const seen_none = covered_name_checked_match_case_checked_body_result_type_seen_none_.template get<4>();
 
-last_checked_body = checked_body;
-yielded_none |= seen_none;
-if (covered_name.has_value()){
-covered_variants.add(covered_name.value());
 }
-final_result_type = result_type;
-checked_patterns.push(checked_match_case);
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_144;};/*case end*/
 case 2 /* CatchAll */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> const& variant_arguments = __jakt_match_value.variant_arguments;
 Jakt::utility::Span const& arguments_span = __jakt_match_value.arguments_span;
@@ -13829,20 +12648,21 @@ Jakt::types::CheckedEnumVariant variant = _magic_value.value();
 {
 if (!covered_variants.contains(variant.name())){
 expanded_catch_all = true;
-JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::types::CheckedMatchPattern,Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool> const covered_name_checked_match_pattern_checked_body_result_type_seen_none_ = TRY((this->typecheck_match_variant(case_,subject_type_id,variant_index,final_result_type,variant,variant_arguments,pattern.common.init_common.defaults,arguments_span,scope_id,safety_mode)));
-JaktInternal::Optional<ByteString> const covered_name = covered_name_checked_match_pattern_checked_body_result_type_seen_none_.template get<0>();
-Jakt::types::CheckedMatchPattern const checked_match_pattern = covered_name_checked_match_pattern_checked_body_result_type_seen_none_.template get<1>();
-Jakt::types::CheckedMatchBody const checked_body = covered_name_checked_match_pattern_checked_body_result_type_seen_none_.template get<2>();
-JaktInternal::Optional<Jakt::ids::TypeId> const result_type = covered_name_checked_match_pattern_checked_body_result_type_seen_none_.template get<3>();
-bool const seen_none = covered_name_checked_match_pattern_checked_body_result_type_seen_none_.template get<4>();
+JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::types::CheckedMatchPattern,Jakt::typechecker::BindingKey> const covered_name_checked_match_pattern_key_ = TRY((this->typecheck_match_variant(case_,subject_type_id,variant_index,variant,variant_arguments,pattern.common.init_common.defaults,arguments_span,scope_id,safety_mode,match_builder.start_pattern(case_proof))));
+JaktInternal::Optional<ByteString> const covered_name = covered_name_checked_match_pattern_key_.template get<0>();
+Jakt::types::CheckedMatchPattern const checked_match_pattern = covered_name_checked_match_pattern_key_.template get<1>();
+Jakt::typechecker::BindingKey const key = covered_name_checked_match_pattern_key_.template get<2>();
 
-last_checked_body = checked_body;
-yielded_none |= seen_none;
-if (covered_name.has_value()){
-covered_variants.add(covered_name.value());
+JaktInternal::Optional<ByteString> __jakt_tmp223 = covered_name;
+if (__jakt_tmp223.has_value()){
+ByteString const name = __jakt_tmp223.value();
+covered_variants.add(name);
 }
-final_result_type = result_type;
-checked_patterns.push(checked_match_pattern);
+TRY((match_builder.register_pattern(case_proof,case_.body,safety_mode,key,scope_id,checked_match_pattern,*this,[variant]() -> ByteString {{
+return __jakt_format(StringView::from_string_literal("catch-enum-variant({})"sv),variant.name());
+}
+}
+)));
 }
 variant_index++;
 }
@@ -13852,57 +12672,24 @@ variant_index++;
 
 }
 else {
-Jakt::ids::ScopeId const new_scope_id = this->create_scope(scope_id,this->get_scope(scope_id)->can_throw,ByteString::from_utf8_without_validation("catch-all"sv),true);
-JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> defaults = DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>>::create_with({});
-{
-JaktInternal::DictionaryIterator<ByteString,Jakt::parser::ParsedPatternDefault> _magic = pattern.common.init_common.defaults.iterator();
-for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault>> const _magic_value = _magic.next();
-if (!_magic_value.has_value()){
-break;
-}
-JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault> ___default___ = _magic_value.value();
-{
-JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault> const jakt_____default___ = ___default___;
-ByteString const _ = jakt_____default___.template get<0>();
-Jakt::parser::ParsedPatternDefault const default_ = jakt_____default___.template get<1>();
+JaktInternal::Tuple<JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>,Jakt::typechecker::BindingKey> const defaults_key_ = TRY((this->typecheck_pattern_defaults(pattern.common.init_common.defaults,scope_id,safety_mode,match_builder.start_pattern(case_proof))));
+JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const defaults = defaults_key_.template get<0>();
+Jakt::typechecker::BindingKey const key = defaults_key_.template get<1>();
 
-NonnullRefPtr<typename Jakt::types::CheckedStatement> const checked_var_decl = TRY((this->typecheck_var_decl(default_.variable,default_.value,new_scope_id,safety_mode,default_.variable.span)));
-defaults.push(checked_var_decl);
+Jakt::types::CheckedMatchPattern const checked_match_pattern = Jakt::types::CheckedMatchPattern::CatchAll(defaults,case_.marker_span,false);
+TRY((match_builder.register_pattern(case_proof,case_.body,safety_mode,key,scope_id,checked_match_pattern,*this,[]() -> ByteString {{
+return ByteString::from_utf8_without_validation("catch-all"sv);
+}
+}
+)));
 }
 
 }
-}
-
-JaktInternal::Tuple<Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool> const checked_body_result_type_seen_none_ = TRY((this->typecheck_match_body(case_.body,new_scope_id,safety_mode,this->generic_inferences,final_result_type,case_.marker_span)));
-Jakt::types::CheckedMatchBody const checked_body = checked_body_result_type_seen_none_.template get<0>();
-JaktInternal::Optional<Jakt::ids::TypeId> const result_type = checked_body_result_type_seen_none_.template get<1>();
-bool const seen_none = checked_body_result_type_seen_none_.template get<2>();
-
-last_checked_body = checked_body;
-yielded_none |= seen_none;
-final_result_type = result_type;
-Jakt::types::CheckedMatchPattern const checked_match_pattern = Jakt::types::CheckedMatchPattern::CatchAll(defaults,false,case_.marker_span);
-checked_patterns.push(checked_match_pattern);
-}
-
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_144;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_144;}/*switch end*/
+break;}goto __jakt_label_144; __jakt_label_144:;;
 }
 
 }
@@ -13957,8 +12744,7 @@ else if (seen_catch_all && (!expanded_catch_all)){
 this->error(ByteString::from_utf8_without_validation("All variants are covered, but an irrefutable pattern is also present"sv),span);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_143;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& enum_id = __jakt_match_value.id;
 {
@@ -13978,13 +12764,7 @@ break;
 }
 Jakt::parser::ParsedMatchCase case_ = _magic_value.value();
 {
-JaktInternal::DynamicArray<Jakt::types::CheckedMatchPattern> checked_patterns = DynamicArray<Jakt::types::CheckedMatchPattern>::create_with({});
-JaktInternal::Optional<Jakt::types::CheckedMatchBody> last_checked_body = JaktInternal::OptionalNone();
-ScopeGuard __jakt_var_93([&] {
-if (!checked_patterns.is_empty()){
-checked_cases.push(Jakt::types::CheckedMatchCase(checked_patterns,last_checked_body.value()));
-}
-});
+Jakt::typechecker::CaseStartedProof const case_proof = match_builder.start_case();
 {
 JaktInternal::ArrayIterator<Jakt::parser::ParsedMatchPattern> _magic = case_.patterns.iterator();
 for (;;){
@@ -13994,9 +12774,7 @@ break;
 }
 Jakt::parser::ParsedMatchPattern pattern = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = pattern;
+{auto&& __jakt_match_variant = pattern;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* EnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>> const& variant_names = __jakt_match_value.variant_names;
@@ -14005,63 +12783,65 @@ Jakt::utility::Span const& arguments_span = __jakt_match_value.arguments_span;
 {
 JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>> variant_names_ = variant_names;
 if (variant_names_.size() == static_cast<size_t>(1ULL)){
-JaktInternal::Tuple<ByteString,Jakt::utility::Span> const temp = variant_names_.operator[](static_cast<i64>(0LL));
-variant_names_ = DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>::create_with({Tuple{enum_.name, variant_names_.operator[](static_cast<i64>(0LL)).template get<1>()}, temp});
+JaktInternal::Tuple<ByteString,Jakt::utility::Span> const temp = variant_names_[static_cast<i64>(0LL)];
+variant_names_ = DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>>::create_with({Tuple{enum_.name, variant_names_[static_cast<i64>(0LL)].template get<1>()}, temp});
 }
 if (variant_names_.is_empty()){
-return JaktInternal::LoopContinue{};
+continue;
 }
 if ([](ByteString const& self, ByteString rhs) -> bool {{
 return !(self == rhs);
 }
 }
-(variant_names_.operator[](static_cast<i64>(0LL)).template get<0>(),enum_.name)){
-this->error(__jakt_format(StringView::from_string_literal("Match case '{}' does not match enum '{}'"sv),variant_names_.operator[](static_cast<i64>(0LL)).template get<0>(),enum_.name),variant_names_.operator[](static_cast<i64>(0LL)).template get<1>());
-return JaktInternal::LoopContinue{};
+(variant_names_[static_cast<i64>(0LL)].template get<0>(),enum_.name)){
+this->error(__jakt_format(StringView::from_string_literal("Match case '{}' does not match enum '{}'"sv),variant_names_[static_cast<i64>(0LL)].template get<0>(),enum_.name),variant_names_[static_cast<i64>(0LL)].template get<1>());
+continue;
 }
-size_t i = static_cast<size_t>(0ULL);
-JaktInternal::Optional<Jakt::types::CheckedEnumVariant> matched_variant = JaktInternal::OptionalNone();
-JaktInternal::Optional<size_t> variant_index = JaktInternal::OptionalNone();
+JaktInternal::Optional<size_t> maybe_variant_index = JaktInternal::OptionalNone();
 {
-JaktInternal::ArrayIterator<Jakt::types::CheckedEnumVariant> _magic = enum_.variants.iterator();
+JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(enum_.variants.size())};
 for (;;){
-JaktInternal::Optional<Jakt::types::CheckedEnumVariant> const _magic_value = _magic.next();
+JaktInternal::Optional<size_t> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
 break;
 }
-Jakt::types::CheckedEnumVariant v = _magic_value.value();
+size_t i = _magic_value.value();
 {
-if (v.name() == variant_names_.operator[](static_cast<i64>(1LL)).template get<0>()){
-matched_variant = v;
-variant_index = i;
+if (enum_.variants[i].name() == variant_names_[static_cast<i64>(1LL)].template get<0>()){
+maybe_variant_index = i;
 }
-i++;
 }
 
 }
 }
 
-if (!matched_variant.has_value()){
-this->error(__jakt_format(StringView::from_string_literal("Enum '{}' does not contain a variant named '{}'"sv),enum_.name,variant_names_.operator[](static_cast<i64>(1LL)).template get<0>()),case_.marker_span);
+JaktInternal::Optional<size_t> __jakt_tmp221 = maybe_variant_index;
+if (__jakt_tmp221.has_value()){
+size_t const variant_index = __jakt_tmp221.value();
+Jakt::types::CheckedEnumVariant const variant = enum_.variants[variant_index];
+JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::types::CheckedMatchPattern,Jakt::typechecker::BindingKey> const covered_name_pattern_key_ = TRY((this->typecheck_match_variant(case_,subject_type_id,variant_index,variant,variant_arguments,pattern.common.init_common.defaults,arguments_span,scope_id,safety_mode,match_builder.start_pattern(case_proof))));
+JaktInternal::Optional<ByteString> const covered_name = covered_name_pattern_key_.template get<0>();
+Jakt::types::CheckedMatchPattern const pattern = covered_name_pattern_key_.template get<1>();
+Jakt::typechecker::BindingKey const key = covered_name_pattern_key_.template get<2>();
+
+JaktInternal::Optional<ByteString> __jakt_tmp222 = covered_name;
+if (__jakt_tmp222.has_value()){
+ByteString const name = __jakt_tmp222.value();
+covered_variants.add(name);
+}
+TRY((match_builder.register_pattern(case_proof,case_.body,safety_mode,key,scope_id,pattern,*this,[variant]() -> ByteString {{
+return __jakt_format(StringView::from_string_literal("catch-enum-variant({})"sv),variant.name());
+}
+}
+)));
+}
+else {
+this->error(__jakt_format(StringView::from_string_literal("Enum '{}' does not contain a variant named '{}'"sv),enum_.name,variant_names_[static_cast<i64>(1LL)].template get<0>()),case_.marker_span);
 return Jakt::types::CheckedExpression::Match(JaktInternal::OptionalNone(),checked_expr,DynamicArray<Jakt::types::CheckedMatchCase>::create_with({}),span,Jakt::types::unknown_type_id(),false);
 }
-JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::types::CheckedMatchPattern,Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool> const covered_name_checked_match_case_checked_body_result_type_seen_none_ = TRY((this->typecheck_match_variant(case_,subject_type_id,variant_index.value(),final_result_type,matched_variant.value(),variant_arguments,pattern.common.init_common.defaults,arguments_span,scope_id,safety_mode)));
-JaktInternal::Optional<ByteString> const covered_name = covered_name_checked_match_case_checked_body_result_type_seen_none_.template get<0>();
-Jakt::types::CheckedMatchPattern const checked_match_case = covered_name_checked_match_case_checked_body_result_type_seen_none_.template get<1>();
-Jakt::types::CheckedMatchBody const checked_body = covered_name_checked_match_case_checked_body_result_type_seen_none_.template get<2>();
-JaktInternal::Optional<Jakt::ids::TypeId> const result_type = covered_name_checked_match_case_checked_body_result_type_seen_none_.template get<3>();
-bool const seen_none = covered_name_checked_match_case_checked_body_result_type_seen_none_.template get<4>();
 
-last_checked_body = checked_body;
-yielded_none |= seen_none;
-if (covered_name.has_value()){
-covered_variants.add(covered_name.value());
 }
-final_result_type = result_type;
-checked_patterns.push(checked_match_case);
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_145;};/*case end*/
 case 2 /* CatchAll */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> const& variant_arguments = __jakt_match_value.variant_arguments;
 Jakt::utility::Span const& arguments_span = __jakt_match_value.arguments_span;
@@ -14089,20 +12869,21 @@ Jakt::types::CheckedEnumVariant variant = _magic_value.value();
 {
 if (!covered_variants.contains(variant.name())){
 expanded_catch_all = true;
-JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::types::CheckedMatchPattern,Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool> const covered_name_checked_match_pattern_checked_body_result_type_seen_none_ = TRY((this->typecheck_match_variant(case_,subject_type_id,variant_index,final_result_type,variant,variant_arguments,pattern.common.init_common.defaults,arguments_span,scope_id,safety_mode)));
-JaktInternal::Optional<ByteString> const covered_name = covered_name_checked_match_pattern_checked_body_result_type_seen_none_.template get<0>();
-Jakt::types::CheckedMatchPattern const checked_match_pattern = covered_name_checked_match_pattern_checked_body_result_type_seen_none_.template get<1>();
-Jakt::types::CheckedMatchBody const checked_body = covered_name_checked_match_pattern_checked_body_result_type_seen_none_.template get<2>();
-JaktInternal::Optional<Jakt::ids::TypeId> const result_type = covered_name_checked_match_pattern_checked_body_result_type_seen_none_.template get<3>();
-bool const seen_none = covered_name_checked_match_pattern_checked_body_result_type_seen_none_.template get<4>();
+JaktInternal::Tuple<JaktInternal::Optional<ByteString>,Jakt::types::CheckedMatchPattern,Jakt::typechecker::BindingKey> const covered_name_checked_match_pattern_key_ = TRY((this->typecheck_match_variant(case_,subject_type_id,variant_index,variant,variant_arguments,pattern.common.init_common.defaults,arguments_span,scope_id,safety_mode,match_builder.start_pattern(case_proof))));
+JaktInternal::Optional<ByteString> const covered_name = covered_name_checked_match_pattern_key_.template get<0>();
+Jakt::types::CheckedMatchPattern const checked_match_pattern = covered_name_checked_match_pattern_key_.template get<1>();
+Jakt::typechecker::BindingKey const key = covered_name_checked_match_pattern_key_.template get<2>();
 
-last_checked_body = checked_body;
-yielded_none |= seen_none;
-if (covered_name.has_value()){
-covered_variants.add(covered_name.value());
+JaktInternal::Optional<ByteString> __jakt_tmp223 = covered_name;
+if (__jakt_tmp223.has_value()){
+ByteString const name = __jakt_tmp223.value();
+covered_variants.add(name);
 }
-final_result_type = result_type;
-checked_patterns.push(checked_match_pattern);
+TRY((match_builder.register_pattern(case_proof,case_.body,safety_mode,key,scope_id,checked_match_pattern,*this,[variant]() -> ByteString {{
+return __jakt_format(StringView::from_string_literal("catch-enum-variant({})"sv),variant.name());
+}
+}
+)));
 }
 variant_index++;
 }
@@ -14112,57 +12893,24 @@ variant_index++;
 
 }
 else {
-Jakt::ids::ScopeId const new_scope_id = this->create_scope(scope_id,this->get_scope(scope_id)->can_throw,ByteString::from_utf8_without_validation("catch-all"sv),true);
-JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> defaults = DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>>::create_with({});
-{
-JaktInternal::DictionaryIterator<ByteString,Jakt::parser::ParsedPatternDefault> _magic = pattern.common.init_common.defaults.iterator();
-for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault>> const _magic_value = _magic.next();
-if (!_magic_value.has_value()){
-break;
-}
-JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault> ___default___ = _magic_value.value();
-{
-JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault> const jakt_____default___ = ___default___;
-ByteString const _ = jakt_____default___.template get<0>();
-Jakt::parser::ParsedPatternDefault const default_ = jakt_____default___.template get<1>();
+JaktInternal::Tuple<JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>,Jakt::typechecker::BindingKey> const defaults_key_ = TRY((this->typecheck_pattern_defaults(pattern.common.init_common.defaults,scope_id,safety_mode,match_builder.start_pattern(case_proof))));
+JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const defaults = defaults_key_.template get<0>();
+Jakt::typechecker::BindingKey const key = defaults_key_.template get<1>();
 
-NonnullRefPtr<typename Jakt::types::CheckedStatement> const checked_var_decl = TRY((this->typecheck_var_decl(default_.variable,default_.value,new_scope_id,safety_mode,default_.variable.span)));
-defaults.push(checked_var_decl);
+Jakt::types::CheckedMatchPattern const checked_match_pattern = Jakt::types::CheckedMatchPattern::CatchAll(defaults,case_.marker_span,false);
+TRY((match_builder.register_pattern(case_proof,case_.body,safety_mode,key,scope_id,checked_match_pattern,*this,[]() -> ByteString {{
+return ByteString::from_utf8_without_validation("catch-all"sv);
+}
+}
+)));
 }
 
 }
-}
-
-JaktInternal::Tuple<Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool> const checked_body_result_type_seen_none_ = TRY((this->typecheck_match_body(case_.body,new_scope_id,safety_mode,this->generic_inferences,final_result_type,case_.marker_span)));
-Jakt::types::CheckedMatchBody const checked_body = checked_body_result_type_seen_none_.template get<0>();
-JaktInternal::Optional<Jakt::ids::TypeId> const result_type = checked_body_result_type_seen_none_.template get<1>();
-bool const seen_none = checked_body_result_type_seen_none_.template get<2>();
-
-last_checked_body = checked_body;
-yielded_none |= seen_none;
-final_result_type = result_type;
-Jakt::types::CheckedMatchPattern const checked_match_pattern = Jakt::types::CheckedMatchPattern::CatchAll(defaults,false,case_.marker_span);
-checked_patterns.push(checked_match_pattern);
-}
-
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_145;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_145;}/*switch end*/
+break;}goto __jakt_label_145; __jakt_label_145:;;
 }
 
 }
@@ -14217,38 +12965,26 @@ else if (seen_catch_all && (!expanded_catch_all)){
 this->error(ByteString::from_utf8_without_validation("All variants are covered, but an irrefutable pattern is also present"sv),span);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_143;};/*case end*/
 case 0 /* Void */:{
 this->error(ByteString::from_utf8_without_validation("Can't match on 'void' type"sv),checked_expr->span());
 }
-return JaktInternal::ExplicitValue<void>();
-default:return ({({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>> {
-auto __jakt_enum_value = (type_to_match_on->is_boxed(this->program));
+goto __jakt_label_143;default:{auto __jakt_enum_value = type_to_match_on->is_boxed(this->program);
 if (__jakt_enum_value) {{
-JaktInternal::Tuple<Jakt::ids::StructId,JaktInternal::DynamicArray<Jakt::ids::StructId>> const struct_to_match_on_struct_inheritance_chain_ = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<Jakt::ids::StructId,JaktInternal::DynamicArray<Jakt::ids::StructId>>, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *type_to_match_on;
+JaktInternal::Tuple<Jakt::ids::StructId,JaktInternal::DynamicArray<Jakt::ids::StructId>> const struct_to_match_on_struct_inheritance_chain_ = [&]() -> JaktInternal::Tuple<Jakt::ids::StructId,JaktInternal::DynamicArray<Jakt::ids::StructId>> { auto&& __jakt_match_variant = *type_to_match_on;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Tuple{id, this->struct_inheritance_chain(id)});
-};/*case end*/
+return Tuple{id, this->struct_inheritance_chain(id)};};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(Tuple{id, this->struct_inheritance_chain(id)});
-};/*case end*/
+return Tuple{id, this->struct_inheritance_chain(id)};};/*case end*/
 default:{
 this->compiler->panic(ByteString::from_utf8_without_validation("Expected struct or generic instance in inheritance-style match expression"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 Jakt::ids::StructId const struct_to_match_on = struct_to_match_on_struct_inheritance_chain_.template get<0>();
 JaktInternal::DynamicArray<Jakt::ids::StructId> const struct_inheritance_chain = struct_to_match_on_struct_inheritance_chain_.template get<1>();
 
@@ -14265,13 +13001,7 @@ break;
 }
 Jakt::parser::ParsedMatchCase case_ = _magic_value.value();
 {
-JaktInternal::DynamicArray<Jakt::types::CheckedMatchPattern> checked_patterns = DynamicArray<Jakt::types::CheckedMatchPattern>::create_with({});
-JaktInternal::Optional<Jakt::types::CheckedMatchBody> last_checked_body = JaktInternal::OptionalNone();
-ScopeGuard __jakt_var_94([&] {
-if (!checked_patterns.is_empty()){
-checked_cases.push(Jakt::types::CheckedMatchCase(checked_patterns,last_checked_body.value()));
-}
-});
+Jakt::typechecker::CaseStartedProof const case_proof = match_builder.start_case();
 {
 JaktInternal::ArrayIterator<Jakt::parser::ParsedMatchPattern> _magic = case_.patterns.iterator();
 for (;;){
@@ -14281,9 +13011,7 @@ break;
 }
 Jakt::parser::ParsedMatchPattern pattern = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = pattern;
+{auto&& __jakt_match_variant = pattern;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* EnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>> const& variant_names = __jakt_match_value.variant_names;
@@ -14306,23 +13034,12 @@ names.push(name.template get<0>());
 }
 }
 
-Jakt::ids::TypeId const type = TRY((this->typecheck_typename(Jakt::parser::ParsedType::NamespacedName(JaktInternal::OptionalNone(),names.last().value(),names.operator[](JaktInternal::Range<size_t>{static_cast<size_t>(0LL),static_cast<size_t>(JaktInternal::checked_sub(names.size(),static_cast<size_t>(1ULL)))}).to_array(),DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>>::create_with({}),case_.marker_span),scope_id,JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
+Jakt::ids::TypeId const type = TRY((this->typecheck_typename(Jakt::parser::ParsedType::NamespacedName(JaktInternal::OptionalNone(),names.last().value(),names[JaktInternal::Range<size_t>{static_cast<size_t>(0LL),static_cast<size_t>(JaktInternal::checked_sub(names.size(),static_cast<size_t>(1ULL)))}].to_array(),DynamicArray<NonnullRefPtr<typename Jakt::parser::ParsedType>>::create_with({}),case_.marker_span),scope_id,JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
 if (seen_catch_all){
-this->error_with_hint(ByteString::from_utf8_without_validation("This case is unreachable because a catch-all case is present before it"sv),case_.marker_span,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>> {
-auto __jakt_enum_value = (catch_all_matches_original_type);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Catch-all case matching the original subject type seen here"sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Catch-all case seen here"sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}),catch_all_marker_span.value());
+this->error_with_hint(ByteString::from_utf8_without_validation("This case is unreachable because a catch-all case is present before it"sv),case_.marker_span,[&]() -> ByteString { auto __jakt_enum_value = catch_all_matches_original_type;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation("Catch-all case matching the original subject type seen here"sv);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation("Catch-all case seen here"sv);}VERIFY_NOT_REACHED();
+ 
+}(),catch_all_marker_span.value());
 }
 Function<ErrorOr<void>(Jakt::ids::StructId)> const check_cover_overlap = [this, &type, &case_, &covered_cases](Jakt::ids::StructId id) -> ErrorOr<void> {{
 {
@@ -14359,9 +13076,7 @@ TRY((check_cover_overlap(struct_to_match_on)));
 
 }
 else {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = *this->get_type(type);
+{auto&& __jakt_match_variant = *this->get_type(type);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
@@ -14375,8 +13090,7 @@ covered_cases.add(id);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_148;};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
 {
@@ -14389,52 +13103,37 @@ covered_cases.add(id);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_148;};/*case end*/
 default:{
 this->error(__jakt_format(StringView::from_string_literal("Type ‘{}’ cannot be used as a match case for ‘{}’"sv),TRY((this->type_name(type,false))),TRY((this->type_name(subject_type_id,false)))),case_.marker_span);
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-});
+goto __jakt_label_148;}/*switch end*/
+break;}goto __jakt_label_148; __jakt_label_148:;;
 }
 
-Jakt::ids::ScopeId const new_scope_id = this->create_scope(scope_id,this->get_scope(scope_id)->can_throw,__jakt_format(StringView::from_string_literal("class-variant({})"sv),names),true);
 JaktInternal::Optional<Jakt::types::ClassInstanceRebind> rebind_name = JaktInternal::OptionalNone();
+Jakt::typechecker::BindingKeyBuilder key_builder = match_builder.start_pattern(case_proof);
 if (!variant_arguments.is_empty()){
 if (variant_arguments.size() != static_cast<size_t>(1ULL)){
 this->error(ByteString::from_utf8_without_validation("Class instance matches may only have one match argument (the name to rebind to)"sv),arguments_span);
 }
-Jakt::parser::EnumVariantPatternArgument const arg = variant_arguments.operator[](static_cast<i64>(0LL));
-rebind_name = Jakt::types::ClassInstanceRebind(arg.name_in_enum(),arg.name_in_enum_span(),arg.is_mutable,arg.is_reference);
-NonnullRefPtr<Jakt::types::Module> module = this->current_module();
-Jakt::ids::VarId const variable_id = module->add_variable(Jakt::types::CheckedVariable::__jakt_create(rebind_name.value().name,type,rebind_name.value().is_mutable,rebind_name.value().name_span,case_.marker_span,Jakt::types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone()));
-if (rebind_name.value().is_mutable && (!checked_expr->is_mutable(this->program))){
+Jakt::parser::EnumVariantPatternArgument const& arg = variant_arguments[static_cast<i64>(0LL)];
+if (arg.is_mutable && (!checked_expr->is_mutable(this->program))){
 this->error(ByteString::from_utf8_without_validation("Cannot call mutating method on an immutable object instance"sv),span);
 }
-this->add_var_to_scope(new_scope_id,rebind_name.value().name,variable_id,rebind_name.value().name_span);
+rebind_name = Jakt::types::ClassInstanceRebind(arg.name_in_enum(),arg.name_in_enum_span(),arg.is_mutable,arg.is_reference);
+Jakt::types::ClassInstanceRebind const rebind = rebind_name.value();
+NonnullRefPtr<Jakt::types::Module> module = this->current_module();
+Jakt::ids::VarId const variable_id = module->add_variable(Jakt::types::CheckedVariable::__jakt_create(rebind.name,type,rebind.is_mutable,rebind.name_span,case_.marker_span,Jakt::types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone()));
+key_builder = key_builder.submit(rebind.name,variable_id,this->program);
 }
-JaktInternal::Tuple<Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool> const checked_body_result_type_seen_none_ = TRY((this->typecheck_match_body(case_.body,new_scope_id,safety_mode,this->generic_inferences,final_result_type,case_.marker_span)));
-Jakt::types::CheckedMatchBody const checked_body = checked_body_result_type_seen_none_.template get<0>();
-JaktInternal::Optional<Jakt::ids::TypeId> const result_type = checked_body_result_type_seen_none_.template get<1>();
-bool const seen_none = checked_body_result_type_seen_none_.template get<2>();
-
-last_checked_body = checked_body;
-yielded_none |= seen_none;
-final_result_type = result_type;
-checked_patterns.push(Jakt::types::CheckedMatchPattern::ClassInstance(DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>>::create_with({}),type,rebind_name,case_.marker_span));
+TRY((match_builder.register_pattern(case_proof,case_.body,safety_mode,key_builder.finish(),scope_id,Jakt::types::CheckedMatchPattern::ClassInstance(Dictionary<ByteString, NonnullRefPtr<typename Jakt::types::CheckedExpression>>::create_with_entries({}),case_.marker_span,type,rebind_name),*this,[names]() -> ByteString {{
+return __jakt_format(StringView::from_string_literal("class-variant({})"sv),names);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+}
+)));
+}
+goto __jakt_label_147;};/*case end*/
 case 2 /* CatchAll */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> const& variant_arguments = __jakt_match_value.variant_arguments;
 Jakt::utility::Span const& arguments_span = __jakt_match_value.arguments_span;
@@ -14445,39 +13144,23 @@ this->error(ByteString::from_utf8_without_validation("Multiple catch-all cases i
 else {
 seen_catch_all = true;
 catch_all_marker_span = case_.marker_span;
-Jakt::ids::ScopeId const new_scope_id = this->create_scope(scope_id,this->get_scope(scope_id)->can_throw,ByteString::from_utf8_without_validation("class-variant(else)"sv),true);
 if (!variant_arguments.is_empty()){
 this->error(ByteString::from_utf8_without_validation("Catch-all cases in class instance matches cannot have arguments"sv),arguments_span);
 }
-JaktInternal::Tuple<Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool> const checked_body_result_type_seen_none_ = TRY((this->typecheck_match_body(case_.body,new_scope_id,safety_mode,this->generic_inferences,final_result_type,case_.marker_span)));
-Jakt::types::CheckedMatchBody const checked_body = checked_body_result_type_seen_none_.template get<0>();
-JaktInternal::Optional<Jakt::ids::TypeId> const result_type = checked_body_result_type_seen_none_.template get<1>();
-bool const seen_none = checked_body_result_type_seen_none_.template get<2>();
-
-last_checked_body = checked_body;
-yielded_none |= seen_none;
-final_result_type = result_type;
-checked_patterns.push(Jakt::types::CheckedMatchPattern::CatchAll(DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>>::create_with({}),false,case_.marker_span));
+TRY((match_builder.register_pattern(case_proof,case_.body,safety_mode,Jakt::typechecker::BindingKey::New(Dictionary<ByteString, Jakt::ids::VarId>::create_with_entries({})),scope_id,Jakt::types::CheckedMatchPattern::CatchAll(Dictionary<ByteString, NonnullRefPtr<typename Jakt::types::CheckedExpression>>::create_with_entries({}),case_.marker_span,false),*this,[]() -> ByteString {{
+return ByteString::from_utf8_without_validation("class-variant(else)"sv);
+}
+}
+)));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_147;};/*case end*/
 default:{
 this->error(ByteString::from_utf8_without_validation("Only named types and 'else' patterns are allowed in class instance match expressions"sv),case_.marker_span);
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_147;}/*switch end*/
+break;}goto __jakt_label_147; __jakt_label_147:;;
 }
 
 }
@@ -14538,8 +13221,7 @@ this->error(builder.to_string(),span);
 }
 }
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (!__jakt_enum_value) {{
+goto __jakt_label_146;}else if (!__jakt_enum_value) {{
 bool const is_boolean_match = type_to_match_on->__jakt_init_index() == 1 /* Bool */;
 bool seen_true = false;
 bool seen_false = false;
@@ -14559,13 +13241,7 @@ break;
 }
 Jakt::parser::ParsedMatchCase case_ = _magic_value.value();
 {
-JaktInternal::DynamicArray<Jakt::types::CheckedMatchPattern> checked_patterns = DynamicArray<Jakt::types::CheckedMatchPattern>::create_with({});
-JaktInternal::Optional<Jakt::types::CheckedMatchBody> last_checked_body = JaktInternal::OptionalNone();
-ScopeGuard __jakt_var_95([&] {
-if (!checked_patterns.is_empty()){
-checked_cases.push(Jakt::types::CheckedMatchCase(checked_patterns,last_checked_body.value()));
-}
-});
+Jakt::typechecker::CaseStartedProof const case_proof = match_builder.start_case();
 {
 JaktInternal::ArrayIterator<Jakt::parser::ParsedMatchPattern> _magic = case_.patterns.iterator();
 for (;;){
@@ -14575,9 +13251,7 @@ break;
 }
 Jakt::parser::ParsedMatchPattern pattern = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = pattern;
+{auto&& __jakt_match_variant = pattern;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* EnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span>> const& variant_names = __jakt_match_value.variant_names;
@@ -14591,41 +13265,18 @@ if (variant_names.size() == static_cast<size_t>(0ULL)){
 this->compiler->panic(ByteString::from_utf8_without_validation("typecheck_match - else - EnumVariant - variant_names.size() == 0"sv));
 }
 is_enum_match = true;
-Jakt::ids::ScopeId const new_scope_id = this->create_scope(scope_id,this->get_scope(scope_id)->can_throw,__jakt_format(StringView::from_string_literal("catch-enum-variant({})"sv),variant_names),true);
-JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> defaults = DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>>::create_with({});
-{
-JaktInternal::DictionaryIterator<ByteString,Jakt::parser::ParsedPatternDefault> _magic = pattern.common.init_common.defaults.iterator();
-for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault>> const _magic_value = _magic.next();
-if (!_magic_value.has_value()){
-break;
-}
-JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault> ___default___ = _magic_value.value();
-{
-JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault> const jakt_____default___ = ___default___;
-ByteString const _ = jakt_____default___.template get<0>();
-Jakt::parser::ParsedPatternDefault const default_ = jakt_____default___.template get<1>();
+JaktInternal::Tuple<JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>,Jakt::typechecker::BindingKey> const defaults_key_ = TRY((this->typecheck_pattern_defaults(pattern.common.init_common.defaults,scope_id,safety_mode,match_builder.start_pattern(case_proof))));
+JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const defaults = defaults_key_.template get<0>();
+Jakt::typechecker::BindingKey const key = defaults_key_.template get<1>();
 
-NonnullRefPtr<typename Jakt::types::CheckedStatement> const checked_var_decl = TRY((this->typecheck_var_decl(default_.variable,default_.value,new_scope_id,safety_mode,default_.variable.span)));
-defaults.push(checked_var_decl);
+Jakt::types::CheckedMatchPattern const checked_match_pattern = Jakt::types::CheckedMatchPattern::EnumVariant(defaults,case_.marker_span,variant_names.last().value().template get<0>(),variant_arguments,subject_type_id,static_cast<size_t>(0ULL));
+TRY((match_builder.register_pattern(case_proof,case_.body,safety_mode,key,scope_id,checked_match_pattern,*this,[variant_names]() -> ByteString {{
+return __jakt_format(StringView::from_string_literal("catch-enum-variant({})"sv),variant_names);
 }
-
 }
+)));
 }
-
-JaktInternal::Tuple<Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool> const checked_body_result_type_seen_none_ = TRY((this->typecheck_match_body(case_.body,new_scope_id,safety_mode,this->generic_inferences,final_result_type,case_.marker_span)));
-Jakt::types::CheckedMatchBody const checked_body = checked_body_result_type_seen_none_.template get<0>();
-JaktInternal::Optional<Jakt::ids::TypeId> const result_type = checked_body_result_type_seen_none_.template get<1>();
-bool const seen_none = checked_body_result_type_seen_none_.template get<2>();
-
-last_checked_body = checked_body;
-yielded_none |= seen_none;
-final_result_type = result_type;
-Jakt::types::CheckedMatchPattern const checked_match_pattern = Jakt::types::CheckedMatchPattern::EnumVariant(defaults,variant_names.last().value().template get<0>(),variant_arguments,subject_type_id,static_cast<size_t>(0ULL),new_scope_id,case_.marker_span);
-checked_patterns.push(checked_match_pattern);
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_149;};/*case end*/
 case 2 /* CatchAll */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> const& variant_arguments = __jakt_match_value.variant_arguments;
 {
@@ -14643,41 +13294,18 @@ seen_catch_all = true;
 if (variant_arguments.size() != static_cast<size_t>(0ULL)){
 this->compiler->errors.push(Jakt::error::JaktError::Message(ByteString::from_utf8_without_validation("Bindings are not allowed on a generic else"sv),case_.marker_span));
 }
-Jakt::ids::ScopeId const new_scope_id = this->create_scope(scope_id,this->get_scope(scope_id)->can_throw,ByteString::from_utf8_without_validation("catch-all"sv),true);
-JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> defaults = DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>>::create_with({});
-{
-JaktInternal::DictionaryIterator<ByteString,Jakt::parser::ParsedPatternDefault> _magic = pattern.common.init_common.defaults.iterator();
-for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault>> const _magic_value = _magic.next();
-if (!_magic_value.has_value()){
-break;
-}
-JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault> ___default___ = _magic_value.value();
-{
-JaktInternal::Tuple<ByteString,Jakt::parser::ParsedPatternDefault> const jakt_____default___ = ___default___;
-ByteString const _ = jakt_____default___.template get<0>();
-Jakt::parser::ParsedPatternDefault const default_ = jakt_____default___.template get<1>();
+JaktInternal::Tuple<JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>>,Jakt::typechecker::BindingKey> const defaults_key_ = TRY((this->typecheck_pattern_defaults(pattern.common.init_common.defaults,scope_id,safety_mode,match_builder.start_pattern(case_proof))));
+JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const defaults = defaults_key_.template get<0>();
+Jakt::typechecker::BindingKey const key = defaults_key_.template get<1>();
 
-NonnullRefPtr<typename Jakt::types::CheckedStatement> const checked_var_decl = TRY((this->typecheck_var_decl(default_.variable,default_.value,new_scope_id,safety_mode,default_.variable.span)));
-defaults.push(checked_var_decl);
+Jakt::types::CheckedMatchPattern const checked_match_pattern = Jakt::types::CheckedMatchPattern::CatchAll(defaults,case_.marker_span,variant_arguments.size() != static_cast<size_t>(0ULL));
+TRY((match_builder.register_pattern(case_proof,case_.body,safety_mode,key,scope_id,checked_match_pattern,*this,[]() -> ByteString {{
+return ByteString::from_utf8_without_validation("catch-all"sv);
 }
-
 }
+)));
 }
-
-JaktInternal::Tuple<Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool> const checked_body_result_type_seen_none_ = TRY((this->typecheck_match_body(case_.body,new_scope_id,safety_mode,this->generic_inferences,final_result_type,case_.marker_span)));
-Jakt::types::CheckedMatchBody const checked_body = checked_body_result_type_seen_none_.template get<0>();
-JaktInternal::Optional<Jakt::ids::TypeId> const result_type = checked_body_result_type_seen_none_.template get<1>();
-bool const seen_none = checked_body_result_type_seen_none_.template get<2>();
-
-last_checked_body = checked_body;
-yielded_none |= seen_none;
-final_result_type = result_type;
-Jakt::types::CheckedMatchPattern const checked_match_pattern = Jakt::types::CheckedMatchPattern::CatchAll(defaults,variant_arguments.size() != static_cast<size_t>(0ULL),case_.marker_span);
-checked_patterns.push(checked_match_pattern);
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_149;};/*case end*/
 case 1 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expr = __jakt_match_value.value;
 {
@@ -14722,9 +13350,9 @@ return {};
 ((*this),pre_condition,scope_id,safety_mode,this->current_block)));
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_expression = TRY((this->typecheck_expression_and_dereference_if_needed(new_condition,scope_id,safety_mode,Jakt::typechecker::TypeHint::CouldBe(subject_type_id),span)));
 if (is_boolean_match){
-NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp361 = checked_expression;
-if (__jakt_tmp361->__jakt_init_index() == 0 /* Boolean */){
-bool const val = __jakt_tmp361->as.Boolean.val;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp224 = checked_expression;
+if (__jakt_tmp224->__jakt_init_index() == 0 /* Boolean */){
+bool const val = __jakt_tmp224->as.Boolean.val;
 if (val){
 seen_true = true;
 }
@@ -14738,10 +13366,10 @@ if (!checked_expression->to_number_constant(this->program).has_value()){
 all_variants_constant = false;
 }
 Jakt::ids::TypeId expression_type = checked_expression->type();
-NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp362 = checked_expression;
-if (__jakt_tmp362->__jakt_init_index() == 9 /* Range */){
-JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const from = __jakt_tmp362->as.Range.from;
-JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const to = __jakt_tmp362->as.Range.to;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp225 = checked_expression;
+if (__jakt_tmp225->__jakt_init_index() == 9 /* Range */){
+JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const from = __jakt_tmp225->as.Range.from;
+JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const to = __jakt_tmp225->as.Range.to;
 if (from.has_value() || to.has_value()){
 if (from.has_value()){
 expression_type = from.value()->type();
@@ -14752,7 +13380,7 @@ expression_type = to.value()->type();
 }
 else {
 this->error(ByteString::from_utf8_without_validation("There has to be at least a 'from', or a 'to' in a range expression"sv),expr->span());
-return JaktInternal::LoopContinue{};
+continue;
 }
 
 }
@@ -14760,34 +13388,17 @@ TRY((this->check_types_for_compat(expression_type,subject_type_id,this->generic_
 if (!pattern.common.init_common.defaults.is_empty()){
 this->error(ByteString::from_utf8_without_validation("Expression patterns cannot have default bindings"sv),case_.marker_span);
 }
-Jakt::ids::ScopeId const new_scope_id = this->create_scope(scope_id,this->get_scope(scope_id)->can_throw,__jakt_format(StringView::from_string_literal("catch-expression({})"sv),expr),true);
-JaktInternal::Tuple<Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool> const checked_body_result_type_seen_none_ = TRY((this->typecheck_match_body(case_.body,new_scope_id,safety_mode,this->generic_inferences,final_result_type,case_.marker_span)));
-Jakt::types::CheckedMatchBody const checked_body = checked_body_result_type_seen_none_.template get<0>();
-JaktInternal::Optional<Jakt::ids::TypeId> const result_type = checked_body_result_type_seen_none_.template get<1>();
-bool const seen_none = checked_body_result_type_seen_none_.template get<2>();
-
-last_checked_body = checked_body;
-yielded_none |= seen_none;
-final_result_type = result_type;
-Jakt::types::CheckedMatchPattern const checked_match_pattern = Jakt::types::CheckedMatchPattern::Expression(DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>>::create_with({}),checked_expression,case_.marker_span);
-checked_patterns.push(checked_match_pattern);
+TRY((match_builder.register_pattern(case_proof,case_.body,safety_mode,match_builder.empty_binding_key(case_proof),scope_id,Jakt::types::CheckedMatchPattern::Expression(Dictionary<ByteString, NonnullRefPtr<typename Jakt::types::CheckedExpression>>::create_with_entries({}),case_.marker_span,checked_expression),*this,[expr]() -> ByteString {{
+return __jakt_format(StringView::from_string_literal("catch-expression({})"sv),expr);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+}
+)));
+}
+goto __jakt_label_149;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_149;}/*switch end*/
+break;}goto __jakt_label_149; __jakt_label_149:;;
 }
 
 }
@@ -14806,45 +13417,56 @@ if (is_value_match && (seen_catch_all && (is_boolean_match && (seen_true && seen
 this->error(ByteString::from_utf8_without_validation("All cases are covered, but an irrefutable pattern is also present"sv),catch_all_span.value());
 }
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});}), JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-if (yielded_none && final_result_type.has_value()){
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp363 = this->get_type(final_result_type.value());
-if (__jakt_tmp363->__jakt_init_index() == 20 /* GenericInstance */){
-Jakt::ids::StructId const id = __jakt_tmp363->as.GenericInstance.id;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp363->as.GenericInstance.args;
+goto __jakt_label_146;}VERIFY_NOT_REACHED();
+}goto __jakt_label_146; __jakt_label_146:;;goto __jakt_label_143;}/*switch end*/
+}goto __jakt_label_143; __jakt_label_143:;;
+if (match_builder.yielded_none){
+JaktInternal::Optional<Jakt::ids::TypeId> __jakt_tmp226 = match_builder.final_result_type;
+if (__jakt_tmp226.has_value()){
+Jakt::ids::TypeId const final_result_type = __jakt_tmp226.value();
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp227 = this->get_type(final_result_type);
+if (__jakt_tmp227->__jakt_init_index() == 20 /* GenericInstance */){
+Jakt::ids::StructId const id = __jakt_tmp227->as.GenericInstance.id;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp227->as.GenericInstance.args;
 if ((!id.equals(TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("Optional"sv)))))) && (!id.equals(TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("WeakPtr"sv))))))){
-this->error(__jakt_format(StringView::from_string_literal("Type mismatch: expected ‘{}’, but got None"sv),TRY((this->type_name(final_result_type.value(),false)))),span);
+this->error(__jakt_format(StringView::from_string_literal("Type mismatch: expected ‘{}’, but got None"sv),TRY((this->type_name(final_result_type,false)))),span);
 }
 }
 else {
-this->error(__jakt_format(StringView::from_string_literal("Type mismatch: expected ‘{}’, but got None"sv),TRY((this->type_name(final_result_type.value(),false)))),span);
+this->error(__jakt_format(StringView::from_string_literal("Type mismatch: expected ‘{}’, but got None"sv),TRY((this->type_name(final_result_type,false)))),span);
 }
 
 }
-return Jakt::types::CheckedExpression::Match(JaktInternal::OptionalNone(),checked_expr,checked_cases,span,final_result_type.value_or_lazy_evaluated([&] { return Jakt::types::void_type_id(); }),true);
+}
+return Jakt::types::CheckedExpression::Match(JaktInternal::OptionalNone(),checked_expr,match_builder.all_cases,span,match_builder.final_result_type.value_or_lazy_evaluated([&] { return Jakt::types::void_type_id(); }),true);
 }
 }
 
-ErrorOr<JaktInternal::Tuple<Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool>> Jakt::typechecker::Typechecker::typecheck_match_body(Jakt::parser::ParsedMatchBody const body,Jakt::ids::ScopeId const scope_id,Jakt::types::SafetyMode const safety_mode,Jakt::types::GenericInferences& generic_inferences,JaktInternal::Optional<Jakt::ids::TypeId> const final_result_type,Jakt::utility::Span const span) {
+ErrorOr<JaktInternal::Tuple<Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool>> Jakt::typechecker::Typechecker::typecheck_match_body(Jakt::parser::ParsedMatchBody const body,Jakt::ids::ScopeId const parent_scope_id,JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> const bindings,ByteString const body_scope_debug_name,Jakt::types::SafetyMode const safety_mode,JaktInternal::Optional<Jakt::ids::TypeId> const final_result_type,Jakt::utility::Span const span) {
 {
+Jakt::ids::ScopeId const scope_id = this->create_scope(parent_scope_id,this->get_scope(parent_scope_id)->can_throw,body_scope_debug_name,true);
+{
+JaktInternal::DictionaryIterator<ByteString,Jakt::ids::VarId> _magic = bindings.iterator();
+for (;;){
+JaktInternal::Optional<JaktInternal::Tuple<ByteString,Jakt::ids::VarId>> const _magic_value = _magic.next();
+if (!_magic_value.has_value()){
+break;
+}
+JaktInternal::Tuple<ByteString,Jakt::ids::VarId> name__var_id__ = _magic_value.value();
+{
+JaktInternal::Tuple<ByteString,Jakt::ids::VarId> const jakt__name__var_id__ = name__var_id__;
+ByteString const name = jakt__name__var_id__.template get<0>();
+Jakt::ids::VarId const var_id = jakt__name__var_id__.template get<1>();
+
+this->add_var_to_scope(scope_id,name,var_id,this->program->get_variable(var_id)->definition_span);
+}
+
+}
+}
+
 JaktInternal::Optional<Jakt::ids::TypeId> result_type = final_result_type;
 bool seen_none = false;
-Jakt::types::CheckedMatchBody const checked_match_body = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::CheckedMatchBody, ErrorOr<JaktInternal::Tuple<Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool>>>{
-auto&& __jakt_match_variant = body;
+Jakt::types::CheckedMatchBody const checked_match_body = TRY(([&]() -> ErrorOr<Jakt::types::CheckedMatchBody> { auto&& __jakt_match_variant = body;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::parser::ParsedBlock const& block = __jakt_match_value.value;
@@ -14859,13 +13481,13 @@ Jakt::ids::TypeId const block_type_id = checked_block.yielded_type.value_or_lazy
 Jakt::utility::Span const yield_span = block.find_yield_span().value_or_lazy_evaluated([&] { return span; });
 seen_none = checked_block.yielded_none;
 if (result_type.has_value()){
-result_type = TRY((this->choose_broader_type_id(result_type_hint.value().common.init_common.type_id,block_type_id,generic_inferences,yield_span)));
+result_type = TRY((this->choose_broader_type_id(result_type_hint.value().common.init_common.type_id,block_type_id,this->generic_inferences,yield_span)));
 }
 else {
 result_type = block_type_id;
 }
 
-TRY((this->check_types_for_compat(result_type.value(),block_type_id,generic_inferences,yield_span)));
+TRY((this->check_types_for_compat(result_type.value(),block_type_id,this->generic_inferences,yield_span)));
 }
 JaktInternal::Optional<Jakt::types::CheckedMatchBody> final_body = JaktInternal::OptionalNone();
 if (checked_block.yielded_type.has_value() && (!checked_block.control_flow.never_returns())){
@@ -14875,7 +13497,7 @@ else {
 final_body = Jakt::types::CheckedMatchBody::Block(checked_block);
 }
 
-return JaktInternal::ExplicitValue<Jakt::types::CheckedMatchBody>(final_body.value());
+return final_body.value();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -14891,24 +13513,20 @@ if (checked_expression->__jakt_init_index() == 25 /* OptionalNone */){
 seen_none = true;
 }
 if (result_type.has_value()){
-result_type = TRY((this->choose_broader_type_id(result_type_hint.value().common.init_common.type_id,checked_expression->type(),generic_inferences,span)));
+result_type = TRY((this->choose_broader_type_id(result_type_hint.value().common.init_common.type_id,checked_expression->type(),this->generic_inferences,span)));
 }
 else {
 result_type = checked_expression->type();
 }
 
-TRY((this->check_types_for_compat(result_type.value(),checked_expression->type(),generic_inferences,span)));
-return JaktInternal::ExplicitValue<Jakt::types::CheckedMatchBody>(Jakt::types::CheckedMatchBody::Expression(checked_expression));
+TRY((this->check_types_for_compat(result_type.value(),checked_expression->type(),this->generic_inferences,span)));
+return Jakt::types::CheckedMatchBody::Expression(checked_expression);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 return Tuple{checked_match_body, result_type, seen_none};
 }
 }
@@ -14928,8 +13546,8 @@ if (type_hint.has_value()){
 type_hint_ids = TRY((this->get_type_ids_from_type_hint_if_struct_ids_match(type_hint.value().common.init_common.type_id,dictionary_struct_id)));
 }
 if (type_hint_ids.has_value()){
-key_hint = type_hint_ids.value().operator[](static_cast<i64>(0LL));
-value_hint = type_hint_ids.value().operator[](static_cast<i64>(1LL));
+key_hint = type_hint_ids.value()[static_cast<i64>(0LL)];
+value_hint = type_hint_ids.value()[static_cast<i64>(1LL)];
 }
 {
 JaktInternal::ArrayIterator<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,NonnullRefPtr<typename Jakt::parser::ParsedExpression>>> _magic = values.iterator();
@@ -15039,11 +13657,11 @@ break;
 }
 size_t namespace_index = _magic_value.value();
 {
-ByteString const scope_name = call.namespace_.operator[](namespace_index);
+ByteString const scope_name = call.namespace_[namespace_index];
 JaktInternal::Optional<Jakt::ids::StructId> const maybe_struct_scope = TRY((this->find_struct_in_scope(current_scope_id,scope_name,JaktInternal::OptionalNone())));
 if (maybe_struct_scope.has_value()){
 Jakt::types::CheckedStruct const structure = this->get_struct(maybe_struct_scope.value());
-namespaces.operator[](namespace_index).external_name = structure.external_name;
+namespaces[namespace_index].external_name = structure.external_name;
 current_scope_id = structure.scope_id;
 continue;
 }
@@ -15053,59 +13671,43 @@ Jakt::types::CheckedEnum const enum_ = this->get_enum(maybe_enum_scope.value());
 current_scope_id = enum_.scope_id;
 continue;
 }
-JaktInternal::Optional<Jakt::ids::TypeId> __jakt_tmp364 = this->generic_inferences.find_and_map(scope_name,this->program);
-if (__jakt_tmp364.has_value()){
-Jakt::ids::TypeId const type_id = __jakt_tmp364.value();
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::DynamicArray<Jakt::ids::FunctionId>>>{
-auto&& __jakt_match_variant = *this->get_type(type_id);
+JaktInternal::Optional<Jakt::ids::TypeId> __jakt_tmp228 = this->generic_inferences.find_and_map(scope_name,this->program);
+if (__jakt_tmp228.has_value()){
+Jakt::ids::TypeId const type_id = __jakt_tmp228.value();
+{auto&& __jakt_match_variant = *this->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
 {
 current_scope_id = this->get_enum(enum_id).scope_id;
-return JaktInternal::LoopContinue{};
+continue;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_150;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& enum_id = __jakt_match_value.id;
 {
 current_scope_id = this->get_enum(enum_id).scope_id;
-return JaktInternal::LoopContinue{};
+continue;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_150;};/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
 {
 current_scope_id = this->get_struct(struct_id).scope_id;
-return JaktInternal::LoopContinue{};
+continue;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_150;};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& struct_id = __jakt_match_value.id;
 {
 current_scope_id = this->get_struct(struct_id).scope_id;
-return JaktInternal::LoopContinue{};
+continue;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_150;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_150;}/*switch end*/
+break;}goto __jakt_label_150; __jakt_label_150:;;
 }
 JaktInternal::Optional<JaktInternal::Tuple<Jakt::ids::ScopeId,bool>> const maybe_ns_scope = TRY((this->find_namespace_in_scope(current_scope_id,scope_name,false,JaktInternal::OptionalNone())));
 if (maybe_ns_scope.has_value()){
@@ -15114,10 +13716,10 @@ Jakt::ids::ScopeId const scope_id = scope_id_is_import_.template get<0>();
 bool const is_import = scope_id_is_import_.template get<1>();
 
 if (is_import){
-namespaces.operator[](namespace_index).name = this->program->modules.operator[](scope_id.module_id.id)->name;
+namespaces[namespace_index].name = this->program->modules[scope_id.module_id.id]->name;
 }
-namespaces.operator[](namespace_index).external_name = this->get_scope(scope_id)->external_name;
-is_base_ns_alias_or_import.operator[](namespace_index) = TRY((this->find_namespace_in_scope(current_scope_id,scope_name,true,JaktInternal::OptionalNone()))).value().template get<1>();
+namespaces[namespace_index].external_name = this->get_scope(scope_id)->external_name;
+is_base_ns_alias_or_import[namespace_index] = TRY((this->find_namespace_in_scope(current_scope_id,scope_name,true,JaktInternal::OptionalNone()))).value().template get<1>();
 current_scope_id = scope_id;
 continue;
 }
@@ -15129,7 +13731,7 @@ this->error(__jakt_format(StringView::from_string_literal("Not a namespace, enum
 
 Jakt::ids::ScopeId initial_scope_id = current_scope_id;
 JaktInternal::Optional<Jakt::ids::ScopeId> owning_scope = JaktInternal::OptionalNone();
-ScopeGuard __jakt_var_96([&] {
+ScopeGuard __jakt_var_92([&] {
 {
 JaktInternal::DynamicArray<Jakt::types::ResolvedNamespace> resolved_namespaces = DynamicArray<Jakt::types::ResolvedNamespace>::create_with({});
 {
@@ -15143,10 +13745,10 @@ break;
 }
 Jakt::types::ResolvedNamespace ns = _magic_value.value();
 {
-ScopeGuard __jakt_var_97([&] {
+ScopeGuard __jakt_var_93([&] {
 ns_index += static_cast<i64>(1LL);
 });
-if (!is_base_ns_alias_or_import.operator[](ns_index)){
+if (!is_base_ns_alias_or_import[ns_index]){
 resolved_namespaces.push(ns);
 }
 }
@@ -15170,7 +13772,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-aliased_namespaces.push(scope->alias_path.value().operator[](JaktInternal::checked_sub(i,static_cast<size_t>(1ULL))));
+aliased_namespaces.push(scope->alias_path.value()[JaktInternal::checked_sub(i,static_cast<size_t>(1ULL))]);
 }
 
 }
@@ -15198,7 +13800,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-resolved_namespaces.push(aliased_namespaces.operator[](JaktInternal::checked_sub(i,static_cast<size_t>(1ULL))));
+resolved_namespaces.push(aliased_namespaces[JaktInternal::checked_sub(i,static_cast<size_t>(1ULL))]);
 }
 
 }
@@ -15212,35 +13814,26 @@ namespaces.push_values(resolved_namespaces);
 });
 JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedVariable>> const maybe_var = TRY((this->find_var_in_scope(current_scope_id,call.name,JaktInternal::OptionalNone())));
 if (maybe_var.has_value()){
-Jakt::ids::TypeId const inner_type = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId, ErrorOr<JaktInternal::DynamicArray<Jakt::ids::FunctionId>>>{
-auto&& __jakt_match_variant = *this->get_type(maybe_var.value()->type_id);
+Jakt::ids::TypeId const inner_type = [&]() -> Jakt::ids::TypeId { auto&& __jakt_match_variant = *this->get_type(maybe_var.value()->type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 27 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 28 /* MutableReference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MutableReference;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(maybe_var.value()->type_id);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp365 = this->get_type(inner_type);
-if (__jakt_tmp365->__jakt_init_index() == 29 /* Function */){
-Jakt::ids::FunctionId const pseudo_function_id = __jakt_tmp365->as.Function.pseudo_function_id;
+return type_id;};/*case end*/
+default:return maybe_var.value()->type_id;}/*switch end*/
+ 
+}();
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp229 = this->get_type(inner_type);
+if (__jakt_tmp229->__jakt_init_index() == 29 /* Function */){
+Jakt::ids::FunctionId const pseudo_function_id = __jakt_tmp229->as.Function.pseudo_function_id;
 return DynamicArray<Jakt::ids::FunctionId>::create_with({pseudo_function_id});
 }
 }
 JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::ids::FunctionId>,Jakt::ids::ScopeId>> const maybe_overload_set = TRY((this->find_scoped_functions_with_name_in_scope(current_scope_id,call.name,JaktInternal::OptionalNone())));
 if (maybe_overload_set.has_value()){
-NonnullRefPtr<Jakt::types::CheckedFunction> const function = this->get_function(maybe_overload_set.value().template get<0>().operator[](static_cast<i64>(0LL)));
+NonnullRefPtr<Jakt::types::CheckedFunction> const function = this->get_function(maybe_overload_set.value().template get<0>()[static_cast<i64>(0LL)]);
 if ((!must_be_enum_constructor) || (function->type.__jakt_init_index() == 4 /* ImplicitEnumConstructor */)){
 owning_scope = function->owner_scope;
 current_scope_id = maybe_overload_set.value().template get<1>();
@@ -15257,7 +13850,7 @@ Jakt::ids::StructId const struct_id = maybe_struct_id.value();
 Jakt::types::CheckedStruct const structure = this->get_struct(struct_id);
 JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::ids::FunctionId>,Jakt::ids::ScopeId>> const maybe_function_id = TRY((this->find_scoped_functions_with_name_in_scope(structure.scope_id,structure.name,structure.scope_id)));
 if (maybe_function_id.has_value()){
-owning_scope = this->get_function(maybe_function_id.value().template get<0>().operator[](static_cast<i64>(0LL)))->owner_scope;
+owning_scope = this->get_function(maybe_function_id.value().template get<0>()[static_cast<i64>(0LL)])->owner_scope;
 current_scope_id = maybe_function_id.value().template get<1>();
 return maybe_function_id.value().template get<0>();
 }
@@ -15279,7 +13872,7 @@ JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> const generic_infe
 if (callee_candidate->is_instantiated){
 this->generic_inferences.perform_checkpoint(true);
 }
-ScopeGuard __jakt_var_98([&] {
+ScopeGuard __jakt_var_94([&] {
 {
 this->generic_inferences.restore(generic_inference_checkpoint);
 }
@@ -15308,7 +13901,7 @@ if (callee_candidate->generics->params.size() <= type_arg_index){
 this->error(ByteString::from_utf8_without_validation("Trying to access generic parameter out of bounds"sv),parsed_type->span());
 continue;
 }
-Jakt::ids::TypeId const typevar_type_id = callee_candidate->generics->params.operator[](type_arg_index).type_id();
+Jakt::ids::TypeId const typevar_type_id = callee_candidate->generics->params[type_arg_index].type_id();
 if (!typevar_type_id.equals(checked_type)){
 this->generic_inferences.set(typevar_type_id,checked_type);
 }
@@ -15323,10 +13916,10 @@ if (this_expr.has_value()){
 Jakt::ids::TypeId const type_id = this_expr.value()->type();
 maybe_this_type_id = type_id;
 NonnullRefPtr<typename Jakt::types::Type> const param_type = this->get_type(type_id);
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp366 = param_type;
-if (__jakt_tmp366->__jakt_init_index() == 20 /* GenericInstance */){
-Jakt::ids::StructId const id = __jakt_tmp366->as.GenericInstance.id;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp366->as.GenericInstance.args;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp230 = param_type;
+if (__jakt_tmp230->__jakt_init_index() == 20 /* GenericInstance */){
+Jakt::ids::StructId const id = __jakt_tmp230->as.GenericInstance.id;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = __jakt_tmp230->as.GenericInstance.args;
 Jakt::types::CheckedStruct const structure = this->get_struct(id);
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(structure.generic_parameters.size())};
@@ -15337,10 +13930,10 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (structure.generic_parameters.operator[](i).type_id.equals(args.operator[](i))){
+if (structure.generic_parameters[i].type_id.equals(args[i])){
 continue;
 }
-this->generic_inferences.set(structure.generic_parameters.operator[](i).type_id,args.operator[](i));
+this->generic_inferences.set(structure.generic_parameters[i].type_id,args[i]);
 }
 
 }
@@ -15366,10 +13959,10 @@ JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span,No
 JaktInternal::DynamicArray<Jakt::ids::TypeId> params_to_compare = DynamicArray<Jakt::ids::TypeId>::create_with({});
 bool is_specialized_comptime_function = false;
 if (callee_candidate->is_comptime){
-JaktInternal::Optional<size_t> __jakt_tmp367 = callee_candidate->specialization_index;
-if (__jakt_tmp367.has_value()){
-size_t const index = __jakt_tmp367.value();
-params_to_compare = callee_candidate->generics->specializations.operator[](index);
+JaktInternal::Optional<size_t> __jakt_tmp231 = callee_candidate->specialization_index;
+if (__jakt_tmp231.has_value()){
+size_t const index = __jakt_tmp231.value();
+params_to_compare = callee_candidate->generics->specializations[index];
 is_specialized_comptime_function = true;
 }
 else {
@@ -15421,17 +14014,17 @@ break;
 }
 size_t i = _magic_value.value();
 {
-JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const name_span_checked_arg_ = resolved_args.operator[](i);
+JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::types::CheckedExpression>> const name_span_checked_arg_ = resolved_args[i];
 ByteString const name = name_span_checked_arg_.template get<0>();
 Jakt::utility::Span const span = name_span_checked_arg_.template get<1>();
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_arg = name_span_checked_arg_.template get<2>();
 
-NonnullRefPtr<typename Jakt::types::Type> const type_to = this->get_type(params_to_compare.operator[](JaktInternal::checked_add(i,arg_offset)));
+NonnullRefPtr<typename Jakt::types::Type> const type_to = this->get_type(params_to_compare[JaktInternal::checked_add(i,arg_offset)]);
 total_function_specificity += type_to->specificity(this->program,static_cast<i64>(1LL) << static_cast<i64>(31LL));
 if (is_specialized_comptime_function){
-TRY((this->check_types_for_compat(callee_candidate->generics->base_params.operator[](JaktInternal::checked_add(i,arg_offset)).variable->type_id,checked_arg->type(),this->generic_inferences,checked_arg->span())));
+TRY((this->check_types_for_compat(callee_candidate->generics->base_params[JaktInternal::checked_add(i,arg_offset)].variable->type_id,checked_arg->type(),this->generic_inferences,checked_arg->span())));
 }
-TRY((this->check_types_for_compat(params_to_compare.operator[](JaktInternal::checked_add(i,arg_offset)),checked_arg->type(),this->generic_inferences,checked_arg->span())));
+TRY((this->check_types_for_compat(params_to_compare[JaktInternal::checked_add(i,arg_offset)],checked_arg->type(),this->generic_inferences,checked_arg->span())));
 args.push(checked_arg);
 }
 
@@ -15440,7 +14033,7 @@ args.push(checked_arg);
 
 if ((params_to_compare.size() < JaktInternal::checked_add(resolved_args.size(),arg_offset)) && callee_candidate->has_varargs){
 {
-JaktInternal::ArrayIterator<JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::types::CheckedExpression>>> _magic = resolved_args.operator[](JaktInternal::Range<size_t>{static_cast<size_t>(JaktInternal::checked_sub(params_to_compare.size(),arg_offset)),static_cast<size_t>(9223372036854775807LL)}).iterator();
+JaktInternal::ArrayIterator<JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::types::CheckedExpression>>> _magic = resolved_args[JaktInternal::Range<size_t>{static_cast<size_t>(JaktInternal::checked_sub(params_to_compare.size(),arg_offset)),static_cast<size_t>(9223372036854775807LL)}].iterator();
 for (;;){
 JaktInternal::Optional<JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::types::CheckedExpression>>> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
@@ -15570,11 +14163,11 @@ builder.append(StringView::from_string_literal(" throws"sv));
 }
 builder.append(StringView::from_string_literal(" -> "sv));
 TRY((mapped(function->return_type_id)));
-JaktInternal::Optional<size_t> __jakt_tmp368 = function->specialization_index;
-if (__jakt_tmp368.has_value()){
-size_t const index = __jakt_tmp368.value();
+JaktInternal::Optional<size_t> __jakt_tmp232 = function->specialization_index;
+if (__jakt_tmp232.has_value()){
+size_t const index = __jakt_tmp232.value();
 builder.appendff(ByteString::from_utf8_without_validation(" [specialization {}: <"sv),index);
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const type_ids = function->generics->specializations.operator[](index);
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const type_ids = function->generics->specializations[index];
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(type_ids.size())};
 for (;;){
@@ -15587,7 +14180,7 @@ size_t i = _magic_value.value();
 if (i != static_cast<size_t>(0ULL)){
 builder.append(StringView::from_string_literal(", "sv));
 }
-TRY((mapped(type_ids.operator[](i))));
+TRY((mapped(type_ids[i])));
 }
 
 }
@@ -15611,19 +14204,12 @@ JaktInternal::Optional<Jakt::ids::FunctionId> resolved_function_id = JaktInterna
 JaktInternal::Optional<Jakt::ids::TypeId> maybe_this_type_id = JaktInternal::OptionalNone();
 JaktInternal::Optional<Jakt::ids::FunctionId> generic_checked_function_to_instantiate = JaktInternal::OptionalNone();
 JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> const old_generic_inferences = this->generic_inferences.perform_checkpoint(false);
-ScopeGuard __jakt_var_99([&] {
+ScopeGuard __jakt_var_95([&] {
 this->generic_inferences.restore(old_generic_inferences);
 });
-bool const is_print_like = call.namespace_.is_empty() && ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool,ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>> {
-auto __jakt_enum_value = (call.name);
-if ((__jakt_enum_value == ByteString::from_utf8_without_validation("print"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("println"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("eprintln"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("eprint"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("format"sv))) {return JaktInternal::ExplicitValue(true);
-}else {return JaktInternal::ExplicitValue(false);
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+bool const is_print_like = call.namespace_.is_empty() && [&]() -> bool { auto __jakt_enum_value = call.name;
+if ((__jakt_enum_value == ByteString::from_utf8_without_validation("print"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("println"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("eprintln"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("eprint"sv))||(__jakt_enum_value == ByteString::from_utf8_without_validation("format"sv))) {return true;}else {return false;} 
+}();
 {
 JaktInternal::ArrayIterator<ByteString> _magic = call.namespace_.iterator();
 for (;;){
@@ -15639,12 +14225,8 @@ resolved_namespaces.push(Jakt::types::ResolvedNamespace(name,JaktInternal::Optio
 }
 }
 
-Jakt::ids::ScopeId callee_scope_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::ScopeId,ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>> {
-auto __jakt_enum_value = (parent_id.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::ScopeId, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = parent_id.value();
+Jakt::ids::ScopeId callee_scope_id = TRY(([&]() -> ErrorOr<Jakt::ids::ScopeId> { auto __jakt_enum_value = parent_id.has_value();
+if (__jakt_enum_value) {{auto&& __jakt_match_variant = parent_id.value();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
@@ -15669,7 +14251,7 @@ break;
 }
 
 }
-return JaktInternal::ExplicitValue<Jakt::ids::ScopeId>(scope_id);
+return scope_id;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -15678,7 +14260,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const
 {
 Jakt::ids::ScopeId const scope_id = this->get_enum(id).scope_id;
 resolved_function_id_candidates = TRY((this->resolve_call(call,resolved_namespaces,span,scope_id,must_be_enum_constructor)));
-return JaktInternal::ExplicitValue<Jakt::ids::ScopeId>(scope_id);
+return scope_id;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -15687,29 +14269,20 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId con
 {
 Jakt::ids::ScopeId const scope_id = this->get_trait(id)->scope_id;
 resolved_function_id_candidates = TRY((this->resolve_call(call,resolved_namespaces,span,scope_id,must_be_enum_constructor)));
-return JaktInternal::ExplicitValue<Jakt::ids::ScopeId>(scope_id);
+return scope_id;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else {{
+}}else {{
 if (!is_print_like){
 resolved_function_id_candidates = TRY((this->resolve_call(call,resolved_namespaces,span,caller_scope_id,must_be_enum_constructor)));
 }
-return JaktInternal::ExplicitValue<Jakt::ids::ScopeId>(caller_scope_id);
+return caller_scope_id;
 }
 VERIFY_NOT_REACHED();
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+} 
+}()));
 JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> generic_inferences_from_parent = Dictionary<Jakt::ids::TypeId, Jakt::ids::TypeId>::create_with_entries({});
 if (parent_id.has_value() && parent_id.value().common.init_common.generic_arguments.has_value()){
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const arguments = parent_id.value().common.init_common.generic_arguments.value();
@@ -15727,8 +14300,8 @@ break;
 }
 size_t i = _magic_value.value();
 {
-generic_inferences_from_parent.set(parameters.operator[](i),arguments.operator[](i));
-this->generic_inferences.set(parameters.operator[](i),arguments.operator[](i));
+generic_inferences_from_parent.set(parameters[i],arguments[i]);
+this->generic_inferences.set(parameters[i],arguments[i]);
 }
 
 }
@@ -15746,25 +14319,15 @@ break;
 }
 JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>> arg = _magic_value.value();
 {
-JaktInternal::Optional<Jakt::typechecker::TypeHint> const type_hint = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::typechecker::TypeHint>,ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>> {
-auto __jakt_enum_value = (first);
+JaktInternal::Optional<Jakt::typechecker::TypeHint> const type_hint = TRY(([&]() -> ErrorOr<JaktInternal::Optional<Jakt::typechecker::TypeHint>> { auto __jakt_enum_value = first;
 if (__jakt_enum_value) {{
 first = false;
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::typechecker::TypeHint>>(static_cast<JaktInternal::Optional<Jakt::typechecker::TypeHint>>(Jakt::typechecker::TypeHint::MustBe(TRY((this->prelude_struct_type_named(ByteString::from_utf8_without_validation("StringView"sv)))))));
+return static_cast<JaktInternal::Optional<Jakt::typechecker::TypeHint>>(Jakt::typechecker::TypeHint::MustBe(TRY((this->prelude_struct_type_named(ByteString::from_utf8_without_validation("StringView"sv))))));
 }
 VERIFY_NOT_REACHED();
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+}else if (!__jakt_enum_value) {return JaktInternal::OptionalNone();}VERIFY_NOT_REACHED();
+ 
+}()));
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_arg = TRY((this->typecheck_expression(arg.template get<2>(),caller_scope_id,safety_mode,type_hint)));
 args.push(Tuple{call.name, checked_arg});
 }
@@ -15789,9 +14352,7 @@ break;
 }
 Jakt::ids::FunctionId candidate = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = TRY((this->match_function_and_resolve_args(call,caller_scope_id,candidate,safety_mode,span,this_expr)));
+{auto&& __jakt_match_variant = TRY((this->match_function_and_resolve_args(call,caller_scope_id,candidate,safety_mode,span,this_expr)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* MatchSuccess */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MatchSuccess;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& resolved_args = __jakt_match_value.args;
@@ -15822,8 +14383,7 @@ args.push(Tuple{call.name, resolved_arg});
 
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_151;};/*case end*/
 case 1 /* MatchError */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MatchError;JaktInternal::DynamicArray<Jakt::error::JaktError> const& errors = __jakt_match_value.errors;
 {
@@ -15842,21 +14402,11 @@ errors_while_trying_to_find_matching_function.push(error);
 }
 }
 
-return JaktInternal::LoopContinue{};
+continue;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_151;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+break;}goto __jakt_label_151; __jakt_label_151:;;
 }
 
 }
@@ -15940,7 +14490,7 @@ this->error(ByteString::from_utf8_without_validation("Cannot call unsafe functio
 }
 if (type_hint.has_value() && (!type_hint.value().common.init_common.type_id.equals(Jakt::types::unknown_type_id()))){
 JaktInternal::Tuple<bool,bool> const snapshot = this->enter_ignore_error_mode(true);
-ScopeGuard __jakt_var_100([&] {
+ScopeGuard __jakt_var_96([&] {
 this->exit_ignore_error_mode(snapshot);
 });
 TRY((this->check_types_for_compat(return_type,type_hint.value(),this->generic_inferences,span)));
@@ -15948,7 +14498,7 @@ TRY((this->check_types_for_compat(return_type,type_hint.value(),this->generic_in
 return_type = TRY((this->substitute_typevars_in_type(return_type,this->generic_inferences)));
 if (type_hint.has_value() && (!type_hint.value().common.init_common.type_id.equals(Jakt::types::unknown_type_id()))){
 JaktInternal::Tuple<bool,bool> const snapshot = this->enter_ignore_error_mode(callee->is_instantiated);
-ScopeGuard __jakt_var_101([&] {
+ScopeGuard __jakt_var_97([&] {
 this->exit_ignore_error_mode(snapshot);
 });
 TRY((this->check_types_for_compat(type_hint.value(),return_type,this->generic_inferences,span)));
@@ -16003,24 +14553,18 @@ resolved_function_id = TRY((this->typecheck_and_specialize_generic_function(gene
 if (this->dump_try_hints && callee_throws){
 this->dump_try_hint(span);
 }
-JaktInternal::Optional<Jakt::parser::ExternalName> const external_name = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::parser::ExternalName>,ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>> {
-auto __jakt_enum_value = (resolved_function_id.has_value());
+JaktInternal::Optional<Jakt::parser::ExternalName> const external_name = [&]() -> JaktInternal::Optional<Jakt::parser::ExternalName> { auto __jakt_enum_value = resolved_function_id.has_value();
 if (__jakt_enum_value) {{
 NonnullRefPtr<Jakt::types::CheckedFunction> const function = this->get_function(resolved_function_id.value());
 if (function->deprecated_message.has_value()){
 this->error(__jakt_format(StringView::from_string_literal("Call to deprecated function: {}"sv),function->deprecated_message.value()),span);
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::parser::ExternalName>>(function->external_name);
+return function->external_name;
 }
 VERIFY_NOT_REACHED();
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}else if (!__jakt_enum_value) {return JaktInternal::OptionalNone();}VERIFY_NOT_REACHED();
+ 
+}();
 if (resolved_function_id.has_value()){
 NonnullRefPtr<Jakt::types::CheckedFunction> const function = this->get_function(resolved_function_id.value());
 if (function->stores_arguments.has_value()){
@@ -16040,37 +14584,24 @@ Jakt::parser::ArgumentStoreLevel const level = jakt__index__level__.template get
 
 Function<ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(size_t)> const resolve_arg = [&args, &this_expr, &function](size_t index) -> ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>> {{
 if (function->is_static()){
-return args.operator[](index).template get<1>();
+return args[index].template get<1>();
 }
 if (index == static_cast<size_t>(0ULL)){
 return this_expr.value();
 }
-return args.operator[](JaktInternal::checked_sub(index,static_cast<size_t>(1ULL))).template get<1>();
+return args[JaktInternal::checked_sub(index,static_cast<size_t>(1ULL))].template get<1>();
 }
 }
 ;
 JaktInternal::Optional<Jakt::ids::ScopeId> const arg_scope_id = TRY((this->required_scope_id_in_hierarchy_for(TRY((resolve_arg(index))),caller_scope_id))).template get<0>();
-JaktInternal::Optional<Jakt::ids::ScopeId> const stored_scope_id = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ids::ScopeId>, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = level;
+JaktInternal::Optional<Jakt::ids::ScopeId> const stored_scope_id = TRY(([&]() -> ErrorOr<JaktInternal::Optional<Jakt::ids::ScopeId>> { auto&& __jakt_match_variant = level;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* InStaticStorage */:return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(this->root_scope_id()));
-case 0 /* InObject */: {
+case 2 /* InStaticStorage */:return static_cast<JaktInternal::Optional<Jakt::ids::ScopeId>>(this->root_scope_id());case 0 /* InObject */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.InObject;size_t const& argument_index = __jakt_match_value.argument_index;
-return JaktInternal::ExplicitValue(TRY((this->required_scope_id_in_hierarchy_for(TRY((resolve_arg(argument_index))),caller_scope_id))).template get<0>());
-};/*case end*/
-case 1 /* InReturnValue */:return JaktInternal::ExplicitValue(caller_scope_id);
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+return TRY((this->required_scope_id_in_hierarchy_for(TRY((resolve_arg(argument_index))),caller_scope_id))).template get<0>();};/*case end*/
+case 1 /* InReturnValue */:return caller_scope_id;default: VERIFY_NOT_REACHED();}/*switch end*/
+ 
+}()));
 if (this->scope_lifetime_subsumes(stored_scope_id,arg_scope_id)){
 this->error(ByteString::from_utf8_without_validation("Cannot pass this argument by reference, it is not guaranteed to outlive the object it will be stored in"sv),TRY((resolve_arg(index)))->span());
 }
@@ -16081,17 +14612,10 @@ this->error(ByteString::from_utf8_without_validation("Cannot pass this argument 
 
 }
 }
-Jakt::parser::InlineState const force_inline = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::parser::InlineState,ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>> {
-auto __jakt_enum_value = (resolved_function_id.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(this->get_function(resolved_function_id.value())->force_inline);
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::parser::InlineState::Default());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+Jakt::parser::InlineState const force_inline = [&]() -> Jakt::parser::InlineState { auto __jakt_enum_value = resolved_function_id.has_value();
+if (__jakt_enum_value) {return this->get_function(resolved_function_id.value())->force_inline;}else if (!__jakt_enum_value) {return Jakt::parser::InlineState::Default();}VERIFY_NOT_REACHED();
+ 
+}();
 Jakt::types::CheckedCall const function_call = Jakt::types::CheckedCall(resolved_namespaces,call.name,args,generic_arguments,resolved_function_id,return_type,callee_throws,external_name,force_inline);
 NonnullRefPtr<typename Jakt::types::CheckedExpression> const checked_call = Jakt::types::CheckedExpression::Call(this->generic_inferences.perform_checkpoint(false),function_call,span,return_type);
 bool const in_comptime_function = this->current_function_id.has_value() && this->get_function(this->current_function_id.value())->is_comptime;
@@ -16122,17 +14646,17 @@ eval_scope->type_bindings.set(key,value);
 }
 
 if (this_expr.has_value()){
-auto __jakt_var_102 = [&]() -> ErrorOr<void> {
+auto __jakt_var_98 = [&]() -> ErrorOr<void> {
 {
 Jakt::interpreter::StatementResult const evaluated_this = TRY((interpreter->execute_expression(this_expr.value(),eval_scope)));
-Jakt::interpreter::StatementResult __jakt_tmp369 = evaluated_this;
-Jakt::interpreter::StatementResult __jakt_tmp370 = evaluated_this;
-if (__jakt_tmp369.__jakt_init_index() == 5 /* JustValue */){
-Jakt::types::Value const value = __jakt_tmp369.as.JustValue.value;
+Jakt::interpreter::StatementResult __jakt_tmp233 = evaluated_this;
+Jakt::interpreter::StatementResult __jakt_tmp234 = evaluated_this;
+if (__jakt_tmp233.__jakt_init_index() == 5 /* JustValue */){
+Jakt::types::Value const value = __jakt_tmp233.as.JustValue.value;
 this_argument = value;
 }
-else if (__jakt_tmp370.__jakt_init_index() == 1 /* Throw */){
-Jakt::types::Value const value = __jakt_tmp370.as.Throw.value;
+else if (__jakt_tmp234.__jakt_init_index() == 1 /* Throw */){
+Jakt::types::Value const value = __jakt_tmp234.as.Throw.value;
 this->error(__jakt_format(StringView::from_string_literal("Error executing this expression (evaluation threw {})"sv),value),this_expr.value()->span());
 }
 else {
@@ -16143,7 +14667,7 @@ this->error(ByteString::from_utf8_without_validation("Invalid this expression"sv
 
 ;
 return ErrorOr<void> {};}();
-if (__jakt_var_102.is_error()) {{
+if (__jakt_var_98.is_error()) {{
 this->error(ByteString::from_utf8_without_validation("Error executing this expression"sv),this_expr.value()->span());
 }
 };
@@ -16157,47 +14681,35 @@ break;
 }
 JaktInternal::Tuple<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> argument = _magic_value.value();
 {
-Jakt::interpreter::StatementResult const value = ({ Optional<Jakt::interpreter::StatementResult> __jakt_var_103;
-auto __jakt_var_104 = [&]() -> ErrorOr<Jakt::interpreter::StatementResult> { return interpreter->execute_expression(argument.template get<1>(),eval_scope); }();
-if (__jakt_var_104.is_error()) {{
+Jakt::interpreter::StatementResult const value = ({ Optional<Jakt::interpreter::StatementResult> __jakt_var_99;
+auto __jakt_var_100 = [&]() -> ErrorOr<Jakt::interpreter::StatementResult> { return interpreter->execute_expression(argument.template get<1>(),eval_scope); }();
+if (__jakt_var_100.is_error()) {{
 this->error(ByteString::from_utf8_without_validation("Error in argument"sv),span);
 continue;
 }
-} else {__jakt_var_103 = __jakt_var_104.release_value();
+} else {__jakt_var_99 = __jakt_var_100.release_value();
 }
-__jakt_var_103.release_value(); });
-Jakt::interpreter::StatementResult __jakt_tmp371 = value;
-if (__jakt_tmp371.__jakt_init_index() == 1 /* Throw */){
-Jakt::types::Value const err = __jakt_tmp371.as.Throw.value;
-this->error(TRY((Jakt::types::comptime_format_impl(ByteString::from_utf8_without_validation("Compiletime call failed: {}"sv),DynamicArray<Jakt::types::Value>::create_with({err}).operator[](JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}),this->program))),argument.template get<1>()->span());
+__jakt_var_99.release_value(); });
+Jakt::interpreter::StatementResult __jakt_tmp235 = value;
+if (__jakt_tmp235.__jakt_init_index() == 1 /* Throw */){
+Jakt::types::Value const err = __jakt_tmp235.as.Throw.value;
+this->error(TRY((Jakt::types::comptime_format_impl(ByteString::from_utf8_without_validation("Compiletime call failed: {}"sv),DynamicArray<Jakt::types::Value>::create_with({err})[JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}],this->program))),argument.template get<1>()->span());
 break;
 }
-Jakt::types::Value const evaluated_value = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = value;
+Jakt::types::Value const evaluated_value = TRY(([&]() -> ErrorOr<Jakt::types::Value> { auto&& __jakt_match_variant = value;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
+return x;};/*case end*/
 case 5 /* JustValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JustValue;Jakt::types::Value const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
+return x;};/*case end*/
 default:{
 return Error::from_errno(static_cast<i32>(69));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}()));
 call_args.push(evaluated_value);
 }
 
@@ -16214,12 +14726,12 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::types::FunctionGenericParameter const param = resolved_function->generics->params.operator[](i);
+Jakt::types::FunctionGenericParameter const param = resolved_function->generics->params[i];
 if (function_call.type_args.size() <= i){
 this->error(__jakt_format(StringView::from_string_literal("Missing type argument for generic parameter {}"sv),i),span);
 break;
 }
-type_bindings.set(param.type_id(),function_call.type_args.operator[](i));
+type_bindings.set(param.type_id(),function_call.type_args[i]);
 }
 
 }
@@ -16227,42 +14739,34 @@ type_bindings.set(param.type_id(),function_call.type_args.operator[](i));
 
 JaktInternal::Optional<Jakt::interpreter::ExecutionResult> result = JaktInternal::OptionalNone();
 NonnullRefPtr<Jakt::interpreter::InterpreterScope> invocation_scope = Jakt::interpreter::InterpreterScope::create(Dictionary<ByteString, Jakt::types::Value>::create_with_entries({}),eval_scope,type_bindings,this->compiler,caller_scope_id);
-auto __jakt_var_105 = [&]() -> ErrorOr<void> {
+auto __jakt_var_101 = [&]() -> ErrorOr<void> {
 {
 result = TRY((interpreter->execute(resolved_function_id.value(),resolved_namespaces,this_argument,call_args,span,invocation_scope,false)));
 }
 
 ;
 return ErrorOr<void> {};}();
-if (__jakt_var_105.is_error()) {auto error = __jakt_var_105.release_error();
+if (__jakt_var_101.is_error()) {auto error = __jakt_var_101.release_error();
 {
 this->error(__jakt_format(StringView::from_string_literal("Compiletime call failed: {}"sv),error),span);
 return checked_call;
 }
 };
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::CheckedExpression>, ErrorOr<NonnullRefPtr<typename Jakt::types::CheckedExpression>>>{
-auto&& __jakt_match_variant = result.value();
+{auto&& __jakt_match_variant = result.value();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;Jakt::types::Value const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((Jakt::interpreter::value_to_checked_expression(x,interpreter))));
-};/*case end*/
+return Jakt::interpreter::value_to_checked_expression(x,interpreter);};/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::types::Value const& x = __jakt_match_value.value;
 {
-this->error(TRY((Jakt::types::comptime_format_impl(ByteString::from_utf8_without_validation("Compiletime call failed: {}"sv),DynamicArray<Jakt::types::Value>::create_with({x}).operator[](JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}),this->program))),x.span);
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::CheckedExpression>>(checked_call);
+this->error(TRY((Jakt::types::comptime_format_impl(ByteString::from_utf8_without_validation("Compiletime call failed: {}"sv),DynamicArray<Jakt::types::Value>::create_with({x})[JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}],this->program))),x.span);
+return checked_call;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 return checked_call;
 }
@@ -16346,7 +14850,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::types::CheckedParameter const param = params.operator[](i);
+Jakt::types::CheckedParameter const param = params[i];
 JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> maybe_checked_expr = JaktInternal::OptionalNone();
 if (!param.requires_label){
 if (args.size() <= consumed_arg){
@@ -16354,23 +14858,23 @@ if (!param.default_value_expression.has_value()){
 this->error(__jakt_format(StringView::from_string_literal("Missing argument for function parameter {}"sv),param.variable->name),span);
 continue;
 }
-JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>> __jakt_tmp372 = param.default_value_expression;
-if (__jakt_tmp372.has_value()){
-JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId> const default_value = __jakt_tmp372.value();
+JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>> __jakt_tmp236 = param.default_value_expression;
+if (__jakt_tmp236.has_value()){
+JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId> const default_value = __jakt_tmp236.value();
 NonnullRefPtr<Jakt::types::Scope> scope = this->get_scope(scope_id);
 JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId> const expression_default_scope_id_ = default_value;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expression = expression_default_scope_id_.template get<0>();
 Jakt::ids::ScopeId const default_scope_id = expression_default_scope_id_.template get<1>();
 
 scope->resolution_mixins.push(Jakt::types::ResolutionMixin(default_scope_id,true,true,true,true,true,true,true,true,true));
-ScopeGuard __jakt_var_106([&] {
+ScopeGuard __jakt_var_102([&] {
 scope->resolution_mixins.pop();
 });
 maybe_checked_expr = TRY((this->typecheck_expression(expression,scope_id,safety_mode,Jakt::typechecker::TypeHint::MustBe(param.variable->type_id))));
 }
 }
 else {
-JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const name_span_expr_ = args.operator[](consumed_arg);
+JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const name_span_expr_ = args[consumed_arg];
 ByteString const name = name_span_expr_.template get<0>();
 Jakt::utility::Span const span = name_span_expr_.template get<1>();
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = name_span_expr_.template get<2>();
@@ -16388,22 +14892,22 @@ consumed_arg++;
 
 }
 else {
-JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>> __jakt_tmp373 = param.default_value_expression;
-if (__jakt_tmp373.has_value()){
-JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId> const default_value = __jakt_tmp373.value();
+JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId>> __jakt_tmp237 = param.default_value_expression;
+if (__jakt_tmp237.has_value()){
+JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId> const default_value = __jakt_tmp237.value();
 NonnullRefPtr<Jakt::types::Scope> scope = this->get_scope(scope_id);
 JaktInternal::Tuple<NonnullRefPtr<typename Jakt::parser::ParsedExpression>,Jakt::ids::ScopeId> const expression_default_scope_id_ = default_value;
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expression = expression_default_scope_id_.template get<0>();
 Jakt::ids::ScopeId const default_scope_id = expression_default_scope_id_.template get<1>();
 
 scope->resolution_mixins.push(Jakt::types::ResolutionMixin(default_scope_id,true,true,true,true,true,true,true,true,true));
-ScopeGuard __jakt_var_107([&] {
+ScopeGuard __jakt_var_103([&] {
 scope->resolution_mixins.pop();
 });
 maybe_checked_expr = TRY((this->typecheck_expression(expression,scope_id,safety_mode,Jakt::typechecker::TypeHint::MustBe(param.variable->type_id))));
 }
 if (args.size() > consumed_arg){
-JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const name_span_expr_ = args.operator[](consumed_arg);
+JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>> const name_span_expr_ = args[consumed_arg];
 ByteString const name = name_span_expr_.template get<0>();
 Jakt::utility::Span const span = name_span_expr_.template get<1>();
 NonnullRefPtr<typename Jakt::parser::ParsedExpression> const expr = name_span_expr_.template get<2>();
@@ -16413,25 +14917,14 @@ maybe_checked_expr = TRY((this->typecheck_expression(expr,scope_id,safety_mode,J
 consumed_arg++;
 }
 else {
-ByteString const reason = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>>> {
-auto __jakt_enum_value = (name.is_empty());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("Missing argument label (expected '{}:')"sv),param.variable->name));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("Wrong parameter name in argument label (got '{}', expected '{}')"sv),name,param.variable->name));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ByteString const reason = [&]() -> ByteString { auto __jakt_enum_value = name.is_empty();
+if (__jakt_enum_value) {return __jakt_format(StringView::from_string_literal("Missing argument label (expected '{}:')"sv),param.variable->name);}else if (!__jakt_enum_value) {return __jakt_format(StringView::from_string_literal("Wrong parameter name in argument label (got '{}', expected '{}')"sv),name,param.variable->name);}VERIFY_NOT_REACHED();
+ 
+}();
 if (!invalid_considered_argument_uses.contains(consumed_arg)){
 invalid_considered_argument_uses.set(consumed_arg, DynamicArray<JaktInternal::Tuple<size_t,ByteString>>::create_with({}));
 }
-invalid_considered_argument_uses.operator[](consumed_arg).push(Tuple{i, reason});
+invalid_considered_argument_uses[consumed_arg].push(Tuple{i, reason});
 }
 
 }
@@ -16455,30 +14948,19 @@ resolved_args.push(Tuple{param.variable->name, span, checked_arg});
 
 if (!has_varargs){
 while (consumed_arg < args.size()){
-ScopeGuard __jakt_var_108([&] {
+ScopeGuard __jakt_var_104([&] {
 consumed_arg += static_cast<size_t>(1ULL);
 });
 if (invalid_considered_argument_uses.contains(consumed_arg)){
-JaktInternal::Tuple<size_t,ByteString> const last_invalid_use = invalid_considered_argument_uses.operator[](consumed_arg).last().value();
-this->error_with_hint(ByteString::from_utf8_without_validation("Invalid argument not used in call"sv),args.operator[](consumed_arg).template get<1>(),__jakt_format(StringView::from_string_literal("{} position{} considered for the argument, final rejection reason was: {}"sv),invalid_considered_argument_uses.operator[](consumed_arg).size(),({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::types::CheckedExpression>>>>> {
-auto __jakt_enum_value = (invalid_considered_argument_uses.operator[](consumed_arg).size());
-if (__jakt_enum_value == static_cast<size_t>(1ULL)) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}else {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("s"sv));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-}),last_invalid_use.template get<1>()),params.operator[](last_invalid_use.template get<0>()).variable->definition_span);
+JaktInternal::Tuple<size_t,ByteString> const last_invalid_use = invalid_considered_argument_uses[consumed_arg].last().value();
+this->error_with_hint(ByteString::from_utf8_without_validation("Invalid argument not used in call"sv),args[consumed_arg].template get<1>(),__jakt_format(StringView::from_string_literal("{} position{} considered for the argument, final rejection reason was: {}"sv),invalid_considered_argument_uses[consumed_arg].size(),[&]() -> ByteString { auto __jakt_enum_value = invalid_considered_argument_uses[consumed_arg].size();
+if (__jakt_enum_value == static_cast<size_t>(1ULL)) {return ByteString::from_utf8_without_validation(""sv);}else {return ByteString::from_utf8_without_validation("s"sv);} 
+}(),last_invalid_use.template get<1>()),params[last_invalid_use.template get<0>()].variable->definition_span);
 }
 }
 }
 {
-JaktInternal::ArrayIterator<JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>>> _magic = args.operator[](JaktInternal::Range<size_t>{static_cast<size_t>(consumed_arg),static_cast<size_t>(9223372036854775807LL)}).iterator();
+JaktInternal::ArrayIterator<JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>>> _magic = args[JaktInternal::Range<size_t>{static_cast<size_t>(consumed_arg),static_cast<size_t>(9223372036854775807LL)}].iterator();
 for (;;){
 JaktInternal::Optional<JaktInternal::Tuple<ByteString,Jakt::utility::Span,NonnullRefPtr<typename Jakt::parser::ParsedExpression>>> const _magic_value = _magic.next();
 if (!_magic_value.has_value()){
@@ -16513,9 +14995,9 @@ Jakt::ids::TypeId current_type_id = type_var_type_id;
 for (;;){
 current_type_id = this->generic_inferences.map(current_type_id);
 NonnullRefPtr<typename Jakt::types::Type> const type_var_type = this->get_type(current_type_id);
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp374 = type_var_type;
-if (__jakt_tmp374->__jakt_init_index() == 18 /* TypeVariable */){
-ByteString const type_name = __jakt_tmp374->as.TypeVariable.name;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp238 = type_var_type;
+if (__jakt_tmp238->__jakt_init_index() == 18 /* TypeVariable */){
+ByteString const type_name = __jakt_tmp238->as.TypeVariable.name;
 JaktInternal::Optional<Jakt::ids::TypeId> const maybe_found_type_id = TRY((this->find_type_in_scope(scope_id,type_name)));
 if (maybe_found_type_id.has_value()){
 Jakt::ids::TypeId const found_type_id = maybe_found_type_id.value();
@@ -16562,41 +15044,31 @@ ByteString Jakt::typechecker::Typechecker::get_argument_name(JaktInternal::Tuple
 if (!arg.template get<0>().is_empty()){
 return arg.template get<0>();
 }
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ByteString>{
-auto&& __jakt_match_variant = *arg.template get<2>();
+{auto&& __jakt_match_variant = *arg.template get<2>();
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* Var */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Var;ByteString const& name = __jakt_match_value.name;
 {
 return name;
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_152;};/*case end*/
 case 11 /* UnaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;NonnullRefPtr<typename Jakt::parser::ParsedExpression> const& expr = __jakt_match_value.expr;
 Jakt::parser::UnaryOperator const& op = __jakt_match_value.op;
 {
 if (((op.__jakt_init_index() == 7 /* Reference */) || (op.__jakt_init_index() == 8 /* MutableReference */)) || (op.__jakt_init_index() == 5 /* Dereference */)){
-NonnullRefPtr<typename Jakt::parser::ParsedExpression> __jakt_tmp375 = expr;
-if (__jakt_tmp375->__jakt_init_index() == 9 /* Var */){
-ByteString const name = __jakt_tmp375->as.Var.name;
+NonnullRefPtr<typename Jakt::parser::ParsedExpression> __jakt_tmp239 = expr;
+if (__jakt_tmp239->__jakt_init_index() == 9 /* Var */){
+ByteString const name = __jakt_tmp239->as.Var.name;
 return name;
 }
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_152;};/*case end*/
 default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_152;}/*switch end*/
+}goto __jakt_label_152; __jakt_label_152:;;
 return ByteString::from_utf8_without_validation(""sv);
 }
 }
@@ -16605,15 +15077,15 @@ ErrorOr<JaktInternal::DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>
 {
 Function<ErrorOr<bool>(JaktInternal::DynamicArray<Jakt::ids::TypeId>)> const generics_match = [this, &filter_for_generics, &trait_id](JaktInternal::DynamicArray<Jakt::ids::TypeId> generics) -> ErrorOr<bool> {{
 JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> const old_generic_inferences = this->generic_inferences.perform_checkpoint(false);
-ScopeGuard __jakt_var_109([&] {
+ScopeGuard __jakt_var_105([&] {
 this->generic_inferences.restore(old_generic_inferences);
 });
-JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::ids::TypeId>> __jakt_tmp376 = filter_for_generics;
-if (__jakt_tmp376.has_value()){
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const generics_to_match = __jakt_tmp376.value();
+JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::ids::TypeId>> __jakt_tmp240 = filter_for_generics;
+if (__jakt_tmp240.has_value()){
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const generics_to_match = __jakt_tmp240.value();
 if (generics.size() >= generics_to_match.size()){
 JaktInternal::Tuple<bool,bool> const snapshot = this->enter_ignore_error_mode(true);
-ScopeGuard __jakt_var_110([&] {
+ScopeGuard __jakt_var_106([&] {
 this->exit_ignore_error_mode(snapshot);
 });
 {
@@ -16625,8 +15097,8 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::ids::TypeId const generic = generics.operator[](i);
-Jakt::ids::TypeId const generic_to_match = generics_to_match.operator[](i);
+Jakt::ids::TypeId const generic = generics[i];
+Jakt::ids::TypeId const generic_to_match = generics_to_match[i];
 if (!TRY((this->check_types_for_compat(generic,generic_to_match,this->generic_inferences,Jakt::utility::Span(Jakt::utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL)))))){
 return false;
 }
@@ -16653,14 +15125,11 @@ NonnullRefPtr<typename Jakt::types::Type> type = this->get_type(type_id);
 if (type->is_builtin()){
 type = this->get_type(this->get_struct(this->program->builtin_implementation_struct(type->as_builtin_type(),this->program->prelude_module_id())).type_id);
 }
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>, ErrorOr<JaktInternal::DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>{
-auto&& __jakt_match_variant = *type;
+{auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});
-{
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});{
 Jakt::types::CheckedStruct const struct_ = this->get_struct(struct_id);
 this->generic_inferences.set_all(struct_.generic_parameters,args);
 JaktInternal::DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>> implementations = DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>::create_with({});
@@ -16699,7 +15168,7 @@ implementations.push(trait_descriptor.template get<1>());
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>>(implementations);
+return implementations;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16745,7 +15214,7 @@ implementations.push(trait_descriptor.template get<1>());
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>>(implementations);
+return implementations;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16789,7 +15258,7 @@ implementations.push(trait_descriptor.template get<1>());
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>>(implementations);
+return implementations;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16833,7 +15302,7 @@ implementations.push(trait_descriptor.template get<1>());
 }
 }
 
-return JaktInternal::ExplicitValue<JaktInternal::DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>>(implementations);
+return implementations;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16843,7 +15312,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId con
 if (id.equals(trait_id) && TRY((generics_match(DynamicArray<Jakt::ids::TypeId>::create_with({}))))){
 return DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>::create_with({DynamicArray<Jakt::ids::TypeId>::create_with({})});
 }
-return JaktInternal::ExplicitValue<JaktInternal::DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>>(DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>::create_with({}));
+return DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>::create_with({});
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16854,18 +15323,12 @@ JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.a
 if ((!id.equals(trait_id)) || (!TRY((generics_match(args))))){
 return DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>::create_with({});
 }
-return JaktInternal::ExplicitValue<JaktInternal::DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>>(DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>::create_with({args}));
+return DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>::create_with({args});
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>::create_with({}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>::create_with({});}/*switch end*/
+}
 }
 }
 
@@ -16874,7 +15337,7 @@ ErrorOr<bool> Jakt::typechecker::Typechecker::implements_trait(Jakt::ids::TypeId
 Jakt::utility::Span const empty_span = Jakt::utility::Span(Jakt::utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL));
 Function<ErrorOr<bool>(JaktInternal::DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>>, Jakt::ids::TraitId, JaktInternal::DynamicArray<Jakt::ids::TypeId>, Jakt::typechecker::Typechecker&)> const has_matching_trait = [type_id, empty_span](JaktInternal::DynamicArray<JaktInternal::DynamicArray<Jakt::ids::TypeId>> trait_implementations, Jakt::ids::TraitId trait_id, JaktInternal::DynamicArray<Jakt::ids::TypeId> passed_generic_arguments, Jakt::typechecker::Typechecker& typechecker) -> ErrorOr<bool> {{
 JaktInternal::Tuple<bool,bool> const snapshot = typechecker.enter_ignore_error_mode(true);
-ScopeGuard __jakt_var_111([&] {
+ScopeGuard __jakt_var_107([&] {
 typechecker.exit_ignore_error_mode(snapshot);
 });
 bool found = false;
@@ -16900,7 +15363,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-ok = TRY((typechecker.check_types_for_compat(implemented_generic_arguments.operator[](i),passed_generic_arguments.operator[](i),typechecker.generic_inferences,empty_span)));
+ok = TRY((typechecker.check_types_for_compat(implemented_generic_arguments[i],passed_generic_arguments[i],typechecker.generic_inferences,empty_span)));
 if (!ok){
 break;
 }
@@ -16923,29 +15386,20 @@ return found;
 }
 }
 ;
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<bool>>{
-auto&& __jakt_match_variant = this->get_trait(trait_id)->requirements;
+{auto&& __jakt_match_variant = this->get_trait(trait_id)->requirements;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* ComptimeExpression */:{
 JaktInternal::Tuple<bool,bool> const snapshot = this->enter_ignore_error_mode(true);
-ScopeGuard __jakt_var_112([&] {
+ScopeGuard __jakt_var_108([&] {
 this->exit_ignore_error_mode(snapshot);
 });
 TRY((this->check_type_argument_requirements(type_id,DynamicArray<Jakt::ids::TraitId>::create_with({trait_id}),empty_span,Jakt::ids::ScopeId(this->current_module_id,static_cast<size_t>(1ULL)))));
 return !this->had_an_error;
 }
-return JaktInternal::ExplicitValue<void>();
-default:{
+goto __jakt_label_153;default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_153;}/*switch end*/
+}goto __jakt_label_153; __jakt_label_153:;;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const empty = DynamicArray<Jakt::ids::TypeId>::create_with({});
 return has_matching_trait(TRY((this->find_all_implementations_of_trait(type_id,trait_id,JaktInternal::OptionalNone()))),trait_id,generic_arguments.value_or_lazy_evaluated([&] { return empty; }),*this);
 }
@@ -16960,34 +15414,23 @@ Jakt::ids::TypeId const mapped_b = typechecker.generic_inferences.map(b);
 if (mapped_a.equals(mapped_b)){
 return true;
 }
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, ErrorOr<bool>>{
-auto&& __jakt_match_variant = *typechecker.get_type(mapped_a);
+{auto&& __jakt_match_variant = *typechecker.get_type(mapped_a);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 26 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((typechecker.implements_trait(mapped_b,id,JaktInternal::OptionalNone()))));
-};/*case end*/
-case 30 /* Self */:return JaktInternal::ExplicitValue(TRY((typechecker.check_types_for_compat(self_type_id,mapped_b,typechecker.generic_inferences,Jakt::utility::Span(Jakt::utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL))))));
-case 22 /* GenericTraitInstance */: {
+return typechecker.implements_trait(mapped_b,id,JaktInternal::OptionalNone());};/*case end*/
+case 30 /* Self */:return typechecker.check_types_for_compat(self_type_id,mapped_b,typechecker.generic_inferences,Jakt::utility::Span(Jakt::utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL)));case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(TRY((typechecker.implements_trait(mapped_b,id,args))));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(TRY((typechecker.check_types_for_compat(mapped_a,mapped_b,typechecker.generic_inferences,Jakt::utility::Span(Jakt::utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL))))));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return typechecker.implements_trait(mapped_b,id,args);};/*case end*/
+default:return typechecker.check_types_for_compat(mapped_a,mapped_b,typechecker.generic_inferences,Jakt::utility::Span(Jakt::utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL)));}/*switch end*/
+}
 }
 }
 ;
 bool const result = TRY((this->signatures_match_impl(self_type_id,first,second,types_match)));
-JaktInternal::DynamicArray<Jakt::error::JaktError> const errors = this->compiler->errors.operator[](JaktInternal::Range<size_t>{static_cast<size_t>(starting_error_count),static_cast<size_t>(9223372036854775807LL)}).to_array();
-this->compiler->errors = this->compiler->errors.operator[](JaktInternal::Range<size_t>{static_cast<size_t>(0LL),static_cast<size_t>(starting_error_count)}).to_array();
+JaktInternal::DynamicArray<Jakt::error::JaktError> const errors = this->compiler->errors[JaktInternal::Range<size_t>{static_cast<size_t>(starting_error_count),static_cast<size_t>(9223372036854775807LL)}].to_array();
+this->compiler->errors = this->compiler->errors[JaktInternal::Range<size_t>{static_cast<size_t>(0LL),static_cast<size_t>(starting_error_count)}].to_array();
 return Tuple{result, errors};
 }
 }
@@ -17034,7 +15477,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (TRY((types_match(*this,first->params.operator[](i).variable->type_id,second->params.operator[](i).variable->type_id)))){
+if (TRY((types_match(*this,first->params[i].variable->type_id,second->params[i].variable->type_id)))){
 }
 else {
 return false;
@@ -17107,9 +15550,9 @@ this->already_implemented_for.ensure_capacity(count);
 
 void Jakt::typechecker::TraitImplCheck::register_trait(Jakt::ids::TypeId const trait_type_id,ByteString const trait_name,Jakt::types::CheckedTraitRequirements const requirements) {
 {
-Jakt::types::CheckedTraitRequirements __jakt_tmp377 = requirements;
-if (__jakt_tmp377.__jakt_init_index() == 1 /* Methods */){
-JaktInternal::Dictionary<ByteString,Jakt::ids::FunctionId> const trait_methods = __jakt_tmp377.as.Methods.value;
+Jakt::types::CheckedTraitRequirements __jakt_tmp241 = requirements;
+if (__jakt_tmp241.__jakt_init_index() == 1 /* Methods */){
+JaktInternal::Dictionary<ByteString,Jakt::ids::FunctionId> const trait_methods = __jakt_tmp241.as.Methods.value;
 this->private_matching_methods.set(trait_type_id, Dictionary<ByteString, Jakt::utility::Span>::create_with_entries({}));
 this->unmatched_signatures.set(trait_type_id, Dictionary<ByteString, JaktInternal::Tuple<Jakt::utility::Span,JaktInternal::DynamicArray<Jakt::error::JaktError>>>::create_with_entries({}));
 JaktInternal::Dictionary<ByteString,Jakt::ids::FunctionId> missing_methods = Dictionary<ByteString, Jakt::ids::FunctionId>::create_with_entries({});
@@ -17157,40 +15600,27 @@ JaktInternal::Tuple<Jakt::ids::TypeId,JaktInternal::Dictionary<ByteString,Jakt::
 Jakt::ids::TypeId const trait_type_id = jakt__trait_type_id__missing_methods__.template get<0>();
 JaktInternal::Dictionary<ByteString,Jakt::ids::FunctionId> const missing_methods = jakt__trait_type_id__missing_methods__.template get<1>();
 
-JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>> const trait_id_trait_generic_arguments_ = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>>, ErrorOr<void>>{
-auto&& __jakt_match_variant = *typechecker.get_type(trait_type_id);
+JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>> const trait_id_trait_generic_arguments_ = [&]() -> JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>> { auto&& __jakt_match_variant = *typechecker.get_type(trait_type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& trait_id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(Tuple{trait_id, args});
-};/*case end*/
+return Tuple{trait_id, args};};/*case end*/
 case 26 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& trait_id = __jakt_match_value.value;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});
-return JaktInternal::ExplicitValue(Tuple{trait_id, args});
-};/*case end*/
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});return Tuple{trait_id, args};};/*case end*/
 default:{
 Jakt::abort();
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}();
 Jakt::ids::TraitId const trait_id = trait_id_trait_generic_arguments_.template get<0>();
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const trait_generic_arguments = trait_id_trait_generic_arguments_.template get<1>();
 
 ByteString const trait_name = typechecker.get_trait(trait_id)->name;
-JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<Jakt::utility::Span,JaktInternal::DynamicArray<Jakt::error::JaktError>>> const unmatched_signatures = this->unmatched_signatures.operator[](trait_type_id);
-JaktInternal::Dictionary<ByteString,Jakt::utility::Span> const private_matching_methods = this->private_matching_methods.operator[](trait_type_id);
+JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<Jakt::utility::Span,JaktInternal::DynamicArray<Jakt::error::JaktError>>> const unmatched_signatures = this->unmatched_signatures[trait_type_id];
+JaktInternal::Dictionary<ByteString,Jakt::utility::Span> const private_matching_methods = this->private_matching_methods[trait_type_id];
 {
 JaktInternal::DictionaryIterator<ByteString,Jakt::ids::FunctionId> _magic = missing_methods.iterator();
 for (;;){
@@ -17267,40 +15697,27 @@ JaktInternal::Dictionary<ByteString,Jakt::ids::FunctionId> const methods = jakt_
 JaktInternal::Optional<Jakt::ids::FunctionId> const trait_method_id = methods.get(method_name);
 if (trait_method_id.has_value()){
 NonnullRefPtr<Jakt::types::CheckedFunction> const trait_method = typechecker.get_function(trait_method_id.value());
-JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>> const trait_id_trait_generic_arguments_ = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>>, ErrorOr<void>>{
-auto&& __jakt_match_variant = *typechecker.get_type(trait_type_id);
+JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>> const trait_id_trait_generic_arguments_ = [&]() -> JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>> { auto&& __jakt_match_variant = *typechecker.get_type(trait_type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& trait_id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(Tuple{trait_id, args});
-};/*case end*/
+return Tuple{trait_id, args};};/*case end*/
 case 26 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& trait_id = __jakt_match_value.value;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});
-return JaktInternal::ExplicitValue(Tuple{trait_id, args});
-};/*case end*/
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});return Tuple{trait_id, args};};/*case end*/
 default:{
 Jakt::abort();
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}();
 Jakt::ids::TraitId const trait_id = trait_id_trait_generic_arguments_.template get<0>();
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const trait_generic_arguments = trait_id_trait_generic_arguments_.template get<1>();
 
 NonnullRefPtr<Jakt::types::CheckedTrait> const trait_ = typechecker.get_trait(trait_id);
 JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> const old_generic_inferences = typechecker.generic_inferences.perform_checkpoint(false);
-ScopeGuard __jakt_var_113([&] {
+ScopeGuard __jakt_var_109([&] {
 typechecker.generic_inferences.restore(old_generic_inferences);
 });
 if (trait_->generic_parameters.size() == trait_generic_arguments.size()){
@@ -17311,24 +15728,24 @@ JaktInternal::DynamicArray<Jakt::error::JaktError> const errors = matches_errors
 
 if (matches){
 if (method->visibility.__jakt_init_index() == 0 /* Public */){
-this->missing_methods.operator[](trait_type_id).remove(method_name);
+this->missing_methods[trait_type_id].remove(method_name);
 this->already_implemented_for.set(method_name, Jakt::typechecker::AlreadyImplementedFor(trait_->name,method->name_span));
 break;
 }
 else {
-this->private_matching_methods.operator[](trait_type_id).set(method_name,method->name_span);
+this->private_matching_methods[trait_type_id].set(method_name,method->name_span);
 continue;
 }
 
 }
 else {
-this->unmatched_signatures.operator[](trait_type_id).set(method_name,Tuple{method->name_span, errors});
+this->unmatched_signatures[trait_type_id].set(method_name,Tuple{method->name_span, errors});
 continue;
 }
 
 }
 else {
-this->unmatched_signatures.operator[](trait_type_id).set(method_name,Tuple{method->name_span, DynamicArray<Jakt::error::JaktError>::create_with({Jakt::error::JaktError::Message(__jakt_format(StringView::from_string_literal("Expected {} generic arguments, but got {}"sv),trait_->generic_parameters.size(),trait_generic_arguments.size()),method->name_span)})});
+this->unmatched_signatures[trait_type_id].set(method_name,Tuple{method->name_span, DynamicArray<Jakt::error::JaktError>::create_with({Jakt::error::JaktError::Message(__jakt_format(StringView::from_string_literal("Expected {} generic arguments, but got {}"sv),trait_->generic_parameters.size(),trait_generic_arguments.size()),method->name_span)})});
 continue;
 }
 
@@ -17347,6 +15764,74 @@ return {};
 }
 
 Jakt::typechecker::TraitImplCheck::TraitImplCheck(JaktInternal::Dictionary<Jakt::ids::TypeId,JaktInternal::Dictionary<ByteString,Jakt::ids::FunctionId>> a_missing_methods, JaktInternal::Dictionary<Jakt::ids::TypeId,JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<Jakt::utility::Span,JaktInternal::DynamicArray<Jakt::error::JaktError>>>> a_unmatched_signatures, JaktInternal::Dictionary<Jakt::ids::TypeId,JaktInternal::Dictionary<ByteString,Jakt::utility::Span>> a_private_matching_methods, JaktInternal::Dictionary<ByteString,Jakt::typechecker::AlreadyImplementedFor> a_already_implemented_for): missing_methods(move(a_missing_methods)), unmatched_signatures(move(a_unmatched_signatures)), private_matching_methods(move(a_private_matching_methods)), already_implemented_for(move(a_already_implemented_for)){}
+
+ByteString Jakt::typechecker::CaseStartedProof::debug_description() const { auto builder = ByteStringBuilder::create();builder.append("CaseStartedProof("sv);{
+JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};
+JaktInternal::PrettyPrint::must_output_indentation(builder);
+builder.appendff("start_of_case: {}", start_of_case);
+}
+builder.append(")"sv);return builder.to_string(); }
+Jakt::typechecker::CaseStartedProof::CaseStartedProof(size_t a_start_of_case): start_of_case(move(a_start_of_case)){}
+
+ByteString Jakt::typechecker::MatchBuilder::debug_description() const { auto builder = ByteStringBuilder::create();builder.append("MatchBuilder("sv);{
+JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};
+JaktInternal::PrettyPrint::must_output_indentation(builder);
+builder.appendff("all_cases: {}, ", all_cases);
+JaktInternal::PrettyPrint::must_output_indentation(builder);
+builder.appendff("yielded_none: {}, ", yielded_none);
+JaktInternal::PrettyPrint::must_output_indentation(builder);
+builder.appendff("final_result_type: {}", final_result_type);
+}
+builder.append(")"sv);return builder.to_string(); }
+Jakt::typechecker::CaseStartedProof Jakt::typechecker::MatchBuilder::start_case() {
+{
+return Jakt::typechecker::CaseStartedProof(this->all_cases.size());
+}
+}
+
+Jakt::typechecker::BindingKeyBuilder Jakt::typechecker::MatchBuilder::start_pattern(Jakt::typechecker::CaseStartedProof const& proof) const {
+{
+return Jakt::typechecker::BindingKeyBuilder::Empty(this->all_cases[JaktInternal::Range<size_t>{static_cast<size_t>(proof.start_of_case),static_cast<size_t>(9223372036854775807LL)}]);
+}
+}
+
+Jakt::typechecker::BindingKey Jakt::typechecker::MatchBuilder::empty_binding_key(Jakt::typechecker::CaseStartedProof const& proof) const {
+{
+return Jakt::typechecker::search_empty_pattern(this->all_cases[JaktInternal::Range<size_t>{static_cast<size_t>(proof.start_of_case),static_cast<size_t>(9223372036854775807LL)}]);
+}
+}
+
+ErrorOr<void> Jakt::typechecker::MatchBuilder::register_pattern(Jakt::typechecker::CaseStartedProof const& proof,Jakt::parser::ParsedMatchBody const& body,Jakt::types::SafetyMode const safety_mode,Jakt::typechecker::BindingKey const key,Jakt::ids::ScopeId const scope_id,Jakt::types::CheckedMatchPattern const pattern,Jakt::typechecker::Typechecker& typechecker,Function<ByteString()> const& scope_debug_name) {
+{
+{auto&& __jakt_match_variant = key;
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Found */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Found;size_t const& index = __jakt_match_value.value;
+{
+size_t const case_index = JaktInternal::checked_add(index,proof.start_of_case);
+this->all_cases[case_index].patterns.push(pattern);
+}
+return {};};/*case end*/
+case 1 /* New */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.New;JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> const& built = __jakt_match_value.value;
+{
+JaktInternal::Tuple<Jakt::types::CheckedMatchBody,JaktInternal::Optional<Jakt::ids::TypeId>,bool> const body_result_type_seen_none_ = TRY((typechecker.typecheck_match_body(body,scope_id,built,scope_debug_name(),safety_mode,this->final_result_type,pattern.common.init_common.marker_span)));
+Jakt::types::CheckedMatchBody const body = body_result_type_seen_none_.template get<0>();
+JaktInternal::Optional<Jakt::ids::TypeId> const result_type = body_result_type_seen_none_.template get<1>();
+bool const seen_none = body_result_type_seen_none_.template get<2>();
+
+this->final_result_type = result_type;
+this->yielded_none |= seen_none;
+this->all_cases.push(Jakt::types::CheckedMatchCase(DynamicArray<Jakt::types::CheckedMatchPattern>::create_with({pattern}),body,built));
+}
+return {};};/*case end*/
+default: VERIFY_NOT_REACHED();}/*switch end*/
+}
+}
+return {};
+}
+
+Jakt::typechecker::MatchBuilder::MatchBuilder(JaktInternal::DynamicArray<Jakt::types::CheckedMatchCase> a_all_cases, bool a_yielded_none, JaktInternal::Optional<Jakt::ids::TypeId> a_final_result_type): all_cases(move(a_all_cases)), yielded_none(move(a_yielded_none)), final_result_type(move(a_final_result_type)){}
 
 ByteString Jakt::typechecker::FunctionMatchResult::debug_description() const {
 auto builder = ByteStringBuilder::create();
@@ -17972,5 +16457,386 @@ case 1 /* SignedNumericValue */:break;
 case 2 /* UnsignedNumericValue */:break;
 }
 }
+ByteString Jakt::typechecker::BindingKey::debug_description() const {
+auto builder = ByteStringBuilder::create();
+switch (this->__jakt_init_index()) {case 0 /* Found */: {
+builder.append("BindingKey::Found"sv);
+[[maybe_unused]] auto const& that = this->as.Found;
+builder.appendff("({})", that.value);
+break;}
+case 1 /* New */: {
+builder.append("BindingKey::New"sv);
+[[maybe_unused]] auto const& that = this->as.New;
+builder.appendff("({})", that.value);
+break;}
+}
+return builder.to_string();
+}
+[[nodiscard]] BindingKey BindingKey::Found(size_t value){
+BindingKey __jakt_uninit_enum;
+__jakt_uninit_enum.__jakt_variant_index = 1;
+new (&__jakt_uninit_enum.as.Found.value) (decltype(value))(move(value));
+return __jakt_uninit_enum;
+}
+[[nodiscard]] BindingKey BindingKey::New(JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> value){
+BindingKey __jakt_uninit_enum;
+__jakt_uninit_enum.__jakt_variant_index = 2;
+new (&__jakt_uninit_enum.as.New.value) (decltype(value))(move(value));
+return __jakt_uninit_enum;
+}
+BindingKey& BindingKey::operator=(BindingKey const &rhs){
+{VERIFY(this->__jakt_variant_index != 0 && rhs.__jakt_variant_index != 0);
+if (this->__jakt_variant_index != rhs.__jakt_variant_index) {
+this->__jakt_destroy_variant();
+switch (rhs.__jakt_init_index()) {
+case 0 /* Found */:
+new (&this->as.Found.value) (decltype(this->as.Found.value))(rhs.as.Found.value);
+break;
+case 1 /* New */:
+new (&this->as.New.value) (decltype(this->as.New.value))(rhs.as.New.value);
+break;
+}
+} else {
+switch (rhs.__jakt_init_index()) {
+case 0 /* Found */:
+this->as.Found.value = rhs.as.Found.value;
+break;
+case 1 /* New */:
+this->as.New.value = rhs.as.New.value;
+break;
+}
+}
+this->__jakt_variant_index = rhs.__jakt_variant_index;
+}
+return *this;
+}
+BindingKey::BindingKey(BindingKey const &rhs){VERIFY(rhs.__jakt_variant_index != 0);
+switch (rhs.__jakt_init_index()) {
+case 0 /* Found */:
+new (&this->as.Found.value) (decltype(this->as.Found.value))(rhs.as.Found.value);
+break;
+case 1 /* New */:
+new (&this->as.New.value) (decltype(this->as.New.value))(rhs.as.New.value);
+break;
+}
+this->__jakt_variant_index = rhs.__jakt_variant_index;
+}
+BindingKey& BindingKey::operator=(BindingKey &&rhs){
+{VERIFY(this->__jakt_variant_index != 0 && rhs.__jakt_variant_index != 0);
+if (this->__jakt_variant_index != rhs.__jakt_variant_index) {
+this->__jakt_destroy_variant();
+switch (rhs.__jakt_init_index()) {
+case 0 /* Found */:
+new (&this->as.Found.value) (decltype(this->as.Found.value))(move(rhs.as.Found.value));
+break;
+case 1 /* New */:
+new (&this->as.New.value) (decltype(this->as.New.value))(move(rhs.as.New.value));
+break;
+}
+} else {
+switch (rhs.__jakt_init_index()) {
+case 0 /* Found */:
+this->as.Found.value = move(rhs.as.Found.value);
+break;
+case 1 /* New */:
+this->as.New.value = move(rhs.as.New.value);
+break;
+}
+}
+this->__jakt_variant_index = rhs.__jakt_variant_index;
+}
+return *this;
+}
+BindingKey::BindingKey(BindingKey &&rhs){
+{VERIFY(rhs.__jakt_variant_index != 0);
+switch (rhs.__jakt_init_index()) {
+case 0 /* Found */:
+new (&this->as.Found.value) (decltype(this->as.Found.value))(move(rhs.as.Found.value));
+break;
+case 1 /* New */:
+new (&this->as.New.value) (decltype(this->as.New.value))(move(rhs.as.New.value));
+break;
+}
+this->__jakt_variant_index = rhs.__jakt_variant_index;
+}
+}
+BindingKey::~BindingKey(){ if (this->__jakt_variant_index == 0) return;
+this->__jakt_destroy_variant(); }
+void BindingKey::__jakt_destroy_variant() {
+switch (this->__jakt_init_index()) {
+case 0 /* Found */:break;
+case 1 /* New */:this->as.New.value.~Dictionary();
+break;
+}
+}
+ByteString Jakt::typechecker::BindingKeyBuilder::debug_description() const {
+auto builder = ByteStringBuilder::create();
+switch (this->__jakt_init_index()) {case 0 /* Empty */: {
+builder.append("BindingKeyBuilder::Empty"sv);
+[[maybe_unused]] auto const& that = this->as.Empty;
+builder.append("("sv);
+{
+JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};
+JaktInternal::PrettyPrint::must_output_indentation(builder);
+builder.appendff("cases: {}", that.cases);
+}
+builder.append(")"sv);
+break;}
+case 1 /* Known */: {
+builder.append("BindingKeyBuilder::Known"sv);
+[[maybe_unused]] auto const& that = this->as.Known;
+builder.append("("sv);
+{
+JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};
+JaktInternal::PrettyPrint::must_output_indentation(builder);
+builder.appendff("built: {}, ", that.built);
+JaktInternal::PrettyPrint::must_output_indentation(builder);
+builder.appendff("correct: {}, ", that.correct);
+JaktInternal::PrettyPrint::must_output_indentation(builder);
+builder.appendff("cases: {}", that.cases);
+}
+builder.append(")"sv);
+break;}
+case 2 /* New */: {
+builder.append("BindingKeyBuilder::New"sv);
+[[maybe_unused]] auto const& that = this->as.New;
+builder.append("("sv);
+{
+JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};
+JaktInternal::PrettyPrint::must_output_indentation(builder);
+builder.appendff("built: {}", that.built);
+}
+builder.append(")"sv);
+break;}
+}
+return builder.to_string();
+}
+[[nodiscard]] BindingKeyBuilder BindingKeyBuilder::Empty(JaktInternal::ArraySlice<Jakt::types::CheckedMatchCase> cases){
+BindingKeyBuilder __jakt_uninit_enum;
+__jakt_uninit_enum.__jakt_variant_index = 1;
+new (&__jakt_uninit_enum.as.Empty.cases) (decltype(cases))(move(cases));
+return __jakt_uninit_enum;
+}
+[[nodiscard]] BindingKeyBuilder BindingKeyBuilder::Known(JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> built, JaktInternal::Set<size_t> correct, JaktInternal::ArraySlice<Jakt::types::CheckedMatchCase> cases){
+BindingKeyBuilder __jakt_uninit_enum;
+__jakt_uninit_enum.__jakt_variant_index = 2;
+new (&__jakt_uninit_enum.as.Known.built) (decltype(built))(move(built));
+new (&__jakt_uninit_enum.as.Known.correct) (decltype(correct))(move(correct));
+new (&__jakt_uninit_enum.as.Known.cases) (decltype(cases))(move(cases));
+return __jakt_uninit_enum;
+}
+[[nodiscard]] BindingKeyBuilder BindingKeyBuilder::New(JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> built){
+BindingKeyBuilder __jakt_uninit_enum;
+__jakt_uninit_enum.__jakt_variant_index = 3;
+new (&__jakt_uninit_enum.as.New.built) (decltype(built))(move(built));
+return __jakt_uninit_enum;
+}
+BindingKeyBuilder& BindingKeyBuilder::operator=(BindingKeyBuilder const &rhs){
+{VERIFY(this->__jakt_variant_index != 0 && rhs.__jakt_variant_index != 0);
+if (this->__jakt_variant_index != rhs.__jakt_variant_index) {
+this->__jakt_destroy_variant();
+switch (rhs.__jakt_init_index()) {
+case 0 /* Empty */:
+new (&this->as.Empty.cases) (decltype(this->as.Empty.cases))(rhs.as.Empty.cases);
+break;
+case 1 /* Known */:
+new (&this->as.Known.built) (decltype(this->as.Known.built))(rhs.as.Known.built);
+new (&this->as.Known.correct) (decltype(this->as.Known.correct))(rhs.as.Known.correct);
+new (&this->as.Known.cases) (decltype(this->as.Known.cases))(rhs.as.Known.cases);
+break;
+case 2 /* New */:
+new (&this->as.New.built) (decltype(this->as.New.built))(rhs.as.New.built);
+break;
+}
+} else {
+switch (rhs.__jakt_init_index()) {
+case 0 /* Empty */:
+this->as.Empty.cases = rhs.as.Empty.cases;
+break;
+case 1 /* Known */:
+this->as.Known.built = rhs.as.Known.built;
+this->as.Known.correct = rhs.as.Known.correct;
+this->as.Known.cases = rhs.as.Known.cases;
+break;
+case 2 /* New */:
+this->as.New.built = rhs.as.New.built;
+break;
+}
+}
+this->__jakt_variant_index = rhs.__jakt_variant_index;
+}
+return *this;
+}
+BindingKeyBuilder::BindingKeyBuilder(BindingKeyBuilder const &rhs){VERIFY(rhs.__jakt_variant_index != 0);
+switch (rhs.__jakt_init_index()) {
+case 0 /* Empty */:
+new (&this->as.Empty.cases) (decltype(this->as.Empty.cases))(rhs.as.Empty.cases);
+break;
+case 1 /* Known */:
+new (&this->as.Known.built) (decltype(this->as.Known.built))(rhs.as.Known.built);
+new (&this->as.Known.correct) (decltype(this->as.Known.correct))(rhs.as.Known.correct);
+new (&this->as.Known.cases) (decltype(this->as.Known.cases))(rhs.as.Known.cases);
+break;
+case 2 /* New */:
+new (&this->as.New.built) (decltype(this->as.New.built))(rhs.as.New.built);
+break;
+}
+this->__jakt_variant_index = rhs.__jakt_variant_index;
+}
+BindingKeyBuilder& BindingKeyBuilder::operator=(BindingKeyBuilder &&rhs){
+{VERIFY(this->__jakt_variant_index != 0 && rhs.__jakt_variant_index != 0);
+if (this->__jakt_variant_index != rhs.__jakt_variant_index) {
+this->__jakt_destroy_variant();
+switch (rhs.__jakt_init_index()) {
+case 0 /* Empty */:
+new (&this->as.Empty.cases) (decltype(this->as.Empty.cases))(move(rhs.as.Empty.cases));
+break;
+case 1 /* Known */:
+new (&this->as.Known.built) (decltype(this->as.Known.built))(move(rhs.as.Known.built));
+new (&this->as.Known.correct) (decltype(this->as.Known.correct))(move(rhs.as.Known.correct));
+new (&this->as.Known.cases) (decltype(this->as.Known.cases))(move(rhs.as.Known.cases));
+break;
+case 2 /* New */:
+new (&this->as.New.built) (decltype(this->as.New.built))(move(rhs.as.New.built));
+break;
+}
+} else {
+switch (rhs.__jakt_init_index()) {
+case 0 /* Empty */:
+this->as.Empty.cases = move(rhs.as.Empty.cases);
+break;
+case 1 /* Known */:
+this->as.Known.built = move(rhs.as.Known.built);
+this->as.Known.correct = move(rhs.as.Known.correct);
+this->as.Known.cases = move(rhs.as.Known.cases);
+break;
+case 2 /* New */:
+this->as.New.built = move(rhs.as.New.built);
+break;
+}
+}
+this->__jakt_variant_index = rhs.__jakt_variant_index;
+}
+return *this;
+}
+BindingKeyBuilder::BindingKeyBuilder(BindingKeyBuilder &&rhs){
+{VERIFY(rhs.__jakt_variant_index != 0);
+switch (rhs.__jakt_init_index()) {
+case 0 /* Empty */:
+new (&this->as.Empty.cases) (decltype(this->as.Empty.cases))(move(rhs.as.Empty.cases));
+break;
+case 1 /* Known */:
+new (&this->as.Known.built) (decltype(this->as.Known.built))(move(rhs.as.Known.built));
+new (&this->as.Known.correct) (decltype(this->as.Known.correct))(move(rhs.as.Known.correct));
+new (&this->as.Known.cases) (decltype(this->as.Known.cases))(move(rhs.as.Known.cases));
+break;
+case 2 /* New */:
+new (&this->as.New.built) (decltype(this->as.New.built))(move(rhs.as.New.built));
+break;
+}
+this->__jakt_variant_index = rhs.__jakt_variant_index;
+}
+}
+BindingKeyBuilder::~BindingKeyBuilder(){ if (this->__jakt_variant_index == 0) return;
+this->__jakt_destroy_variant(); }
+void BindingKeyBuilder::__jakt_destroy_variant() {
+switch (this->__jakt_init_index()) {
+case 0 /* Empty */:this->as.Empty.cases.~ArraySlice();
+break;
+case 1 /* Known */:this->as.Known.built.~Dictionary();
+this->as.Known.correct.~Set();
+this->as.Known.cases.~ArraySlice();
+break;
+case 2 /* New */:this->as.New.built.~Dictionary();
+break;
+}
+}
+Jakt::typechecker::BindingKey Jakt::typechecker::BindingKeyBuilder::finish() const {
+{
+{auto&& __jakt_match_variant = *this;
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Empty */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Empty;JaktInternal::ArraySlice<Jakt::types::CheckedMatchCase> const& cases = __jakt_match_value.cases;
+return Jakt::typechecker::search_empty_pattern(cases);};/*case end*/
+case 1 /* Known */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Known;JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> const& built = __jakt_match_value.built;
+JaktInternal::Set<size_t> const& correct = __jakt_match_value.correct;
+JaktInternal::ArraySlice<Jakt::types::CheckedMatchCase> const& cases = __jakt_match_value.cases;
+{
+{
+JaktInternal::SetIterator<size_t> _magic = correct.iterator();
+for (;;){
+JaktInternal::Optional<size_t> const _magic_value = _magic.next();
+if (!_magic_value.has_value()){
+break;
+}
+size_t idx = _magic_value.value();
+{
+if (cases[idx].bindings.size() == built.size()){
+return Jakt::typechecker::BindingKey::Found(idx);
+}
+}
+
+}
+}
+
+return Jakt::typechecker::BindingKey::New(built);
+}
+VERIFY_NOT_REACHED();
+};/*case end*/
+case 2 /* New */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.New;JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> const& built = __jakt_match_value.built;
+return Jakt::typechecker::BindingKey::New(built);};/*case end*/
+default: VERIFY_NOT_REACHED();}/*switch end*/
+}
+}
+}
+
+Jakt::typechecker::BindingKeyBuilder Jakt::typechecker::BindingKeyBuilder::submit(ByteString const name,Jakt::ids::VarId const var_id,NonnullRefPtr<Jakt::types::CheckedProgram> const program) {
+{
+{auto&& __jakt_match_variant = *this;
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Empty */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Empty;JaktInternal::ArraySlice<Jakt::types::CheckedMatchCase> const& cases = __jakt_match_value.cases;
+{
+JaktInternal::Set<size_t> const correct = Jakt::typechecker::BindingKeyBuilder::build_correct_set<JaktInternal::Range<size_t>>(JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(cases.size())},name,var_id,cases,program);
+return Jakt::typechecker::BindingKeyBuilder::from_set(correct,Dictionary<ByteString, Jakt::ids::VarId>::create_with_entries({{name, var_id}}),cases);
+}
+VERIFY_NOT_REACHED();
+};/*case end*/
+case 1 /* Known */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Known;JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> const& built_ = __jakt_match_value.built;
+JaktInternal::Set<size_t> const& correct = __jakt_match_value.correct;
+JaktInternal::ArraySlice<Jakt::types::CheckedMatchCase> const& cases = __jakt_match_value.cases;
+{
+JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> built = built_;
+built.set(name, var_id);
+JaktInternal::Set<size_t> const next_correct = Jakt::typechecker::BindingKeyBuilder::build_correct_set<JaktInternal::SetIterator<size_t>>(correct.iterator(),name,var_id,cases,program);
+return Jakt::typechecker::BindingKeyBuilder::from_set(next_correct,built,cases);
+}
+VERIFY_NOT_REACHED();
+};/*case end*/
+case 2 /* New */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.New;JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> const& built_ = __jakt_match_value.built;
+{
+JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> built = built_;
+built.set(name, var_id);
+return Jakt::typechecker::BindingKeyBuilder::New(built);
+}
+VERIFY_NOT_REACHED();
+};/*case end*/
+default: VERIFY_NOT_REACHED();}/*switch end*/
+}
+}
+}
+
+Jakt::typechecker::BindingKeyBuilder Jakt::typechecker::BindingKeyBuilder::from_set(JaktInternal::Set<size_t> const correct,JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> const built,JaktInternal::ArraySlice<Jakt::types::CheckedMatchCase> const cases) {
+{
+{auto __jakt_enum_value = correct.is_empty();
+if (__jakt_enum_value) {return Jakt::typechecker::BindingKeyBuilder::New(built);}else if (!__jakt_enum_value) {return Jakt::typechecker::BindingKeyBuilder::Known(built,correct,cases);}VERIFY_NOT_REACHED();
+}
+}
+}
+
 }
 } // namespace Jakt

--- a/bootstrap/stage0/typechecker_specializations.cpp
+++ b/bootstrap/stage0/typechecker_specializations.cpp
@@ -1,0 +1,70 @@
+#include "typechecker.h"
+#include "jakt__prelude__static_array.h"
+namespace Jakt {
+namespace typechecker {
+
+/* specialisation 0 of function build_correct_set: ["JaktInternal::Range<size_t>"] */
+template<> JaktInternal::Set<size_t> Jakt::typechecker::BindingKeyBuilder::build_correct_set<JaktInternal::Range<size_t>>(JaktInternal::Range<size_t> const src,ByteString const name,Jakt::ids::VarId const var_id,JaktInternal::ArraySlice<Jakt::types::CheckedMatchCase> const cases,NonnullRefPtr<Jakt::types::CheckedProgram> const program);
+
+/* specialisation 1 of function build_correct_set: ["JaktInternal::SetIterator<size_t>"] */
+template<> JaktInternal::Set<size_t> Jakt::typechecker::BindingKeyBuilder::build_correct_set<JaktInternal::SetIterator<size_t>>(JaktInternal::SetIterator<size_t> const src,ByteString const name,Jakt::ids::VarId const var_id,JaktInternal::ArraySlice<Jakt::types::CheckedMatchCase> const cases,NonnullRefPtr<Jakt::types::CheckedProgram> const program);
+template<>
+JaktInternal::Set<size_t> Jakt::typechecker::BindingKeyBuilder::build_correct_set<JaktInternal::Range<size_t>>(JaktInternal::Range<size_t> const src,ByteString const name,Jakt::ids::VarId const var_id,JaktInternal::ArraySlice<Jakt::types::CheckedMatchCase> const cases,NonnullRefPtr<Jakt::types::CheckedProgram> const program) {
+{
+JaktInternal::Set<size_t> correct = Set<size_t>::create_with_values({});
+Jakt::ids::TypeId const wanted_type = program->get_variable(var_id)->type_id;
+{
+JaktInternal::Range<size_t> _magic = src;
+for (;;){
+JaktInternal::Optional<size_t> const _magic_value = _magic.next();
+if (!_magic_value.has_value()){
+break;
+}
+size_t idx = _magic_value.value();
+{
+JaktInternal::Optional<Jakt::ids::VarId> __jakt_tmp242 = cases[idx].bindings.get(name);
+if (__jakt_tmp242.has_value()){
+Jakt::ids::VarId const var = __jakt_tmp242.value();
+if (program->get_variable(var)->type_id.equals(wanted_type)){
+correct.add(idx);
+}
+}
+}
+
+}
+}
+
+return correct;
+}
+}
+template<>
+JaktInternal::Set<size_t> Jakt::typechecker::BindingKeyBuilder::build_correct_set<JaktInternal::SetIterator<size_t>>(JaktInternal::SetIterator<size_t> const src,ByteString const name,Jakt::ids::VarId const var_id,JaktInternal::ArraySlice<Jakt::types::CheckedMatchCase> const cases,NonnullRefPtr<Jakt::types::CheckedProgram> const program) {
+{
+JaktInternal::Set<size_t> correct = Set<size_t>::create_with_values({});
+Jakt::ids::TypeId const wanted_type = program->get_variable(var_id)->type_id;
+{
+JaktInternal::SetIterator<size_t> _magic = src;
+for (;;){
+JaktInternal::Optional<size_t> const _magic_value = _magic.next();
+if (!_magic_value.has_value()){
+break;
+}
+size_t idx = _magic_value.value();
+{
+JaktInternal::Optional<Jakt::ids::VarId> __jakt_tmp243 = cases[idx].bindings.get(name);
+if (__jakt_tmp243.has_value()){
+Jakt::ids::VarId const var = __jakt_tmp243.value();
+if (program->get_variable(var)->type_id.equals(wanted_type)){
+correct.add(idx);
+}
+}
+}
+
+}
+}
+
+return correct;
+}
+}
+}
+} // namespace Jakt

--- a/bootstrap/stage0/types.cpp
+++ b/bootstrap/stage0/types.cpp
@@ -30,76 +30,57 @@ return Jakt::ids::TypeId(Jakt::ids::ModuleId(static_cast<size_t>(0ULL)),builtin.
 
 ErrorOr<ByteString> format_value_impl(ByteString const format_string,Jakt::types::Value const value,NonnullRefPtr<Jakt::types::CheckedProgram> const& program) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = *value.impl;
+{auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Bool */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Bool;bool const& v = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(ByteString::formatted(format_string,v));
-};/*case end*/
+return ByteString::formatted(format_string,v);};/*case end*/
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& v = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(ByteString::formatted(format_string,v));
-};/*case end*/
+return ByteString::formatted(format_string,v);};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& v = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(ByteString::formatted(format_string,v));
-};/*case end*/
+return ByteString::formatted(format_string,v);};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& v = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(ByteString::formatted(format_string,v));
-};/*case end*/
+return ByteString::formatted(format_string,v);};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& v = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(ByteString::formatted(format_string,v));
-};/*case end*/
+return ByteString::formatted(format_string,v);};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& v = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(ByteString::formatted(format_string,v));
-};/*case end*/
+return ByteString::formatted(format_string,v);};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& v = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(ByteString::formatted(format_string,v));
-};/*case end*/
+return ByteString::formatted(format_string,v);};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& v = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(ByteString::formatted(format_string,v));
-};/*case end*/
+return ByteString::formatted(format_string,v);};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& v = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(ByteString::formatted(format_string,v));
-};/*case end*/
+return ByteString::formatted(format_string,v);};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& v = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(ByteString::formatted(format_string,v));
-};/*case end*/
+return ByteString::formatted(format_string,v);};/*case end*/
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& v = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(ByteString::formatted(format_string,v));
-};/*case end*/
+return ByteString::formatted(format_string,v);};/*case end*/
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& v = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(ByteString::formatted(format_string,v));
-};/*case end*/
+return ByteString::formatted(format_string,v);};/*case end*/
 case 15 /* CChar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CChar;char const& v = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(ByteString::formatted(format_string,v));
-};/*case end*/
+return ByteString::formatted(format_string,v);};/*case end*/
 case 16 /* CInt */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CInt;int const& v = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(ByteString::formatted(format_string,v));
-};/*case end*/
+return ByteString::formatted(format_string,v);};/*case end*/
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& v = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(ByteString::formatted(format_string,v));
-};/*case end*/
+return ByteString::formatted(format_string,v);};/*case end*/
 case 14 /* StringView */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StringView;ByteString const& v = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(ByteString::formatted(format_string,v));
-};/*case end*/
-case 0 /* Void */:return JaktInternal::ExplicitValue(ByteString::formatted(format_string,ByteString::from_utf8_without_validation("(void)"sv)));
-case 17 /* Struct */: {
+return ByteString::formatted(format_string,v);};/*case end*/
+case 0 /* Void */:return ByteString::formatted(format_string,ByteString::from_utf8_without_validation("(void)"sv));case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
 Jakt::ids::StructId const& struct_id = __jakt_match_value.struct_id;
 JaktInternal::Optional<Jakt::ids::FunctionId> const& constructor = __jakt_match_value.constructor;
@@ -160,7 +141,7 @@ Jakt::types::Value field = _magic_value.value();
 if (index > static_cast<size_t>(0ULL)){
 builder.append(StringView::from_string_literal(", "sv));
 }
-builder.append(field_names.operator[](index));
+builder.append(field_names[index]);
 builder.append(StringView::from_string_literal(": "sv));
 builder.append(TRY((Jakt::types::format_value_impl(format_string,field,program))));
 index += static_cast<size_t>(1ULL);
@@ -170,7 +151,7 @@ index += static_cast<size_t>(1ULL);
 }
 
 builder.append_code_point(static_cast<u32>(U')'));
-return JaktInternal::ExplicitValue<ByteString>(builder.to_string());
+return builder.to_string();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -235,7 +216,7 @@ Jakt::types::Value field = _magic_value.value();
 if (index > static_cast<size_t>(0ULL)){
 builder.append(StringView::from_string_literal(", "sv));
 }
-builder.append(field_names.operator[](index));
+builder.append(field_names[index]);
 builder.append(StringView::from_string_literal(": "sv));
 builder.append(TRY((Jakt::types::format_value_impl(format_string,field,program))));
 index += static_cast<size_t>(1ULL);
@@ -245,7 +226,7 @@ index += static_cast<size_t>(1ULL);
 }
 
 builder.append_code_point(static_cast<u32>(U')'));
-return JaktInternal::ExplicitValue<ByteString>(builder.to_string());
+return builder.to_string();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -290,7 +271,7 @@ Jakt::types::Value field = _magic_value.value();
 if (index > static_cast<size_t>(0ULL)){
 builder.append(StringView::from_string_literal(", "sv));
 }
-builder.append(field_names.operator[](index));
+builder.append(field_names[index]);
 builder.append(StringView::from_string_literal(": "sv));
 builder.append(TRY((Jakt::types::format_value_impl(format_string,field,program))));
 index += static_cast<size_t>(1ULL);
@@ -300,36 +281,25 @@ index += static_cast<size_t>(1ULL);
 }
 
 builder.append_code_point(static_cast<u32>(U')'));
-return JaktInternal::ExplicitValue<ByteString>(builder.to_string());
+return builder.to_string();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 24 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((Jakt::types::format_value_impl(__jakt_format(StringView::from_string_literal("Some({})"sv),format_string),value,program))));
-};/*case end*/
-case 25 /* OptionalNone */:return JaktInternal::ExplicitValue(ByteString::formatted(format_string,ByteString::from_utf8_without_validation("None"sv)));
-case 26 /* JaktTuple */: {
+return Jakt::types::format_value_impl(__jakt_format(StringView::from_string_literal("Some({})"sv),format_string),value,program);};/*case end*/
+case 25 /* OptionalNone */:return ByteString::formatted(format_string,ByteString::from_utf8_without_validation("None"sv));case 26 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
 {
 ByteStringBuilder builder = ByteStringBuilder::create();
-JaktInternal::Tuple<u32,u32> const surrounding = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<u32,u32>, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = *value.impl;
+JaktInternal::Tuple<u32,u32> const surrounding = [&]() -> JaktInternal::Tuple<u32,u32> { auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 26 /* JaktTuple */:return JaktInternal::ExplicitValue(Tuple{static_cast<u32>(U'('), static_cast<u32>(U')')});
-case 20 /* JaktArray */:return JaktInternal::ExplicitValue(Tuple{static_cast<u32>(U'['), static_cast<u32>(U']')});
-case 22 /* JaktSet */:return JaktInternal::ExplicitValue(Tuple{static_cast<u32>(U'{'), static_cast<u32>(U'}')});
-default:{
+case 26 /* JaktTuple */:return Tuple{static_cast<u32>(U'('), static_cast<u32>(U')')};case 20 /* JaktArray */:return Tuple{static_cast<u32>(U'['), static_cast<u32>(U']')};case 22 /* JaktSet */:return Tuple{static_cast<u32>(U'{'), static_cast<u32>(U'}')};default:{
 Jakt::abort();
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 builder.append_code_point(surrounding.template get<0>());
 size_t index = static_cast<size_t>(0ULL);
 {
@@ -352,7 +322,7 @@ index += static_cast<size_t>(1ULL);
 }
 
 builder.append_code_point(surrounding.template get<1>());
-return JaktInternal::ExplicitValue<ByteString>(builder.to_string());
+return builder.to_string();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -360,23 +330,14 @@ case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.values;
 {
 ByteStringBuilder builder = ByteStringBuilder::create();
-JaktInternal::Tuple<u32,u32> const surrounding = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<u32,u32>, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = *value.impl;
+JaktInternal::Tuple<u32,u32> const surrounding = [&]() -> JaktInternal::Tuple<u32,u32> { auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 26 /* JaktTuple */:return JaktInternal::ExplicitValue(Tuple{static_cast<u32>(U'('), static_cast<u32>(U')')});
-case 20 /* JaktArray */:return JaktInternal::ExplicitValue(Tuple{static_cast<u32>(U'['), static_cast<u32>(U']')});
-case 22 /* JaktSet */:return JaktInternal::ExplicitValue(Tuple{static_cast<u32>(U'{'), static_cast<u32>(U'}')});
-default:{
+case 26 /* JaktTuple */:return Tuple{static_cast<u32>(U'('), static_cast<u32>(U')')};case 20 /* JaktArray */:return Tuple{static_cast<u32>(U'['), static_cast<u32>(U']')};case 22 /* JaktSet */:return Tuple{static_cast<u32>(U'{'), static_cast<u32>(U'}')};default:{
 Jakt::abort();
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 builder.append_code_point(surrounding.template get<0>());
 size_t index = static_cast<size_t>(0ULL);
 {
@@ -399,7 +360,7 @@ index += static_cast<size_t>(1ULL);
 }
 
 builder.append_code_point(surrounding.template get<1>());
-return JaktInternal::ExplicitValue<ByteString>(builder.to_string());
+return builder.to_string();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -407,23 +368,14 @@ case 22 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.values;
 {
 ByteStringBuilder builder = ByteStringBuilder::create();
-JaktInternal::Tuple<u32,u32> const surrounding = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<u32,u32>, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = *value.impl;
+JaktInternal::Tuple<u32,u32> const surrounding = [&]() -> JaktInternal::Tuple<u32,u32> { auto&& __jakt_match_variant = *value.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 26 /* JaktTuple */:return JaktInternal::ExplicitValue(Tuple{static_cast<u32>(U'('), static_cast<u32>(U')')});
-case 20 /* JaktArray */:return JaktInternal::ExplicitValue(Tuple{static_cast<u32>(U'['), static_cast<u32>(U']')});
-case 22 /* JaktSet */:return JaktInternal::ExplicitValue(Tuple{static_cast<u32>(U'{'), static_cast<u32>(U'}')});
-default:{
+case 26 /* JaktTuple */:return Tuple{static_cast<u32>(U'('), static_cast<u32>(U')')};case 20 /* JaktArray */:return Tuple{static_cast<u32>(U'['), static_cast<u32>(U']')};case 22 /* JaktSet */:return Tuple{static_cast<u32>(U'{'), static_cast<u32>(U'}')};default:{
 Jakt::abort();
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 builder.append_code_point(surrounding.template get<0>());
 size_t index = static_cast<size_t>(0ULL);
 {
@@ -446,7 +398,7 @@ index += static_cast<size_t>(1ULL);
 }
 
 builder.append_code_point(surrounding.template get<1>());
-return JaktInternal::ExplicitValue<ByteString>(builder.to_string());
+return builder.to_string();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -471,7 +423,7 @@ builder.append(StringView::from_string_literal(", "sv));
 }
 builder.append(TRY((Jakt::types::format_value_impl(format_string,key,program))));
 builder.append(StringView::from_string_literal(": "sv));
-builder.append(TRY((Jakt::types::format_value_impl(format_string,values.operator[](index),program))));
+builder.append(TRY((Jakt::types::format_value_impl(format_string,values[index],program))));
 index += static_cast<size_t>(1ULL);
 }
 
@@ -479,7 +431,7 @@ index += static_cast<size_t>(1ULL);
 }
 
 builder.append_code_point(static_cast<u32>(U']'));
-return JaktInternal::ExplicitValue<ByteString>(builder.to_string());
+return builder.to_string();
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -488,12 +440,7 @@ warnln(StringView::from_string_literal("Cannot format value {}"sv),value.impl);
 return Error::__jakt_from_string_literal(StringView::from_string_literal("Cannot format value of this type"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -549,9 +496,7 @@ break;
 }
 u32 code_point = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (code_point);
+{auto __jakt_enum_value = code_point;
 if (__jakt_enum_value == static_cast<u32>(U'{')) {{
 if (index_in_field.has_value() && (index_in_field.value() == static_cast<size_t>(0ULL))){
 builder.append_code_point(static_cast<u32>(U'{'));
@@ -566,8 +511,7 @@ index_in_field = static_cast<size_t>(0ULL);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == static_cast<u32>(U'}')) {{
+goto __jakt_label_66;}else if (__jakt_enum_value == static_cast<u32>(U'}')) {{
 if (expect_close_brace){
 builder.append_code_point(static_cast<u32>(U'}'));
 expect_close_brace = false;
@@ -588,12 +532,11 @@ if (effective_index >= arguments.size()){
 return Error::__jakt_from_string_literal(StringView::from_string_literal("Not enough arguments for format string"sv));
 }
 ByteString const effective_format_string = __jakt_format(StringView::from_string_literal("{{{}}}"sv),format_string);
-builder.append(TRY((Jakt::types::format_value_impl(effective_format_string,arguments.operator[](effective_index),program))));
+builder.append(TRY((Jakt::types::format_value_impl(effective_format_string,arguments[effective_index],program))));
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_66;}else {{
 if (index_in_field.has_value()){
 format_field_builder.append_code_point(code_point);
 }
@@ -602,17 +545,7 @@ builder.append_code_point(code_point);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_66;}}goto __jakt_label_66; __jakt_label_66:;;
 }
 
 }
@@ -655,8 +588,8 @@ size_t i = _magic_value.value();
 if (i >= values.size()){
 break;
 }
-Jakt::ids::TypeId const key = keys.operator[](i).type_id;
-Jakt::ids::TypeId const value = values.operator[](i);
+Jakt::ids::TypeId const key = keys[i].type_id;
+Jakt::ids::TypeId const value = values[i];
 this->set(key,value);
 }
 
@@ -727,9 +660,9 @@ JaktInternal::Tuple<Jakt::ids::TypeId,Jakt::ids::TypeId> const jakt__type_id__v_
 Jakt::ids::TypeId const type_id = jakt__type_id__v__.template get<0>();
 Jakt::ids::TypeId const v = jakt__type_id__v__.template get<1>();
 
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp44 = program->get_type(type_id);
-if (__jakt_tmp44->__jakt_init_index() == 18 /* TypeVariable */){
-ByteString const var_name = __jakt_tmp44->as.TypeVariable.name;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp43 = program->get_type(type_id);
+if (__jakt_tmp43->__jakt_init_index() == 18 /* TypeVariable */){
+ByteString const var_name = __jakt_tmp43->as.TypeVariable.name;
 if (var_name == name){
 return this->map(v);
 }
@@ -1223,8 +1156,8 @@ break;
 }
 size_t param_index = _magic_value.value();
 {
-Jakt::types::CheckedParameter const lhs_param = this->params.operator[](param_index);
-Jakt::types::CheckedParameter const rhs_param = other->params.operator[](param_index);
+Jakt::types::CheckedParameter const lhs_param = this->params[param_index];
+Jakt::types::CheckedParameter const rhs_param = other->params[param_index];
 Jakt::ids::TypeId const lhs_param_id = lhs_param.variable->type_id;
 Jakt::ids::TypeId const rhs_param_id = rhs_param.variable->type_id;
 if ((!lhs_param.variable->type_id.equals(rhs_param.variable->type_id)) && (!(lhs_generic_type_ids.contains(lhs_param_id) && rhs_generic_type_ids.contains(rhs_param_id)))){
@@ -1248,7 +1181,7 @@ return [](ByteString const& self, ByteString rhs) -> bool {{
 return !(self == rhs);
 }
 }
-(this->params.operator[](static_cast<i64>(0LL)).variable->name,ByteString::from_utf8_without_validation("this"sv));
+(this->params[static_cast<i64>(0LL)].variable->name,ByteString::from_utf8_without_validation("this"sv));
 }
 }
 
@@ -1257,7 +1190,7 @@ bool Jakt::types::CheckedFunction::is_mutating() const {
 if (this->params.size() < static_cast<size_t>(1ULL)){
 return false;
 }
-NonnullRefPtr<Jakt::types::CheckedVariable> const first_param_variable = this->params.operator[](static_cast<i64>(0LL)).variable;
+NonnullRefPtr<Jakt::types::CheckedVariable> const first_param_variable = this->params[static_cast<i64>(0LL)].variable;
 return (first_param_variable->name == ByteString::from_utf8_without_validation("this"sv)) && first_param_variable->is_mutable;
 }
 }
@@ -1330,7 +1263,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (!types.operator[](i).equals(specialization.operator[](i))){
+if (!types[i].equals(specialization[i])){
 matched = false;
 break;
 }
@@ -1621,10 +1554,12 @@ JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};
 JaktInternal::PrettyPrint::must_output_indentation(builder);
 builder.appendff("patterns: {}, ", patterns);
 JaktInternal::PrettyPrint::must_output_indentation(builder);
-builder.appendff("body: {}", body);
+builder.appendff("body: {}, ", body);
+JaktInternal::PrettyPrint::must_output_indentation(builder);
+builder.appendff("bindings: {}", bindings);
 }
 builder.append(")"sv);return builder.to_string(); }
-Jakt::types::CheckedMatchCase::CheckedMatchCase(JaktInternal::DynamicArray<Jakt::types::CheckedMatchPattern> a_patterns, Jakt::types::CheckedMatchBody a_body): patterns(move(a_patterns)), body(move(a_body)){}
+Jakt::types::CheckedMatchCase::CheckedMatchCase(JaktInternal::DynamicArray<Jakt::types::CheckedMatchPattern> a_patterns, Jakt::types::CheckedMatchBody a_body, JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> a_bindings): patterns(move(a_patterns)), body(move(a_body)), bindings(move(a_bindings)){}
 
 ByteString Jakt::types::OperatorTraitImplementation::debug_description() const { auto builder = ByteStringBuilder::create();builder.append("OperatorTraitImplementation("sv);{
 JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};
@@ -1745,15 +1680,15 @@ if (parent_scope_id.has_value()){
 if (parent_scope_id.value().module_id.id >= this->modules.size()){
 this->compiler->panic(__jakt_format(StringView::from_string_literal("create_scope: parent_scope_id.module is invalid! No module with id {}."sv),parent_scope_id.value().module_id.id));
 }
-if (parent_scope_id.value().id >= this->modules.operator[](parent_scope_id.value().module_id.id)->scopes.size()){
+if (parent_scope_id.value().id >= this->modules[parent_scope_id.value().module_id.id]->scopes.size()){
 this->compiler->panic(__jakt_format(StringView::from_string_literal("create_scope: parent_scope_id.id is invalid! Module {} does not have a scope with id {}."sv),parent_scope_id.value().module_id.id,parent_scope_id.value().id));
 }
 NonnullRefPtr<Jakt::types::Scope> const scope = this->get_scope(parent_scope_id.value());
 is_from_generated_code = scope->is_from_generated_code;
 }
 NonnullRefPtr<Jakt::types::Scope> const scope = Jakt::types::Scope::__jakt_create(parent_scope_id,can_throw,debug_name,for_block,is_from_generated_code,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),Dictionary<ByteString, Jakt::ids::VarId>::create_with_entries({}),Dictionary<ByteString, Jakt::types::Value>::create_with_entries({}),Dictionary<ByteString, Jakt::ids::StructId>::create_with_entries({}),Dictionary<ByteString, JaktInternal::DynamicArray<Jakt::ids::FunctionId>>::create_with_entries({}),Dictionary<ByteString, Jakt::ids::EnumId>::create_with_entries({}),Dictionary<ByteString, Jakt::ids::TypeId>::create_with_entries({}),Dictionary<ByteString, Jakt::ids::TraitId>::create_with_entries({}),Dictionary<ByteString, Jakt::ids::ModuleId>::create_with_entries({}),Dictionary<ByteString, Jakt::ids::ScopeId>::create_with_entries({}),JaktInternal::OptionalNone(),DynamicArray<Jakt::ids::ScopeId>::create_with({}),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),DynamicArray<Jakt::parser::IncludeAction>::create_with({}),DynamicArray<Jakt::parser::IncludeAction>::create_with({}),DynamicArray<Jakt::types::ResolutionMixin>::create_with({}),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),Dictionary<ByteString, Jakt::types::SpecializedType>::create_with_entries({}));
-this->modules.operator[](module_id.id)->scopes.push(scope);
-return Jakt::ids::ScopeId(module_id,JaktInternal::checked_sub(this->modules.operator[](module_id.id)->scopes.size(),static_cast<size_t>(1ULL)));
+this->modules[module_id.id]->scopes.push(scope);
+return Jakt::ids::ScopeId(module_id,JaktInternal::checked_sub(this->modules[module_id.id]->scopes.size(),static_cast<size_t>(1ULL)));
 }
 }
 
@@ -1765,98 +1700,60 @@ return !self.equals(rhs);
 }
 }
 (qualifiers,type->common.init_common.qualifiers)){
-return this->find_or_add_type_id(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::Type>, Jakt::ids::TypeId>{
-auto&& __jakt_match_variant = *type;
+return this->find_or_add_type_id([&]() -> NonnullRefPtr<typename Jakt::types::Type> { auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Void */:return JaktInternal::ExplicitValue(Jakt::types::Type::Void(qualifiers));
-case 1 /* Bool */:return JaktInternal::ExplicitValue(Jakt::types::Type::Bool(qualifiers));
-case 2 /* U8 */:return JaktInternal::ExplicitValue(Jakt::types::Type::U8(qualifiers));
-case 3 /* U16 */:return JaktInternal::ExplicitValue(Jakt::types::Type::U16(qualifiers));
-case 4 /* U32 */:return JaktInternal::ExplicitValue(Jakt::types::Type::U32(qualifiers));
-case 5 /* U64 */:return JaktInternal::ExplicitValue(Jakt::types::Type::U64(qualifiers));
-case 6 /* I8 */:return JaktInternal::ExplicitValue(Jakt::types::Type::I8(qualifiers));
-case 7 /* I16 */:return JaktInternal::ExplicitValue(Jakt::types::Type::I16(qualifiers));
-case 8 /* I32 */:return JaktInternal::ExplicitValue(Jakt::types::Type::I32(qualifiers));
-case 9 /* I64 */:return JaktInternal::ExplicitValue(Jakt::types::Type::I64(qualifiers));
-case 10 /* F32 */:return JaktInternal::ExplicitValue(Jakt::types::Type::F32(qualifiers));
-case 11 /* F64 */:return JaktInternal::ExplicitValue(Jakt::types::Type::F64(qualifiers));
-case 12 /* Usize */:return JaktInternal::ExplicitValue(Jakt::types::Type::Usize(qualifiers));
-case 13 /* JaktString */:return JaktInternal::ExplicitValue(Jakt::types::Type::JaktString(qualifiers));
-case 14 /* CChar */:return JaktInternal::ExplicitValue(Jakt::types::Type::CChar(qualifiers));
-case 15 /* CInt */:return JaktInternal::ExplicitValue(Jakt::types::Type::CInt(qualifiers));
-case 16 /* Unknown */:return JaktInternal::ExplicitValue(Jakt::types::Type::Unknown(Jakt::parser::CheckedQualifiers(false)));
-case 17 /* Never */:return JaktInternal::ExplicitValue(Jakt::types::Type::Never(Jakt::parser::CheckedQualifiers(false)));
-case 18 /* TypeVariable */: {
+case 0 /* Void */:return Jakt::types::Type::Void(qualifiers);case 1 /* Bool */:return Jakt::types::Type::Bool(qualifiers);case 2 /* U8 */:return Jakt::types::Type::U8(qualifiers);case 3 /* U16 */:return Jakt::types::Type::U16(qualifiers);case 4 /* U32 */:return Jakt::types::Type::U32(qualifiers);case 5 /* U64 */:return Jakt::types::Type::U64(qualifiers);case 6 /* I8 */:return Jakt::types::Type::I8(qualifiers);case 7 /* I16 */:return Jakt::types::Type::I16(qualifiers);case 8 /* I32 */:return Jakt::types::Type::I32(qualifiers);case 9 /* I64 */:return Jakt::types::Type::I64(qualifiers);case 10 /* F32 */:return Jakt::types::Type::F32(qualifiers);case 11 /* F64 */:return Jakt::types::Type::F64(qualifiers);case 12 /* Usize */:return Jakt::types::Type::Usize(qualifiers);case 13 /* JaktString */:return Jakt::types::Type::JaktString(qualifiers);case 14 /* CChar */:return Jakt::types::Type::CChar(qualifiers);case 15 /* CInt */:return Jakt::types::Type::CInt(qualifiers);case 16 /* Unknown */:return Jakt::types::Type::Unknown(Jakt::parser::CheckedQualifiers(false));case 17 /* Never */:return Jakt::types::Type::Never(Jakt::parser::CheckedQualifiers(false));case 18 /* TypeVariable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeVariable;ByteString const& name = __jakt_match_value.name;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& trait_implementations = __jakt_match_value.trait_implementations;
 bool const& is_value = __jakt_match_value.is_value;
-return JaktInternal::ExplicitValue(Jakt::types::Type::TypeVariable(qualifiers,name,trait_implementations,is_value));
-};/*case end*/
+return Jakt::types::Type::TypeVariable(qualifiers,name,trait_implementations,is_value);};/*case end*/
 case 19 /* Dependent */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dependent;Jakt::ids::TypeId const& namespace_type = __jakt_match_value.namespace_type;
 ByteString const& name = __jakt_match_value.name;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(Jakt::types::Type::Dependent(qualifiers,namespace_type,name,args));
-};/*case end*/
+return Jakt::types::Type::Dependent(qualifiers,namespace_type,name,args);};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(Jakt::types::Type::GenericInstance(qualifiers,id,args));
-};/*case end*/
+return Jakt::types::Type::GenericInstance(qualifiers,id,args);};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(Jakt::types::Type::GenericEnumInstance(qualifiers,id,args));
-};/*case end*/
+return Jakt::types::Type::GenericEnumInstance(qualifiers,id,args);};/*case end*/
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(Jakt::types::Type::GenericTraitInstance(qualifiers,id,args));
-};/*case end*/
+return Jakt::types::Type::GenericTraitInstance(qualifiers,id,args);};/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Type::Struct(qualifiers,id));
-};/*case end*/
+return Jakt::types::Type::Struct(qualifiers,id);};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Type::Enum(qualifiers,id));
-};/*case end*/
+return Jakt::types::Type::Enum(qualifiers,id);};/*case end*/
 case 25 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;Jakt::ids::TypeId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Type::RawPtr(qualifiers,id));
-};/*case end*/
+return Jakt::types::Type::RawPtr(qualifiers,id);};/*case end*/
 case 26 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Type::Trait(qualifiers,id));
-};/*case end*/
+return Jakt::types::Type::Trait(qualifiers,id);};/*case end*/
 case 27 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;Jakt::ids::TypeId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Type::Reference(qualifiers,id));
-};/*case end*/
+return Jakt::types::Type::Reference(qualifiers,id);};/*case end*/
 case 28 /* MutableReference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MutableReference;Jakt::ids::TypeId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Type::MutableReference(qualifiers,id));
-};/*case end*/
+return Jakt::types::Type::MutableReference(qualifiers,id);};/*case end*/
 case 29 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& params = __jakt_match_value.params;
 bool const& can_throw = __jakt_match_value.can_throw;
 Jakt::ids::TypeId const& return_type_id = __jakt_match_value.return_type_id;
 Jakt::ids::FunctionId const& pseudo_function_id = __jakt_match_value.pseudo_function_id;
-return JaktInternal::ExplicitValue(Jakt::types::Type::Function(qualifiers,params,can_throw,return_type_id,pseudo_function_id));
-};/*case end*/
-case 30 /* Self */:return JaktInternal::ExplicitValue(Jakt::types::Type::Self(qualifiers));
-case 31 /* Const */: {
+return Jakt::types::Type::Function(qualifiers,params,can_throw,return_type_id,pseudo_function_id);};/*case end*/
+case 30 /* Self */:return Jakt::types::Type::Self(qualifiers);case 31 /* Const */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Const;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::Type::Const(qualifiers,value));
-};/*case end*/
+return Jakt::types::Type::Const(qualifiers,value);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),type_id.module,true);
+ 
+}(),type_id.module,true);
 }
 else {
 return type_id;
@@ -1868,9 +1765,9 @@ return type_id;
 Jakt::ids::StructId Jakt::types::CheckedProgram::builtin_implementation_struct(Jakt::types::BuiltinType const builtin,Jakt::ids::ModuleId const for_module) {
 {
 size_t const id = builtin.id();
-NonnullRefPtr<Jakt::types::Module> module = this->modules.operator[](for_module.id);
+NonnullRefPtr<Jakt::types::Module> module = this->modules[for_module.id];
 if (module->builtin_implementation_structs.contains(id)){
-return module->builtin_implementation_structs.operator[](id);
+return module->builtin_implementation_structs[id];
 }
 Jakt::ids::ScopeId const scope_id = this->create_scope(JaktInternal::OptionalNone(),false,__jakt_format(StringView::from_string_literal("builtin({})"sv),builtin.constructor_name()),for_module,false);
 JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>> const trait_implementations = Dictionary<ByteString, JaktInternal::DynamicArray<JaktInternal::Tuple<Jakt::ids::TraitId,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>::create_with_entries({});
@@ -1886,49 +1783,49 @@ return struct_id;
 
 NonnullRefPtr<Jakt::types::Module> Jakt::types::CheckedProgram::get_module(Jakt::ids::ModuleId const id) const {
 {
-return this->modules.operator[](id.id);
+return this->modules[id.id];
 }
 }
 
 NonnullRefPtr<Jakt::types::CheckedFunction> Jakt::types::CheckedProgram::get_function(Jakt::ids::FunctionId const id) const {
 {
-return this->modules.operator[](id.module.id)->functions.operator[](id.id);
+return this->modules[id.module.id]->functions[id.id];
 }
 }
 
 NonnullRefPtr<Jakt::types::CheckedVariable> Jakt::types::CheckedProgram::get_variable(Jakt::ids::VarId const id) const {
 {
-return this->modules.operator[](id.module.id)->variables.operator[](id.id);
+return this->modules[id.module.id]->variables[id.id];
 }
 }
 
 NonnullRefPtr<typename Jakt::types::Type> Jakt::types::CheckedProgram::get_type(Jakt::ids::TypeId const id) const {
 {
-return this->modules.operator[](id.module.id)->types.operator[](id.id);
+return this->modules[id.module.id]->types[id.id];
 }
 }
 
 Jakt::types::CheckedEnum Jakt::types::CheckedProgram::get_enum(Jakt::ids::EnumId const id) const {
 {
-return this->modules.operator[](id.module.id)->enums.operator[](id.id);
+return this->modules[id.module.id]->enums[id.id];
 }
 }
 
 Jakt::types::CheckedStruct Jakt::types::CheckedProgram::get_struct(Jakt::ids::StructId const id) const {
 {
-return this->modules.operator[](id.module.id)->structures.operator[](id.id);
+return this->modules[id.module.id]->structures[id.id];
 }
 }
 
 NonnullRefPtr<Jakt::types::Scope> Jakt::types::CheckedProgram::get_scope(Jakt::ids::ScopeId const id) const {
 {
-return this->modules.operator[](id.module_id.id)->scopes.operator[](id.id);
+return this->modules[id.module_id.id]->scopes[id.id];
 }
 }
 
 NonnullRefPtr<Jakt::types::CheckedTrait> Jakt::types::CheckedProgram::get_trait(Jakt::ids::TraitId const id) const {
 {
-return this->modules.operator[](id.module.id)->traits.operator[](id.id);
+return this->modules[id.module.id]->traits[id.id];
 }
 }
 
@@ -1971,21 +1868,19 @@ NonnullRefPtr<Jakt::types::CheckedFunction> function = this->get_function(overlo
 if (!function->owner_scope.has_value()){
 function->owner_scope = parent_scope_id;
 NonnullRefPtr<Jakt::types::Scope> const scope = this->get_scope(parent_scope_id);
-JaktInternal::Optional<Jakt::ids::TypeId> __jakt_tmp61 = scope->relevant_type_id;
-if (__jakt_tmp61.has_value()){
-Jakt::ids::TypeId const type_id = __jakt_tmp61.value();
+JaktInternal::Optional<Jakt::ids::TypeId> __jakt_tmp60 = scope->relevant_type_id;
+if (__jakt_tmp60.has_value()){
+Jakt::ids::TypeId const type_id = __jakt_tmp60.value();
 JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>> const no_defaults = JaktInternal::OptionalNone();
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const no_args = DynamicArray<Jakt::ids::TypeId>::create_with({});
-JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>> const maybe_generics = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>, void>{
-auto&& __jakt_match_variant = *this->get_type(type_id);
+JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>> const maybe_generics = [&]() -> JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>> { auto&& __jakt_match_variant = *this->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
 {
 Jakt::types::CheckedStruct const struct_ = this->get_struct(id);
-return JaktInternal::ExplicitValue<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>(static_cast<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>(Tuple{struct_.generic_parameters, struct_.generic_parameter_defaults, args}));
+return static_cast<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>(Tuple{struct_.generic_parameters, struct_.generic_parameter_defaults, args});
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -1993,43 +1888,30 @@ case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
 {
 Jakt::types::CheckedStruct const struct_ = this->get_struct(id);
-return JaktInternal::ExplicitValue<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>(static_cast<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>(Tuple{struct_.generic_parameters, struct_.generic_parameter_defaults, no_args}));
+return static_cast<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>(Tuple{struct_.generic_parameters, struct_.generic_parameter_defaults, no_args});
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>(Tuple{this->get_enum(id).generic_parameters, no_defaults, args}));
-};/*case end*/
+return static_cast<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>(Tuple{this->get_enum(id).generic_parameters, no_defaults, args});};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>(Tuple{this->get_enum(id).generic_parameters, no_defaults, no_args}));
-};/*case end*/
+return static_cast<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>(Tuple{this->get_enum(id).generic_parameters, no_defaults, no_args});};/*case end*/
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>(Tuple{this->get_trait(id)->generic_parameters, no_defaults, args}));
-};/*case end*/
+return static_cast<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>(Tuple{this->get_trait(id)->generic_parameters, no_defaults, args});};/*case end*/
 case 26 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>(Tuple{this->get_trait(id)->generic_parameters, no_defaults, no_args}));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
-JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>> __jakt_tmp62 = maybe_generics;
-if (__jakt_tmp62.has_value()){
-JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>> const generics = __jakt_tmp62.value();
+return static_cast<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>>>(Tuple{this->get_trait(id)->generic_parameters, no_defaults, no_args});};/*case end*/
+default:return JaktInternal::OptionalNone();}/*switch end*/
+ 
+}();
+JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>>> __jakt_tmp61 = maybe_generics;
+if (__jakt_tmp61.has_value()){
+JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>> const generics = __jakt_tmp61.value();
 JaktInternal::Dictionary<Jakt::ids::TypeId,Jakt::ids::TypeId> inferences = Dictionary<Jakt::ids::TypeId, Jakt::ids::TypeId>::create_with_entries({});
 JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>,JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<Jakt::ids::TypeId>>>,JaktInternal::DynamicArray<Jakt::ids::TypeId>> const parameters_declared_defaults_args_ = generics;
 JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> const parameters = parameters_declared_defaults_args_.template get<0>();
@@ -2048,22 +1930,11 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::types::CheckedGenericParameter const& parameter = parameters.operator[](i);
-Jakt::ids::TypeId const arg = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::ids::TypeId>,void> {
-auto __jakt_enum_value = (i < args.size());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<Jakt::ids::TypeId>>(args.operator[](i)));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(defaults.operator[](i));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-}).value_or_lazy_evaluated([&] { return parameter.type_id; });
+Jakt::types::CheckedGenericParameter const& parameter = parameters[i];
+Jakt::ids::TypeId const arg = [&]() -> JaktInternal::Optional<Jakt::ids::TypeId> { auto __jakt_enum_value = i < args.size();
+if (__jakt_enum_value) {return static_cast<JaktInternal::Optional<Jakt::ids::TypeId>>(args[i]);}else if (!__jakt_enum_value) {return defaults[i];}VERIFY_NOT_REACHED();
+ 
+}().value_or_lazy_evaluated([&] { return parameter.type_id; });
 inferences.set(parameter.type_id,arg);
 }
 
@@ -2210,23 +2081,13 @@ return this->is_integer(type_id) || this->is_floating(type_id);
 
 ErrorOr<bool> Jakt::types::CheckedProgram::is_string(Jakt::ids::TypeId const type_id) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, ErrorOr<bool>>{
-auto&& __jakt_match_variant = *this->get_type(type_id);
+{auto&& __jakt_match_variant = *this->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 13 /* JaktString */:return JaktInternal::ExplicitValue(true);
-case 23 /* Struct */: {
+case 13 /* JaktString */:return true;case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("String"sv)))).equals(struct_id));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("String"sv)))).equals(struct_id);};/*case end*/
+default:return false;}/*switch end*/
+}
 }
 }
 
@@ -2270,28 +2131,18 @@ continue;
 }
 seen.add(scope_id);
 typename Jakt::utility::IterationDecision<bool> const res = TRY((callback(mixin,JaktInternal::OptionalNone(),false)));
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<JaktInternal::Optional<bool>>> {
-auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer(res);
-if (__jakt_enum_value.__jakt_init_index() == 0 /* Break */) {auto& __jakt_match_value = __jakt_enum_value.as.Break;
-auto& value = __jakt_match_value.value;
+{auto&& __jakt_match_variant = res;
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Break */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Break;bool const& value = __jakt_match_value.value;
 {
 return static_cast<JaktInternal::Optional<bool>>(value);
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_67;};/*case end*/
+default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_67;}/*switch end*/
+break;}goto __jakt_label_67; __jakt_label_67:;;
 NonnullRefPtr<Jakt::types::Scope> const scope = this->get_scope(scope_id);
 if ((!(root_scope.has_value() && scope_id.equals(root_scope.value()))) && scope->parent.has_value()){
 scopes_to_check.enqueue(Jakt::types::ResolutionMixin(scope->parent.value(),true,true,true,true,true,true,true,true,true));
@@ -2350,28 +2201,18 @@ continue;
 }
 seen.add(scope_id);
 typename Jakt::utility::IterationDecision<bool> const res = TRY((callback(mixin,JaktInternal::OptionalNone(),false)));
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<JaktInternal::Optional<bool>>> {
-auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer(res);
-if (__jakt_enum_value.__jakt_init_index() == 0 /* Break */) {auto& __jakt_match_value = __jakt_enum_value.as.Break;
-auto& value = __jakt_match_value.value;
+{auto&& __jakt_match_variant = res;
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Break */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Break;bool const& value = __jakt_match_value.value;
 {
 return static_cast<JaktInternal::Optional<bool>>(value);
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_68;};/*case end*/
+default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_68;}/*switch end*/
+break;}goto __jakt_label_68; __jakt_label_68:;;
 NonnullRefPtr<Jakt::types::Scope> const scope = this->get_scope(scope_id);
 if ((!(root_scope.has_value() && scope_id.equals(root_scope.value()))) && scope->parent.has_value()){
 scopes_to_check.enqueue(Jakt::types::ResolutionMixin(scope->parent.value(),true,true,true,true,true,true,true,true,true));
@@ -2422,28 +2263,18 @@ ByteString const name = jakt__name__alias__.template get<0>();
 Jakt::ids::ScopeId const alias = jakt__name__alias__.template get<1>();
 
 typename Jakt::utility::IterationDecision<bool> const res = TRY((callback(Jakt::types::ResolutionMixin(alias,true,true,true,true,true,true,true,true,true),name,true)));
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<JaktInternal::Optional<bool>>> {
-auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer(res);
-if (__jakt_enum_value.__jakt_init_index() == 0 /* Break */) {auto& __jakt_match_value = __jakt_enum_value.as.Break;
-auto& value = __jakt_match_value.value;
+{auto&& __jakt_match_variant = res;
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Break */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Break;bool const& value = __jakt_match_value.value;
 {
 return static_cast<JaktInternal::Optional<bool>>(value);
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_69;};/*case end*/
+default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_69;}/*switch end*/
+break;}goto __jakt_label_69; __jakt_label_69:;;
 }
 
 }
@@ -2468,28 +2299,18 @@ Jakt::ids::ModuleId const module = jakt__name__module__.template get<1>();
 
 Jakt::ids::ScopeId const import_scope_id = Jakt::ids::ScopeId(module,static_cast<size_t>(0ULL));
 typename Jakt::utility::IterationDecision<bool> const res = TRY((callback(Jakt::types::ResolutionMixin(import_scope_id,true,true,true,true,true,true,true,true,true),name,false)));
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<JaktInternal::Optional<bool>>> {
-auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer(res);
-if (__jakt_enum_value.__jakt_init_index() == 0 /* Break */) {auto& __jakt_match_value = __jakt_enum_value.as.Break;
-auto& value = __jakt_match_value.value;
+{auto&& __jakt_match_variant = res;
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Break */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Break;bool const& value = __jakt_match_value.value;
 {
 return static_cast<JaktInternal::Optional<bool>>(value);
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_70;};/*case end*/
+default:{
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_70;}/*switch end*/
+break;}goto __jakt_label_70; __jakt_label_70:;;
 }
 
 }
@@ -2566,52 +2387,30 @@ this->compiler->panic(__jakt_format(StringView::from_string_literal("internal er
 Jakt::ids::ScopeId Jakt::types::CheckedProgram::find_type_scope_id(Jakt::ids::TypeId const type_id) {
 {
 NonnullRefPtr<typename Jakt::types::Type> const type = this->get_type(type_id);
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::ScopeId, Jakt::ids::ScopeId>{
-auto&& __jakt_match_variant = *type;
+{auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->get_struct(struct_id).scope_id);
-};/*case end*/
+return this->get_struct(struct_id).scope_id;};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& struct_id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(this->get_struct(struct_id).scope_id);
-};/*case end*/
+return this->get_struct(struct_id).scope_id;};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->get_enum(enum_id).scope_id);
-};/*case end*/
+return this->get_enum(enum_id).scope_id;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& enum_id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(this->get_enum(enum_id).scope_id);
-};/*case end*/
+return this->get_enum(enum_id).scope_id;};/*case end*/
 case 26 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& trait_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->get_trait(trait_id)->scope_id);
-};/*case end*/
+return this->get_trait(trait_id)->scope_id;};/*case end*/
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& trait_id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(this->get_trait(trait_id)->scope_id);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::ScopeId,Jakt::ids::ScopeId> {
-auto __jakt_enum_value = (type->is_builtin());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(this->get_struct(this->builtin_implementation_struct(type->as_builtin_type(),this->prelude_module_id())).scope_id);
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(this->prelude_scope_id());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return this->get_trait(trait_id)->scope_id;};/*case end*/
+default:{auto __jakt_enum_value = type->is_builtin();
+if (__jakt_enum_value) {return this->get_struct(this->builtin_implementation_struct(type->as_builtin_type(),this->prelude_module_id())).scope_id;}else if (!__jakt_enum_value) {return this->prelude_scope_id();}VERIFY_NOT_REACHED();
+}}/*switch end*/
+}
 }
 }
 
@@ -2690,7 +2489,7 @@ JaktInternal::DynamicArray<Jakt::ids::FunctionId> const functions = results.valu
 if (functions.size() != static_cast<size_t>(1ULL)){
 this->compiler->panic(__jakt_format(StringView::from_string_literal("internal error: found {} functions with name '{}', but expected 1"sv),functions.size(),function_name));
 }
-return functions.operator[](static_cast<i64>(0LL));
+return functions[static_cast<i64>(0LL)];
 }
 }
 
@@ -2762,11 +2561,11 @@ if (struct_id.equals(weak_ptr_struct_id)){
 if (args.size() != static_cast<size_t>(1ULL)){
 this->compiler->panic(__jakt_format(StringView::from_string_literal("Internal error: Generic type is WeakPtr but there are not exactly 1 type parameter. There are {} parameters."sv),args.size()));
 }
-Jakt::ids::TypeId const inner_type_id = args.operator[](static_cast<i64>(0LL));
+Jakt::ids::TypeId const inner_type_id = args[static_cast<i64>(0LL)];
 NonnullRefPtr<typename Jakt::types::Type> const inner_type = this->get_type(inner_type_id);
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp63 = inner_type;
-if (__jakt_tmp63->__jakt_init_index() == 23 /* Struct */){
-Jakt::ids::StructId const inner_struct_id = __jakt_tmp63->as.Struct.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp62 = inner_type;
+if (__jakt_tmp62->__jakt_init_index() == 23 /* Struct */){
+Jakt::ids::StructId const inner_struct_id = __jakt_tmp62->as.Struct.value;
 return inner_struct_id;
 }
 Jakt::utility::panic(__jakt_format(StringView::from_string_literal("Internal error: Inner type of WeakPtr is not a struct. It is {}."sv),inner_type));
@@ -2781,70 +2580,25 @@ return JaktInternal::OptionalNone();
 ErrorOr<ByteString> Jakt::types::CheckedProgram::type_name(Jakt::ids::TypeId const type_id,bool const debug_mode) const {
 {
 NonnullRefPtr<typename Jakt::types::Type> const type = this->get_type(type_id);
-return (({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (type->common.init_common.qualifiers.is_immutable);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("const "sv));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}) + ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>> {
-auto __jakt_enum_value = (debug_mode);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("({}@{}) "sv),type_id.id,type_id.module.id) + ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = *type;
+return ([&]() -> ByteString { auto __jakt_enum_value = type->common.init_common.qualifiers.is_immutable;
+if (__jakt_enum_value) {return ByteString::from_utf8_without_validation("const "sv);}else if (!__jakt_enum_value) {return ByteString::from_utf8_without_validation(""sv);}VERIFY_NOT_REACHED();
+ 
+}() + [&]() -> ByteString { auto __jakt_enum_value = debug_mode;
+if (__jakt_enum_value) {return __jakt_format(StringView::from_string_literal("({}@{}) "sv),type_id.id,type_id.module.id) + [&]() -> ByteString { auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 18 /* TypeVariable */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("var "sv));
-default:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else {return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation(""sv));
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-})) + ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
-auto&& __jakt_match_variant = *type;
+case 18 /* TypeVariable */:return ByteString::from_utf8_without_validation("var "sv);default:return ByteString::from_utf8_without_validation(""sv);}/*switch end*/
+ 
+}();}else {return ByteString::from_utf8_without_validation(""sv);} 
+}()) + TRY(([&]() -> ErrorOr<ByteString> { auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 17 /* Never */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("never"sv));
-case 10 /* F32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("f32"sv));
-case 11 /* F64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("f64"sv));
-case 6 /* I8 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i8"sv));
-case 7 /* I16 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i16"sv));
-case 8 /* I32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i32"sv));
-case 9 /* I64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i64"sv));
-case 2 /* U8 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u8"sv));
-case 3 /* U16 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u16"sv));
-case 4 /* U32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u32"sv));
-case 5 /* U64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u64"sv));
-case 12 /* Usize */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("usize"sv));
-case 14 /* CChar */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("c_char"sv));
-case 15 /* CInt */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("c_int"sv));
-case 1 /* Bool */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("bool"sv));
-case 0 /* Void */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("void"sv));
-case 16 /* Unknown */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("unknown"sv));
-case 13 /* JaktString */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("builtin(String)"sv));
-case 19 /* Dependent */: {
+case 17 /* Never */:return ByteString::from_utf8_without_validation("never"sv);case 10 /* F32 */:return ByteString::from_utf8_without_validation("f32"sv);case 11 /* F64 */:return ByteString::from_utf8_without_validation("f64"sv);case 6 /* I8 */:return ByteString::from_utf8_without_validation("i8"sv);case 7 /* I16 */:return ByteString::from_utf8_without_validation("i16"sv);case 8 /* I32 */:return ByteString::from_utf8_without_validation("i32"sv);case 9 /* I64 */:return ByteString::from_utf8_without_validation("i64"sv);case 2 /* U8 */:return ByteString::from_utf8_without_validation("u8"sv);case 3 /* U16 */:return ByteString::from_utf8_without_validation("u16"sv);case 4 /* U32 */:return ByteString::from_utf8_without_validation("u32"sv);case 5 /* U64 */:return ByteString::from_utf8_without_validation("u64"sv);case 12 /* Usize */:return ByteString::from_utf8_without_validation("usize"sv);case 14 /* CChar */:return ByteString::from_utf8_without_validation("c_char"sv);case 15 /* CInt */:return ByteString::from_utf8_without_validation("c_int"sv);case 1 /* Bool */:return ByteString::from_utf8_without_validation("bool"sv);case 0 /* Void */:return ByteString::from_utf8_without_validation("void"sv);case 16 /* Unknown */:return ByteString::from_utf8_without_validation("unknown"sv);case 13 /* JaktString */:return ByteString::from_utf8_without_validation("builtin(String)"sv);case 19 /* Dependent */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dependent;Jakt::ids::TypeId const& namespace_type = __jakt_match_value.namespace_type;
 ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("{}::{}"sv),TRY((this->type_name(namespace_type,debug_mode))),name));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("{}::{}"sv),TRY((this->type_name(namespace_type,debug_mode))),name);};/*case end*/
 case 26 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->get_trait(id)->name);
-};/*case end*/
-case 30 /* Self */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Self"sv));
-case 29 /* Function */: {
+return this->get_trait(id)->name;};/*case end*/
+case 30 /* Self */:return ByteString::from_utf8_without_validation("Self"sv);case 29 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& params = __jakt_match_value.params;
 Jakt::ids::TypeId const& return_type_id = __jakt_match_value.return_type_id;
 {
@@ -2865,18 +2619,16 @@ param_names.push(TRY((this->type_name(x,debug_mode))));
 }
 
 ByteString const return_type = TRY((this->type_name(return_type_id,debug_mode)));
-return JaktInternal::ExplicitValue<ByteString>(__jakt_format(StringView::from_string_literal("fn({}) -> {}"sv),Jakt::utility::join(param_names,ByteString::from_utf8_without_validation(", "sv)),return_type));
+return __jakt_format(StringView::from_string_literal("fn({}) -> {}"sv),Jakt::utility::join(param_names,ByteString::from_utf8_without_validation(", "sv)),return_type);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->get_enum(id).name);
-};/*case end*/
+return this->get_enum(id).name;};/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->get_struct(id).name);
-};/*case end*/
+return this->get_struct(id).name;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -2923,7 +2675,7 @@ self = (self + rhs);
 }
 }
 (output,ByteString::from_utf8_without_validation(">"sv));
-return JaktInternal::ExplicitValue<ByteString>(output);
+return output;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -2973,7 +2725,7 @@ self = (self + rhs);
 }
 }
 (output,ByteString::from_utf8_without_validation(">"sv));
-return JaktInternal::ExplicitValue<ByteString>(output);
+return output;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -2990,19 +2742,19 @@ Jakt::ids::StructId const tuple_struct_id = TRY((this->find_struct_in_prelude(By
 Jakt::ids::StructId const weak_ptr_struct_id = TRY((this->find_struct_in_prelude(ByteString::from_utf8_without_validation("WeakPtr"sv))));
 ByteString output = ByteString::from_utf8_without_validation(""sv);
 if (id.equals(array_struct_id)){
-output = __jakt_format(StringView::from_string_literal("[{}]"sv),TRY((this->type_name(args.operator[](static_cast<i64>(0LL)),debug_mode))));
+output = __jakt_format(StringView::from_string_literal("[{}]"sv),TRY((this->type_name(args[static_cast<i64>(0LL)],debug_mode))));
 }
 else if (id.equals(dictionary_struct_id)){
-output = __jakt_format(StringView::from_string_literal("[{}:{}]"sv),TRY((this->type_name(args.operator[](static_cast<i64>(0LL)),debug_mode))),TRY((this->type_name(args.operator[](static_cast<i64>(1LL)),debug_mode))));
+output = __jakt_format(StringView::from_string_literal("[{}:{}]"sv),TRY((this->type_name(args[static_cast<i64>(0LL)],debug_mode))),TRY((this->type_name(args[static_cast<i64>(1LL)],debug_mode))));
 }
 else if (id.equals(optional_struct_id)){
-output = __jakt_format(StringView::from_string_literal("{}?"sv),TRY((this->type_name(args.operator[](static_cast<i64>(0LL)),debug_mode))));
+output = __jakt_format(StringView::from_string_literal("{}?"sv),TRY((this->type_name(args[static_cast<i64>(0LL)],debug_mode))));
 }
 else if (id.equals(range_struct_id)){
-output = __jakt_format(StringView::from_string_literal("{}..{}"sv),TRY((this->type_name(args.operator[](static_cast<i64>(0LL)),debug_mode))),TRY((this->type_name(args.operator[](static_cast<i64>(0LL)),debug_mode))));
+output = __jakt_format(StringView::from_string_literal("{}..{}"sv),TRY((this->type_name(args[static_cast<i64>(0LL)],debug_mode))),TRY((this->type_name(args[static_cast<i64>(0LL)],debug_mode))));
 }
 else if (id.equals(set_struct_id)){
-output = __jakt_format(StringView::from_string_literal("{{{}}}"sv),TRY((this->type_name(args.operator[](static_cast<i64>(0LL)),debug_mode))));
+output = __jakt_format(StringView::from_string_literal("{{{}}}"sv),TRY((this->type_name(args[static_cast<i64>(0LL)],debug_mode))));
 }
 else if (id.equals(tuple_struct_id)){
 output = ByteString::from_utf8_without_validation("("sv);
@@ -3044,7 +2796,7 @@ self = (self + rhs);
 (output,ByteString::from_utf8_without_validation(")"sv));
 }
 else if (id.equals(weak_ptr_struct_id)){
-output = __jakt_format(StringView::from_string_literal("weak {}"sv),TRY((this->type_name(args.operator[](static_cast<i64>(0LL)),debug_mode))));
+output = __jakt_format(StringView::from_string_literal("weak {}"sv),TRY((this->type_name(args[static_cast<i64>(0LL)],debug_mode))));
 }
 else {
 Jakt::types::CheckedStruct const structure = this->get_struct(id);
@@ -3092,37 +2844,28 @@ self = (self + rhs);
 (output,ByteString::from_utf8_without_validation(">"sv));
 }
 
-return JaktInternal::ExplicitValue<ByteString>(output);
+return output;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 18 /* TypeVariable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeVariable;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(name);
-};/*case end*/
+return name;};/*case end*/
 case 25 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("raw {}"sv),TRY((this->type_name(type_id,debug_mode)))));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("raw {}"sv),TRY((this->type_name(type_id,debug_mode))));};/*case end*/
 case 27 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("&{}"sv),TRY((this->type_name(type_id,debug_mode)))));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("&{}"sv),TRY((this->type_name(type_id,debug_mode))));};/*case end*/
 case 28 /* MutableReference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MutableReference;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(__jakt_format(StringView::from_string_literal("&mut {}"sv),TRY((this->type_name(type_id,debug_mode)))));
-};/*case end*/
+return __jakt_format(StringView::from_string_literal("&mut {}"sv),TRY((this->type_name(type_id,debug_mode))));};/*case end*/
 case 31 /* Const */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Const;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((Jakt::types::comptime_format_impl(ByteString::from_utf8_without_validation("comptime {}"sv),DynamicArray<Jakt::types::Value>::create_with({value}).operator[](JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}),*this))));
-};/*case end*/
+return Jakt::types::comptime_format_impl(ByteString::from_utf8_without_validation("comptime {}"sv),DynamicArray<Jakt::types::Value>::create_with({value})[JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)}],*this);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}()));
 }
 }
 
@@ -3139,7 +2882,7 @@ break;
 }
 size_t id = _magic_value.value();
 {
-if (types.operator[](id)->equals(type)){
+if (types[id]->equals(type)){
 return Jakt::ids::TypeId(module_id,id);
 }
 }
@@ -3167,7 +2910,7 @@ break;
 }
 size_t id = _magic_value.value();
 {
-if (module->types.operator[](id)->equals(type)){
+if (module->types[id]->equals(type)){
 return Jakt::ids::TypeId(module->id,id);
 }
 }
@@ -3182,8 +2925,8 @@ return Jakt::ids::TypeId(module->id,id);
 
 }
 
-this->modules.operator[](module_id.id)->types.push(type);
-return Jakt::ids::TypeId(module_id,JaktInternal::checked_sub(this->modules.operator[](module_id.id)->types.size(),static_cast<size_t>(1ULL)));
+this->modules[module_id.id]->types.push(type);
+return Jakt::ids::TypeId(module_id,JaktInternal::checked_sub(this->modules[module_id.id]->types.size(),static_cast<size_t>(1ULL)));
 }
 }
 
@@ -3208,9 +2951,7 @@ ErrorOr<Jakt::ids::TypeId> Jakt::types::CheckedProgram::specialize_type_id(Jakt:
 {
 JaktInternal::DynamicArray<Jakt::ids::TypeId> final_args = DynamicArray<Jakt::ids::TypeId>::create_with({});
 NonnullRefPtr<typename Jakt::types::Type> const type = this->get_type(type_id);
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::ids::TypeId>>{
-auto&& __jakt_match_variant = *type;
+{auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -3221,8 +2962,7 @@ final_args.push_values(args);
 }
 final_args.push_values(new_args);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_71;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
 {
@@ -3232,8 +2972,7 @@ final_args.push_values(args);
 }
 final_args.push_values(new_args);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_71;};/*case end*/
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
 {
@@ -3243,64 +2982,41 @@ final_args.push_values(args);
 }
 final_args.push_values(new_args);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_71;};/*case end*/
 default:{
 final_args.push_values(new_args);
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId, ErrorOr<Jakt::ids::TypeId>>{
-auto&& __jakt_match_variant = *type;
+goto __jakt_label_71;}/*switch end*/
+}goto __jakt_label_71; __jakt_label_71:;;
+{auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),id,final_args),module_id,false));
-};/*case end*/
+return this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),id,final_args),module_id,false);};/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),id,final_args),module_id,false));
-};/*case end*/
+return this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),id,final_args),module_id,false);};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(this->find_or_add_type_id(Jakt::types::Type::GenericEnumInstance(Jakt::parser::CheckedQualifiers(false),id,final_args),module_id,false));
-};/*case end*/
+return this->find_or_add_type_id(Jakt::types::Type::GenericEnumInstance(Jakt::parser::CheckedQualifiers(false),id,final_args),module_id,false);};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->find_or_add_type_id(Jakt::types::Type::GenericEnumInstance(Jakt::parser::CheckedQualifiers(false),id,final_args),module_id,false));
-};/*case end*/
+return this->find_or_add_type_id(Jakt::types::Type::GenericEnumInstance(Jakt::parser::CheckedQualifiers(false),id,final_args),module_id,false);};/*case end*/
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(this->find_or_add_type_id(Jakt::types::Type::GenericTraitInstance(Jakt::parser::CheckedQualifiers(false),id,final_args),module_id,false));
-};/*case end*/
+return this->find_or_add_type_id(Jakt::types::Type::GenericTraitInstance(Jakt::parser::CheckedQualifiers(false),id,final_args),module_id,false);};/*case end*/
 case 26 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(this->find_or_add_type_id(Jakt::types::Type::GenericTraitInstance(Jakt::parser::CheckedQualifiers(false),id,final_args),module_id,false));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(type_id);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return this->find_or_add_type_id(Jakt::types::Type::GenericTraitInstance(Jakt::parser::CheckedQualifiers(false),id,final_args),module_id,false);};/*case end*/
+default:return type_id;}/*switch end*/
+}
 }
 }
 
 ErrorOr<Jakt::ids::TypeId> Jakt::types::CheckedProgram::substitute_typevars_in_type_helper(Jakt::ids::TypeId const type_id,Jakt::types::GenericInferences const generic_inferences,Jakt::ids::ModuleId const module_id) {
 {
 NonnullRefPtr<typename Jakt::types::Type> const type_ = this->get_type(type_id);
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<Jakt::ids::TypeId>>{
-auto&& __jakt_match_variant = *type_;
+{auto&& __jakt_match_variant = *type_;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 18 /* TypeVariable */:{
 JaktInternal::Optional<Jakt::ids::TypeId> const replacement_type_id = generic_inferences.get(type_id);
@@ -3308,8 +3024,7 @@ if (replacement_type_id.has_value()){
 return replacement_type_id.value();
 }
 }
-return JaktInternal::ExplicitValue<void>();
-case 19 /* Dependent */: {
+goto __jakt_label_72;case 19 /* Dependent */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dependent;Jakt::ids::TypeId const& namespace_type = __jakt_match_value.namespace_type;
 ByteString const& name = __jakt_match_value.name;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -3355,8 +3070,7 @@ return type_id;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_72;};/*case end*/
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -3380,8 +3094,7 @@ new_args.push(TRY((this->substitute_typevars_in_type(arg,generic_inferences,modu
 
 return this->find_or_add_type_id(Jakt::types::Type::GenericTraitInstance(Jakt::parser::CheckedQualifiers(false),id,new_args),module_id,false);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_72;};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -3405,8 +3118,7 @@ new_args.push(TRY((this->substitute_typevars_in_type(arg,generic_inferences,modu
 
 return this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),id,new_args),module_id,false);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_72;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
@@ -3430,8 +3142,7 @@ new_args.push(TRY((this->substitute_typevars_in_type(arg,generic_inferences,modu
 
 return this->find_or_add_type_id(Jakt::types::Type::GenericEnumInstance(Jakt::parser::CheckedQualifiers(false),id,new_args),module_id,false);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_72;};/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
 {
@@ -3457,8 +3168,7 @@ new_args.push(TRY((this->substitute_typevars_in_type(arg.type_id,generic_inferen
 return this->find_or_add_type_id(Jakt::types::Type::GenericInstance(Jakt::parser::CheckedQualifiers(false),struct_id,new_args),module_id,false);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_72;};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
 {
@@ -3484,32 +3194,28 @@ new_args.push(TRY((this->substitute_typevars_in_type(arg.type_id,generic_inferen
 return this->find_or_add_type_id(Jakt::types::Type::GenericEnumInstance(Jakt::parser::CheckedQualifiers(false),enum_id,new_args),module_id,false);
 }
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_72;};/*case end*/
 case 25 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;Jakt::ids::TypeId const& rawptr_type_id = __jakt_match_value.value;
 {
 NonnullRefPtr<typename Jakt::types::Type> const rawptr_type = Jakt::types::Type::RawPtr(Jakt::parser::CheckedQualifiers(false),TRY((this->substitute_typevars_in_type(rawptr_type_id,generic_inferences,module_id))));
 return this->find_or_add_type_id(rawptr_type,module_id,false);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_72;};/*case end*/
 case 27 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;Jakt::ids::TypeId const& ref_type_id = __jakt_match_value.value;
 {
 NonnullRefPtr<typename Jakt::types::Type> const ref_type = Jakt::types::Type::Reference(Jakt::parser::CheckedQualifiers(false),TRY((this->substitute_typevars_in_type(ref_type_id,generic_inferences,module_id))));
 return this->find_or_add_type_id(ref_type,module_id,false);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_72;};/*case end*/
 case 28 /* MutableReference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MutableReference;Jakt::ids::TypeId const& ref_type_id = __jakt_match_value.value;
 {
 NonnullRefPtr<typename Jakt::types::Type> const ref_type = Jakt::types::Type::MutableReference(Jakt::parser::CheckedQualifiers(false),TRY((this->substitute_typevars_in_type(ref_type_id,generic_inferences,module_id))));
 return this->find_or_add_type_id(ref_type,module_id,false);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_72;};/*case end*/
 case 29 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& params = __jakt_match_value.params;
 bool const& can_throw = __jakt_match_value.can_throw;
@@ -3552,8 +3258,8 @@ break;
 }
 size_t i = _magic_value.value();
 {
-Jakt::types::CheckedParameter const param = previous_function->params.operator[](i);
-Jakt::types::CheckedParameter const new_param = Jakt::types::CheckedParameter(param.requires_label,Jakt::types::CheckedVariable::__jakt_create(param.variable->name,new_params.operator[](i),param.variable->is_mutable,param.variable->definition_span,param.variable->type_span,param.variable->visibility,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone()),param.default_value_expression);
+Jakt::types::CheckedParameter const param = previous_function->params[i];
+Jakt::types::CheckedParameter const new_param = Jakt::types::CheckedParameter(param.requires_label,Jakt::types::CheckedVariable::__jakt_create(param.variable->name,new_params[i],param.variable->is_mutable,param.variable->definition_span,param.variable->type_span,param.variable->visibility,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone()),param.default_value_expression);
 replacement_params.push(new_param);
 }
 
@@ -3561,22 +3267,15 @@ replacement_params.push(new_param);
 }
 
 NonnullRefPtr<Jakt::types::CheckedFunction> const new_function = Jakt::types::CheckedFunction::__jakt_create(previous_function->name,previous_function->name_span,previous_function->visibility,return_type_substitute,previous_function->return_type_span,replacement_params,previous_function->generics,previous_function->block,can_throw,previous_function->type,previous_function->linkage,previous_function->function_scope_id,previous_function->struct_id,previous_function->is_instantiated,previous_function->parsed_function,previous_function->is_comptime,previous_function->is_virtual,previous_function->is_override,previous_function->is_unsafe,false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),Jakt::parser::InlineState::Default(),false);
-Jakt::ids::FunctionId const new_function_id = this->modules.operator[](module_id.id)->add_function(new_function);
+Jakt::ids::FunctionId const new_function_id = this->modules[module_id.id]->add_function(new_function);
 return this->find_or_add_type_id(Jakt::types::Type::Function(Jakt::parser::CheckedQualifiers(false),new_params,can_throw,return_type_substitute,new_function_id),module_id,false);
 }
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
+goto __jakt_label_72;};/*case end*/
 default:{
 return type_id;
 }
-return JaktInternal::ExplicitValue<void>();
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_72;}/*switch end*/
+}goto __jakt_label_72; __jakt_label_72:;;
 return type_id;
 }
 }
@@ -3599,229 +3298,76 @@ return Jakt::types::Value(this->impl->copy(),this->span);
 
 ByteString Jakt::types::Value::type_name() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ByteString>{
-auto&& __jakt_match_variant = *this->impl;
+{auto&& __jakt_match_variant = *this->impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Void */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("void"sv));
-case 1 /* Bool */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("bool"sv));
-case 2 /* U8 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u8"sv));
-case 3 /* U16 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u16"sv));
-case 4 /* U32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u32"sv));
-case 5 /* U64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("u64"sv));
-case 6 /* I8 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i18"sv));
-case 7 /* I16 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i16"sv));
-case 8 /* I32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i32"sv));
-case 9 /* I64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("i64"sv));
-case 10 /* F32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("f32"sv));
-case 11 /* F64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("f64"sv));
-case 12 /* USize */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("usize"sv));
-case 13 /* JaktString */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("String"sv));
-case 14 /* StringView */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("StringView"sv));
-case 15 /* CChar */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("c_char"sv));
-case 16 /* CInt */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("c_int"sv));
-case 17 /* Struct */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("struct <T>"sv));
-case 18 /* Class */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("class <T>"sv));
-case 19 /* Enum */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("enum <T>"sv));
-case 20 /* JaktArray */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Array"sv));
-case 21 /* JaktDictionary */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Dictionary"sv));
-case 22 /* JaktSet */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Set"sv));
-case 23 /* RawPtr */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("raw <T>"sv));
-case 24 /* OptionalSome */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Some"sv));
-case 25 /* OptionalNone */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("None"sv));
-case 26 /* JaktTuple */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Tuple"sv));
-case 27 /* Function */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Function"sv));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 0 /* Void */:return ByteString::from_utf8_without_validation("void"sv);case 1 /* Bool */:return ByteString::from_utf8_without_validation("bool"sv);case 2 /* U8 */:return ByteString::from_utf8_without_validation("u8"sv);case 3 /* U16 */:return ByteString::from_utf8_without_validation("u16"sv);case 4 /* U32 */:return ByteString::from_utf8_without_validation("u32"sv);case 5 /* U64 */:return ByteString::from_utf8_without_validation("u64"sv);case 6 /* I8 */:return ByteString::from_utf8_without_validation("i18"sv);case 7 /* I16 */:return ByteString::from_utf8_without_validation("i16"sv);case 8 /* I32 */:return ByteString::from_utf8_without_validation("i32"sv);case 9 /* I64 */:return ByteString::from_utf8_without_validation("i64"sv);case 10 /* F32 */:return ByteString::from_utf8_without_validation("f32"sv);case 11 /* F64 */:return ByteString::from_utf8_without_validation("f64"sv);case 12 /* USize */:return ByteString::from_utf8_without_validation("usize"sv);case 13 /* JaktString */:return ByteString::from_utf8_without_validation("String"sv);case 14 /* StringView */:return ByteString::from_utf8_without_validation("StringView"sv);case 15 /* CChar */:return ByteString::from_utf8_without_validation("c_char"sv);case 16 /* CInt */:return ByteString::from_utf8_without_validation("c_int"sv);case 17 /* Struct */:return ByteString::from_utf8_without_validation("struct <T>"sv);case 18 /* Class */:return ByteString::from_utf8_without_validation("class <T>"sv);case 19 /* Enum */:return ByteString::from_utf8_without_validation("enum <T>"sv);case 20 /* JaktArray */:return ByteString::from_utf8_without_validation("Array"sv);case 21 /* JaktDictionary */:return ByteString::from_utf8_without_validation("Dictionary"sv);case 22 /* JaktSet */:return ByteString::from_utf8_without_validation("Set"sv);case 23 /* RawPtr */:return ByteString::from_utf8_without_validation("raw <T>"sv);case 24 /* OptionalSome */:return ByteString::from_utf8_without_validation("Some"sv);case 25 /* OptionalNone */:return ByteString::from_utf8_without_validation("None"sv);case 26 /* JaktTuple */:return ByteString::from_utf8_without_validation("Tuple"sv);case 27 /* Function */:return ByteString::from_utf8_without_validation("Function"sv);default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
 Jakt::types::Value Jakt::types::Value::cast(Jakt::types::Value const expected,Jakt::utility::Span const span) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, Jakt::types::Value>{
-auto&& __jakt_match_variant = *this->impl;
+{auto&& __jakt_match_variant = *this->impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, Jakt::types::Value>{
-auto&& __jakt_match_variant = *expected.impl;
+{auto&& __jakt_match_variant = *expected.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 3 /* U16 */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U16(infallible_integer_cast<u16>(value)),span));
-case 4 /* U32 */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U32(infallible_integer_cast<u32>(value)),span));
-case 5 /* U64 */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U64(infallible_integer_cast<u64>(value)),span));
-case 12 /* USize */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(infallible_integer_cast<size_t>(value)),span));
-default:return JaktInternal::ExplicitValue(*this);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+case 3 /* U16 */:return Jakt::types::Value(Jakt::types::ValueImpl::U16(infallible_integer_cast<u16>(value)),span);case 4 /* U32 */:return Jakt::types::Value(Jakt::types::ValueImpl::U32(infallible_integer_cast<u32>(value)),span);case 5 /* U64 */:return Jakt::types::Value(Jakt::types::ValueImpl::U64(infallible_integer_cast<u64>(value)),span);case 12 /* USize */:return Jakt::types::Value(Jakt::types::ValueImpl::USize(infallible_integer_cast<size_t>(value)),span);default:return *this;}/*switch end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, Jakt::types::Value>{
-auto&& __jakt_match_variant = *expected.impl;
+{auto&& __jakt_match_variant = *expected.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 4 /* U32 */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U32(infallible_integer_cast<u32>(value)),span));
-case 5 /* U64 */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U64(infallible_integer_cast<u64>(value)),span));
-case 12 /* USize */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(infallible_integer_cast<size_t>(value)),span));
-default:return JaktInternal::ExplicitValue(*this);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+case 4 /* U32 */:return Jakt::types::Value(Jakt::types::ValueImpl::U32(infallible_integer_cast<u32>(value)),span);case 5 /* U64 */:return Jakt::types::Value(Jakt::types::ValueImpl::U64(infallible_integer_cast<u64>(value)),span);case 12 /* USize */:return Jakt::types::Value(Jakt::types::ValueImpl::USize(infallible_integer_cast<size_t>(value)),span);default:return *this;}/*switch end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, Jakt::types::Value>{
-auto&& __jakt_match_variant = *expected.impl;
+{auto&& __jakt_match_variant = *expected.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 5 /* U64 */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U64(infallible_integer_cast<u64>(value)),span));
-case 12 /* USize */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(infallible_integer_cast<size_t>(value)),span));
-default:return JaktInternal::ExplicitValue(*this);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+case 5 /* U64 */:return Jakt::types::Value(Jakt::types::ValueImpl::U64(infallible_integer_cast<u64>(value)),span);case 12 /* USize */:return Jakt::types::Value(Jakt::types::ValueImpl::USize(infallible_integer_cast<size_t>(value)),span);default:return *this;}/*switch end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, Jakt::types::Value>{
-auto&& __jakt_match_variant = *expected.impl;
+{auto&& __jakt_match_variant = *expected.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 12 /* USize */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(infallible_integer_cast<size_t>(value)),span));
-default:return JaktInternal::ExplicitValue(*this);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+case 12 /* USize */:return Jakt::types::Value(Jakt::types::ValueImpl::USize(infallible_integer_cast<size_t>(value)),span);default:return *this;}/*switch end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, Jakt::types::Value>{
-auto&& __jakt_match_variant = *expected.impl;
+{auto&& __jakt_match_variant = *expected.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 7 /* I16 */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I16(infallible_integer_cast<i16>(value)),span));
-case 8 /* I32 */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I32(infallible_integer_cast<i32>(value)),span));
-case 9 /* I64 */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I64(infallible_integer_cast<i64>(value)),span));
-default:return JaktInternal::ExplicitValue(*this);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+case 7 /* I16 */:return Jakt::types::Value(Jakt::types::ValueImpl::I16(infallible_integer_cast<i16>(value)),span);case 8 /* I32 */:return Jakt::types::Value(Jakt::types::ValueImpl::I32(infallible_integer_cast<i32>(value)),span);case 9 /* I64 */:return Jakt::types::Value(Jakt::types::ValueImpl::I64(infallible_integer_cast<i64>(value)),span);default:return *this;}/*switch end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, Jakt::types::Value>{
-auto&& __jakt_match_variant = *expected.impl;
+{auto&& __jakt_match_variant = *expected.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 8 /* I32 */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I32(infallible_integer_cast<i32>(value)),span));
-case 9 /* I64 */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I64(infallible_integer_cast<i64>(value)),span));
-default:return JaktInternal::ExplicitValue(*this);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+case 8 /* I32 */:return Jakt::types::Value(Jakt::types::ValueImpl::I32(infallible_integer_cast<i32>(value)),span);case 9 /* I64 */:return Jakt::types::Value(Jakt::types::ValueImpl::I64(infallible_integer_cast<i64>(value)),span);default:return *this;}/*switch end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, Jakt::types::Value>{
-auto&& __jakt_match_variant = *expected.impl;
+{auto&& __jakt_match_variant = *expected.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 9 /* I64 */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::I64(infallible_integer_cast<i64>(value)),span));
-default:return JaktInternal::ExplicitValue(*this);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+case 9 /* I64 */:return Jakt::types::Value(Jakt::types::ValueImpl::I64(infallible_integer_cast<i64>(value)),span);default:return *this;}/*switch end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, Jakt::types::Value>{
-auto&& __jakt_match_variant = *expected.impl;
+{auto&& __jakt_match_variant = *expected.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 12 /* USize */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::USize(infallible_integer_cast<size_t>(value)),span));
-default:return JaktInternal::ExplicitValue(*this);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+case 12 /* USize */:return Jakt::types::Value(Jakt::types::ValueImpl::USize(infallible_integer_cast<size_t>(value)),span);default:return *this;}/*switch end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, Jakt::types::Value>{
-auto&& __jakt_match_variant = *expected.impl;
+{auto&& __jakt_match_variant = *expected.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 5 /* U64 */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::U64(infallible_integer_cast<u64>(value)),span));
-case 16 /* CInt */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::CInt(infallible_integer_cast<int>(value)),span));
-default:return JaktInternal::ExplicitValue(*this);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-case 24 /* OptionalSome */:return JaktInternal::ExplicitValue(*this);
-default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::Value, Jakt::types::Value>{
-auto&& __jakt_match_variant = *expected.impl;
+case 5 /* U64 */:return Jakt::types::Value(Jakt::types::ValueImpl::U64(infallible_integer_cast<u64>(value)),span);case 16 /* CInt */:return Jakt::types::Value(Jakt::types::ValueImpl::CInt(infallible_integer_cast<int>(value)),span);default:return *this;}/*switch end*/
+}};/*case end*/
+case 24 /* OptionalSome */:return *this;default:{auto&& __jakt_match_variant = *expected.impl;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 24 /* OptionalSome */:case 25 /* OptionalNone */:return JaktInternal::ExplicitValue(Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(*this),span));
-default:return JaktInternal::ExplicitValue(*this);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 24 /* OptionalSome */:case 25 /* OptionalNone */:return Jakt::types::Value(Jakt::types::ValueImpl::OptionalSome(*this),span);default:return *this;}/*switch end*/
+}}/*switch end*/
+}
 }
 }
 
@@ -4104,29 +3650,20 @@ break;
 }
 JaktInternal::DynamicArray<Jakt::ids::TypeId> Jakt::types::StructLikeId::generic_parameters(NonnullRefPtr<Jakt::types::CheckedProgram> const& program) const {
 {
-JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> const parameters = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>, JaktInternal::DynamicArray<Jakt::ids::TypeId>>{
-auto&& __jakt_match_variant = *this;
+JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> const parameters = [&]() -> JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> { auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_struct(id).generic_parameters);
-};/*case end*/
+return program->get_struct(id).generic_parameters;};/*case end*/
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_enum(id).generic_parameters);
-};/*case end*/
+return program->get_enum(id).generic_parameters;};/*case end*/
 case 2 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_trait(id)->generic_parameters);
-};/*case end*/
+return program->get_trait(id)->generic_parameters;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+ 
+}();
 JaktInternal::DynamicArray<Jakt::ids::TypeId> result = DynamicArray<Jakt::ids::TypeId>::create_with({});
 {
 JaktInternal::ArrayIterator<Jakt::types::CheckedGenericParameter> _magic = parameters.iterator();
@@ -4149,160 +3686,103 @@ return result;
 
 JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter> Jakt::types::StructLikeId::generic_parameters_as_checked(NonnullRefPtr<Jakt::types::CheckedProgram> const& program) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>, JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_struct(id).generic_parameters);
-};/*case end*/
+return program->get_struct(id).generic_parameters;};/*case end*/
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_enum(id).generic_parameters);
-};/*case end*/
+return program->get_enum(id).generic_parameters;};/*case end*/
 case 2 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_trait(id)->generic_parameters);
-};/*case end*/
+return program->get_trait(id)->generic_parameters;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 Jakt::ids::ScopeId Jakt::types::StructLikeId::scope_id(NonnullRefPtr<Jakt::types::CheckedProgram> const& program) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::ScopeId, Jakt::ids::ScopeId>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_struct(id).scope_id);
-};/*case end*/
+return program->get_struct(id).scope_id;};/*case end*/
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_enum(id).scope_id);
-};/*case end*/
+return program->get_enum(id).scope_id;};/*case end*/
 case 2 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_trait(id)->scope_id);
-};/*case end*/
+return program->get_trait(id)->scope_id;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 Jakt::ids::TypeId Jakt::types::StructLikeId::specialized_by(JaktInternal::DynamicArray<Jakt::ids::TypeId> const arguments,NonnullRefPtr<Jakt::types::CheckedProgram>& program,Jakt::ids::ModuleId const module_id,Jakt::parser::CheckedQualifiers const qualifiers) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId, Jakt::ids::TypeId>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->find_or_add_type_id(Jakt::types::Type::GenericInstance(qualifiers,id,arguments),module_id,false));
-};/*case end*/
+return program->find_or_add_type_id(Jakt::types::Type::GenericInstance(qualifiers,id,arguments),module_id,false);};/*case end*/
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->find_or_add_type_id(Jakt::types::Type::GenericEnumInstance(qualifiers,id,arguments),module_id,false));
-};/*case end*/
+return program->find_or_add_type_id(Jakt::types::Type::GenericEnumInstance(qualifiers,id,arguments),module_id,false);};/*case end*/
 case 2 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->find_or_add_type_id(Jakt::types::Type::GenericTraitInstance(qualifiers,id,arguments),module_id,false));
-};/*case end*/
+return program->find_or_add_type_id(Jakt::types::Type::GenericTraitInstance(qualifiers,id,arguments),module_id,false);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 JaktInternal::Optional<Jakt::types::StructLikeId> Jakt::types::StructLikeId::from_type_id(Jakt::ids::TypeId const type_id,NonnullRefPtr<Jakt::types::CheckedProgram> const& program) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::types::StructLikeId>, JaktInternal::Optional<Jakt::types::StructLikeId>>{
-auto&& __jakt_match_variant = *program->get_type(type_id);
+{auto&& __jakt_match_variant = *program->get_type(type_id);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& struct_id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(Jakt::types::StructLikeId::Struct(args,struct_id));
-};/*case end*/
+return Jakt::types::StructLikeId::Struct(args,struct_id);};/*case end*/
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});
-return JaktInternal::ExplicitValue(Jakt::types::StructLikeId::Struct(args,struct_id));
-};/*case end*/
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});return Jakt::types::StructLikeId::Struct(args,struct_id);};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& enum_id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(Jakt::types::StructLikeId::Enum(args,enum_id));
-};/*case end*/
+return Jakt::types::StructLikeId::Enum(args,enum_id);};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});
-return JaktInternal::ExplicitValue(Jakt::types::StructLikeId::Enum(args,enum_id));
-};/*case end*/
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});return Jakt::types::StructLikeId::Enum(args,enum_id);};/*case end*/
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& trait_id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(Jakt::types::StructLikeId::Trait(args,trait_id));
-};/*case end*/
+return Jakt::types::StructLikeId::Trait(args,trait_id);};/*case end*/
 case 26 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& trait_id = __jakt_match_value.value;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});
-return JaktInternal::ExplicitValue(Jakt::types::StructLikeId::Trait(args,trait_id));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const args = DynamicArray<Jakt::ids::TypeId>::create_with({});return Jakt::types::StructLikeId::Trait(args,trait_id);};/*case end*/
+default:return JaktInternal::OptionalNone();}/*switch end*/
+}
 }
 }
 
 Jakt::ids::ScopeId Jakt::types::StructLikeId::associated_scope_id(NonnullRefPtr<Jakt::types::CheckedProgram> const& program) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::ScopeId, Jakt::ids::ScopeId>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_struct(id).scope_id);
-};/*case end*/
+return program->get_struct(id).scope_id;};/*case end*/
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_enum(id).scope_id);
-};/*case end*/
+return program->get_enum(id).scope_id;};/*case end*/
 case 2 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_trait(id)->scope_id);
-};/*case end*/
+return program->get_trait(id)->scope_id;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -4830,69 +4310,19 @@ case 17 /* Never */:break;
 }
 size_t Jakt::types::BuiltinType::id() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, size_t>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Void */:return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-case 1 /* Bool */:return JaktInternal::ExplicitValue(static_cast<size_t>(1ULL));
-case 2 /* U8 */:return JaktInternal::ExplicitValue(static_cast<size_t>(2ULL));
-case 3 /* U16 */:return JaktInternal::ExplicitValue(static_cast<size_t>(3ULL));
-case 4 /* U32 */:return JaktInternal::ExplicitValue(static_cast<size_t>(4ULL));
-case 5 /* U64 */:return JaktInternal::ExplicitValue(static_cast<size_t>(5ULL));
-case 6 /* I8 */:return JaktInternal::ExplicitValue(static_cast<size_t>(6ULL));
-case 7 /* I16 */:return JaktInternal::ExplicitValue(static_cast<size_t>(7ULL));
-case 8 /* I32 */:return JaktInternal::ExplicitValue(static_cast<size_t>(8ULL));
-case 9 /* I64 */:return JaktInternal::ExplicitValue(static_cast<size_t>(9ULL));
-case 10 /* F32 */:return JaktInternal::ExplicitValue(static_cast<size_t>(10ULL));
-case 11 /* F64 */:return JaktInternal::ExplicitValue(static_cast<size_t>(11ULL));
-case 12 /* Usize */:return JaktInternal::ExplicitValue(static_cast<size_t>(12ULL));
-case 13 /* JaktString */:return JaktInternal::ExplicitValue(static_cast<size_t>(13ULL));
-case 14 /* CChar */:return JaktInternal::ExplicitValue(static_cast<size_t>(14ULL));
-case 15 /* CInt */:return JaktInternal::ExplicitValue(static_cast<size_t>(15ULL));
-case 16 /* Unknown */:return JaktInternal::ExplicitValue(static_cast<size_t>(16ULL));
-case 17 /* Never */:return JaktInternal::ExplicitValue(static_cast<size_t>(17ULL));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 0 /* Void */:return static_cast<size_t>(0ULL);case 1 /* Bool */:return static_cast<size_t>(1ULL);case 2 /* U8 */:return static_cast<size_t>(2ULL);case 3 /* U16 */:return static_cast<size_t>(3ULL);case 4 /* U32 */:return static_cast<size_t>(4ULL);case 5 /* U64 */:return static_cast<size_t>(5ULL);case 6 /* I8 */:return static_cast<size_t>(6ULL);case 7 /* I16 */:return static_cast<size_t>(7ULL);case 8 /* I32 */:return static_cast<size_t>(8ULL);case 9 /* I64 */:return static_cast<size_t>(9ULL);case 10 /* F32 */:return static_cast<size_t>(10ULL);case 11 /* F64 */:return static_cast<size_t>(11ULL);case 12 /* Usize */:return static_cast<size_t>(12ULL);case 13 /* JaktString */:return static_cast<size_t>(13ULL);case 14 /* CChar */:return static_cast<size_t>(14ULL);case 15 /* CInt */:return static_cast<size_t>(15ULL);case 16 /* Unknown */:return static_cast<size_t>(16ULL);case 17 /* Never */:return static_cast<size_t>(17ULL);default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
 ByteString Jakt::types::BuiltinType::constructor_name() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ByteString>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Void */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Void"sv));
-case 1 /* Bool */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Bool"sv));
-case 2 /* U8 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("U8"sv));
-case 3 /* U16 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("U16"sv));
-case 4 /* U32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("U32"sv));
-case 5 /* U64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("U64"sv));
-case 6 /* I8 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("I8"sv));
-case 7 /* I16 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("I16"sv));
-case 8 /* I32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("I32"sv));
-case 9 /* I64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("I64"sv));
-case 10 /* F32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("F32"sv));
-case 11 /* F64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("F64"sv));
-case 12 /* Usize */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Usize"sv));
-case 13 /* JaktString */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("JaktString"sv));
-case 14 /* CChar */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("CChar"sv));
-case 15 /* CInt */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("CInt"sv));
-case 16 /* Unknown */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Unknown"sv));
-case 17 /* Never */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Never"sv));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 0 /* Void */:return ByteString::from_utf8_without_validation("Void"sv);case 1 /* Bool */:return ByteString::from_utf8_without_validation("Bool"sv);case 2 /* U8 */:return ByteString::from_utf8_without_validation("U8"sv);case 3 /* U16 */:return ByteString::from_utf8_without_validation("U16"sv);case 4 /* U32 */:return ByteString::from_utf8_without_validation("U32"sv);case 5 /* U64 */:return ByteString::from_utf8_without_validation("U64"sv);case 6 /* I8 */:return ByteString::from_utf8_without_validation("I8"sv);case 7 /* I16 */:return ByteString::from_utf8_without_validation("I16"sv);case 8 /* I32 */:return ByteString::from_utf8_without_validation("I32"sv);case 9 /* I64 */:return ByteString::from_utf8_without_validation("I64"sv);case 10 /* F32 */:return ByteString::from_utf8_without_validation("F32"sv);case 11 /* F64 */:return ByteString::from_utf8_without_validation("F64"sv);case 12 /* Usize */:return ByteString::from_utf8_without_validation("Usize"sv);case 13 /* JaktString */:return ByteString::from_utf8_without_validation("JaktString"sv);case 14 /* CChar */:return ByteString::from_utf8_without_validation("CChar"sv);case 15 /* CInt */:return ByteString::from_utf8_without_validation("CInt"sv);case 16 /* Unknown */:return ByteString::from_utf8_without_validation("Unknown"sv);case 17 /* Never */:return ByteString::from_utf8_without_validation("Never"sv);default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
@@ -5934,104 +5364,66 @@ break;
 }
 JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>> Jakt::types::Type::generic_parameters(NonnullRefPtr<Jakt::types::CheckedProgram> const program) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>>, JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>>>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>>>(program->get_struct(id).generic_parameters));
-};/*case end*/
+return static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>>>(program->get_struct(id).generic_parameters);};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>>>(program->get_struct(id).generic_parameters));
-};/*case end*/
+return static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>>>(program->get_struct(id).generic_parameters);};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>>>(program->get_enum(id).generic_parameters));
-};/*case end*/
+return static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>>>(program->get_enum(id).generic_parameters);};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>>>(program->get_enum(id).generic_parameters));
-};/*case end*/
+return static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>>>(program->get_enum(id).generic_parameters);};/*case end*/
 case 26 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>>>(program->get_trait(id)->generic_parameters));
-};/*case end*/
+return static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>>>(program->get_trait(id)->generic_parameters);};/*case end*/
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>>>(program->get_trait(id)->generic_parameters));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::types::CheckedGenericParameter>>>(program->get_trait(id)->generic_parameters);};/*case end*/
+default:return JaktInternal::OptionalNone();}/*switch end*/
+}
 }
 }
 
 bool Jakt::types::Type::is_boxed(NonnullRefPtr<Jakt::types::CheckedProgram> const program) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_struct(struct_id).record_type.__jakt_init_index() == 1 /* Class */);
-};/*case end*/
+return program->get_struct(struct_id).record_type.__jakt_init_index() == 1 /* Class */;};/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& struct_id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(program->get_struct(struct_id).record_type.__jakt_init_index() == 1 /* Class */);
-};/*case end*/
+return program->get_struct(struct_id).record_type.__jakt_init_index() == 1 /* Class */;};/*case end*/
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(program->get_enum(enum_id).is_boxed);
-};/*case end*/
+return program->get_enum(enum_id).is_boxed;};/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& enum_id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(program->get_enum(enum_id).is_boxed);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return program->get_enum(enum_id).is_boxed;};/*case end*/
+default:return false;}/*switch end*/
+}
 }
 }
 
 bool Jakt::types::Type::is_concrete() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 18 /* TypeVariable */:case 30 /* Self */:case 19 /* Dependent */:case 26 /* Trait */:case 22 /* GenericTraitInstance */:case 16 /* Unknown */:return JaktInternal::ExplicitValue(false);
-default:return JaktInternal::ExplicitValue(true);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 18 /* TypeVariable */:case 30 /* Self */:case 19 /* Dependent */:case 26 /* Trait */:case 22 /* GenericTraitInstance */:case 16 /* Unknown */:return false;default:return true;}/*switch end*/
+}
 }
 }
 
 i64 Jakt::types::Type::specificity(NonnullRefPtr<Jakt::types::CheckedProgram> const program,i64 const base_specificity) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<i64, i64>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 18 /* TypeVariable */:return JaktInternal::ExplicitValue(static_cast<i64>(0LL));
-case 19 /* Dependent */: {
+case 18 /* TypeVariable */:return static_cast<i64>(0LL);case 19 /* Dependent */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dependent;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
 {
 i64 specificity = JaktInternal::checked_div(base_specificity,static_cast<i64>(2LL));
@@ -6051,12 +5443,11 @@ specificity += subtype->specificity(program,JaktInternal::checked_div(base_speci
 }
 }
 
-return JaktInternal::ExplicitValue<i64>(specificity);
+return specificity;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-case 31 /* Const */:return JaktInternal::ExplicitValue(base_specificity);
-case 20 /* GenericInstance */: {
+case 31 /* Const */:return base_specificity;case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
 {
 i64 specificity = JaktInternal::checked_div(base_specificity,static_cast<i64>(2LL));
@@ -6076,7 +5467,7 @@ specificity += subtype->specificity(program,JaktInternal::checked_div(base_speci
 }
 }
 
-return JaktInternal::ExplicitValue<i64>(specificity);
+return specificity;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -6100,7 +5491,7 @@ specificity += subtype->specificity(program,JaktInternal::checked_div(base_speci
 }
 }
 
-return JaktInternal::ExplicitValue<i64>(specificity);
+return specificity;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -6124,66 +5515,21 @@ specificity += subtype->specificity(program,JaktInternal::checked_div(base_speci
 }
 }
 
-return JaktInternal::ExplicitValue<i64>(specificity);
+return specificity;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(base_specificity);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return base_specificity;}/*switch end*/
+}
 }
 }
 
 ByteString Jakt::types::Type::constructor_name() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ByteString>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Void */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Void"sv));
-case 1 /* Bool */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Bool"sv));
-case 2 /* U8 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("U8"sv));
-case 3 /* U16 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("U16"sv));
-case 4 /* U32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("U32"sv));
-case 5 /* U64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("U64"sv));
-case 6 /* I8 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("I8"sv));
-case 7 /* I16 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("I16"sv));
-case 8 /* I32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("I32"sv));
-case 9 /* I64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("I64"sv));
-case 10 /* F32 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("F32"sv));
-case 11 /* F64 */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("F64"sv));
-case 12 /* Usize */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Usize"sv));
-case 13 /* JaktString */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("JaktString"sv));
-case 14 /* CChar */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("CChar"sv));
-case 15 /* CInt */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("CInt"sv));
-case 16 /* Unknown */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Unknown"sv));
-case 17 /* Never */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Never"sv));
-case 18 /* TypeVariable */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("TypeVariable"sv));
-case 19 /* Dependent */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Dependent"sv));
-case 20 /* GenericInstance */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("GenericInstance"sv));
-case 21 /* GenericEnumInstance */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("GenericEnumInstance"sv));
-case 22 /* GenericTraitInstance */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("GenericTraitInstance"sv));
-case 23 /* Struct */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Struct"sv));
-case 24 /* Enum */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Enum"sv));
-case 25 /* RawPtr */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("RawPtr"sv));
-case 26 /* Trait */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Trait"sv));
-case 27 /* Reference */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Reference"sv));
-case 28 /* MutableReference */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("MutableReference"sv));
-case 29 /* Function */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Function"sv));
-case 30 /* Self */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Self"sv));
-case 31 /* Const */:return JaktInternal::ExplicitValue(ByteString::from_utf8_without_validation("Const"sv));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 0 /* Void */:return ByteString::from_utf8_without_validation("Void"sv);case 1 /* Bool */:return ByteString::from_utf8_without_validation("Bool"sv);case 2 /* U8 */:return ByteString::from_utf8_without_validation("U8"sv);case 3 /* U16 */:return ByteString::from_utf8_without_validation("U16"sv);case 4 /* U32 */:return ByteString::from_utf8_without_validation("U32"sv);case 5 /* U64 */:return ByteString::from_utf8_without_validation("U64"sv);case 6 /* I8 */:return ByteString::from_utf8_without_validation("I8"sv);case 7 /* I16 */:return ByteString::from_utf8_without_validation("I16"sv);case 8 /* I32 */:return ByteString::from_utf8_without_validation("I32"sv);case 9 /* I64 */:return ByteString::from_utf8_without_validation("I64"sv);case 10 /* F32 */:return ByteString::from_utf8_without_validation("F32"sv);case 11 /* F64 */:return ByteString::from_utf8_without_validation("F64"sv);case 12 /* Usize */:return ByteString::from_utf8_without_validation("Usize"sv);case 13 /* JaktString */:return ByteString::from_utf8_without_validation("JaktString"sv);case 14 /* CChar */:return ByteString::from_utf8_without_validation("CChar"sv);case 15 /* CInt */:return ByteString::from_utf8_without_validation("CInt"sv);case 16 /* Unknown */:return ByteString::from_utf8_without_validation("Unknown"sv);case 17 /* Never */:return ByteString::from_utf8_without_validation("Never"sv);case 18 /* TypeVariable */:return ByteString::from_utf8_without_validation("TypeVariable"sv);case 19 /* Dependent */:return ByteString::from_utf8_without_validation("Dependent"sv);case 20 /* GenericInstance */:return ByteString::from_utf8_without_validation("GenericInstance"sv);case 21 /* GenericEnumInstance */:return ByteString::from_utf8_without_validation("GenericEnumInstance"sv);case 22 /* GenericTraitInstance */:return ByteString::from_utf8_without_validation("GenericTraitInstance"sv);case 23 /* Struct */:return ByteString::from_utf8_without_validation("Struct"sv);case 24 /* Enum */:return ByteString::from_utf8_without_validation("Enum"sv);case 25 /* RawPtr */:return ByteString::from_utf8_without_validation("RawPtr"sv);case 26 /* Trait */:return ByteString::from_utf8_without_validation("Trait"sv);case 27 /* Reference */:return ByteString::from_utf8_without_validation("Reference"sv);case 28 /* MutableReference */:return ByteString::from_utf8_without_validation("MutableReference"sv);case 29 /* Function */:return ByteString::from_utf8_without_validation("Function"sv);case 30 /* Self */:return ByteString::from_utf8_without_validation("Self"sv);case 31 /* Const */:return ByteString::from_utf8_without_validation("Const"sv);default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
@@ -6215,9 +5561,9 @@ case 17 /* Never */:return JaktInternal::ExplicitValue(rhs->__jakt_init_index() 
 case 18 /* TypeVariable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeVariable;ByteString const& lhs_name = __jakt_match_value.name;
 {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp45 = rhs;
-if (__jakt_tmp45->__jakt_init_index() == 18 /* TypeVariable */){
-ByteString const rhs_name = __jakt_tmp45->as.TypeVariable.name;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp44 = rhs;
+if (__jakt_tmp44->__jakt_init_index() == 18 /* TypeVariable */){
+ByteString const rhs_name = __jakt_tmp44->as.TypeVariable.name;
 return lhs_name == rhs_name;
 }
 return JaktInternal::ExplicitValue<bool>(false);
@@ -6229,11 +5575,11 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Dependent;Jakt::ids::TypeId 
 ByteString const& name = __jakt_match_value.name;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& args = __jakt_match_value.args;
 {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp46 = rhs;
-if (__jakt_tmp46->__jakt_init_index() == 19 /* Dependent */){
-Jakt::ids::TypeId const rhs_namespace_type = __jakt_tmp46->as.Dependent.namespace_type;
-ByteString const rhs_name = __jakt_tmp46->as.Dependent.name;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const rhs_args = __jakt_tmp46->as.Dependent.args;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp45 = rhs;
+if (__jakt_tmp45->__jakt_init_index() == 19 /* Dependent */){
+Jakt::ids::TypeId const rhs_namespace_type = __jakt_tmp45->as.Dependent.namespace_type;
+ByteString const rhs_name = __jakt_tmp45->as.Dependent.name;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const rhs_args = __jakt_tmp45->as.Dependent.args;
 if (namespace_type.equals(rhs_namespace_type) && (name == rhs_name)){
 if (args.size() == rhs_args.size()){
 {
@@ -6249,7 +5595,7 @@ if ([](Jakt::ids::TypeId const& self, Jakt::ids::TypeId rhs) -> bool {{
 return !self.equals(rhs);
 }
 }
-(args.operator[](idx),rhs_args.operator[](idx))){
+(args[idx],rhs_args[idx])){
 return false;
 }
 }
@@ -6275,31 +5621,23 @@ VERIFY_NOT_REACHED();
 };/*case end*/
 case 31 /* Const */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Const;Jakt::types::Value const& lhs_value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *rhs;
+return JaktInternal::ExplicitValue([&]() -> bool { auto&& __jakt_match_variant = *rhs;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 31 /* Const */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Const;Jakt::types::Value const& rhs_value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(lhs_value.impl->equals(rhs_value.impl));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+return lhs_value.impl->equals(rhs_value.impl);};/*case end*/
+default:return false;}/*switch end*/
+ 
+}());
 };/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;Jakt::ids::StructId const& lhs_id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& lhs_args = __jakt_match_value.args;
 {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp47 = rhs;
-if (__jakt_tmp47->__jakt_init_index() == 20 /* GenericInstance */){
-Jakt::ids::StructId const rhs_id = __jakt_tmp47->as.GenericInstance.id;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const rhs_args = __jakt_tmp47->as.GenericInstance.args;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp46 = rhs;
+if (__jakt_tmp46->__jakt_init_index() == 20 /* GenericInstance */){
+Jakt::ids::StructId const rhs_id = __jakt_tmp46->as.GenericInstance.id;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const rhs_args = __jakt_tmp46->as.GenericInstance.args;
 if (lhs_id.equals(rhs_id) && (lhs_args.size() == rhs_args.size())){
 size_t idx = static_cast<size_t>(0ULL);
 while (idx < lhs_args.size()){
@@ -6307,7 +5645,7 @@ if ([](Jakt::ids::TypeId const& self, Jakt::ids::TypeId rhs) -> bool {{
 return !self.equals(rhs);
 }
 }
-(lhs_args.operator[](idx),rhs_args.operator[](idx))){
+(lhs_args[idx],rhs_args[idx])){
 return false;
 }
 idx++;
@@ -6329,14 +5667,14 @@ case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;Jakt::ids::TraitId const& lhs_id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& lhs_args = __jakt_match_value.args;
 {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp48 = rhs;
-if (__jakt_tmp48->__jakt_init_index() == 22 /* GenericTraitInstance */){
-Jakt::ids::TraitId const rhs_id = __jakt_tmp48->as.GenericTraitInstance.id;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const rhs_args = __jakt_tmp48->as.GenericTraitInstance.args;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp47 = rhs;
+if (__jakt_tmp47->__jakt_init_index() == 22 /* GenericTraitInstance */){
+Jakt::ids::TraitId const rhs_id = __jakt_tmp47->as.GenericTraitInstance.id;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const rhs_args = __jakt_tmp47->as.GenericTraitInstance.args;
 if (lhs_id.equals(rhs_id) && (lhs_args.size() == rhs_args.size())){
 size_t idx = static_cast<size_t>(0ULL);
 while (idx < lhs_args.size()){
-if (!lhs_args.operator[](idx).equals(rhs_args.operator[](idx))){
+if (!lhs_args[idx].equals(rhs_args[idx])){
 return false;
 }
 idx++;
@@ -6358,14 +5696,14 @@ case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;Jakt::ids::EnumId const& lhs_id = __jakt_match_value.id;
 JaktInternal::DynamicArray<Jakt::ids::TypeId> const& lhs_args = __jakt_match_value.args;
 {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp49 = rhs;
-if (__jakt_tmp49->__jakt_init_index() == 21 /* GenericEnumInstance */){
-Jakt::ids::EnumId const rhs_id = __jakt_tmp49->as.GenericEnumInstance.id;
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const rhs_args = __jakt_tmp49->as.GenericEnumInstance.args;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp48 = rhs;
+if (__jakt_tmp48->__jakt_init_index() == 21 /* GenericEnumInstance */){
+Jakt::ids::EnumId const rhs_id = __jakt_tmp48->as.GenericEnumInstance.id;
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const rhs_args = __jakt_tmp48->as.GenericEnumInstance.args;
 if (lhs_id.equals(rhs_id) && (lhs_args.size() == rhs_args.size())){
 size_t idx = static_cast<size_t>(0ULL);
 while (idx < lhs_args.size()){
-if (!lhs_args.operator[](idx).equals(rhs_args.operator[](idx))){
+if (!lhs_args[idx].equals(rhs_args[idx])){
 return false;
 }
 idx++;
@@ -6386,9 +5724,9 @@ return false;
 case 23 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& lhs_id = __jakt_match_value.value;
 {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp50 = rhs;
-if (__jakt_tmp50->__jakt_init_index() == 23 /* Struct */){
-Jakt::ids::StructId const rhs_id = __jakt_tmp50->as.Struct.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp49 = rhs;
+if (__jakt_tmp49->__jakt_init_index() == 23 /* Struct */){
+Jakt::ids::StructId const rhs_id = __jakt_tmp49->as.Struct.value;
 return lhs_id.equals(rhs_id);
 }
 return false;
@@ -6397,9 +5735,9 @@ return false;
 case 24 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& lhs_id = __jakt_match_value.value;
 {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp51 = rhs;
-if (__jakt_tmp51->__jakt_init_index() == 24 /* Enum */){
-Jakt::ids::EnumId const rhs_id = __jakt_tmp51->as.Enum.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp50 = rhs;
+if (__jakt_tmp50->__jakt_init_index() == 24 /* Enum */){
+Jakt::ids::EnumId const rhs_id = __jakt_tmp50->as.Enum.value;
 return lhs_id.equals(rhs_id);
 }
 return false;
@@ -6408,9 +5746,9 @@ return false;
 case 25 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;Jakt::ids::TypeId const& lhs_id = __jakt_match_value.value;
 {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp52 = rhs;
-if (__jakt_tmp52->__jakt_init_index() == 25 /* RawPtr */){
-Jakt::ids::TypeId const rhs_id = __jakt_tmp52->as.RawPtr.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp51 = rhs;
+if (__jakt_tmp51->__jakt_init_index() == 25 /* RawPtr */){
+Jakt::ids::TypeId const rhs_id = __jakt_tmp51->as.RawPtr.value;
 return lhs_id.equals(rhs_id);
 }
 return false;
@@ -6419,9 +5757,9 @@ return false;
 case 27 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;Jakt::ids::TypeId const& lhs_id = __jakt_match_value.value;
 {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp53 = rhs;
-if (__jakt_tmp53->__jakt_init_index() == 27 /* Reference */){
-Jakt::ids::TypeId const rhs_id = __jakt_tmp53->as.Reference.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp52 = rhs;
+if (__jakt_tmp52->__jakt_init_index() == 27 /* Reference */){
+Jakt::ids::TypeId const rhs_id = __jakt_tmp52->as.Reference.value;
 return lhs_id.equals(rhs_id);
 }
 return false;
@@ -6430,9 +5768,9 @@ return false;
 case 28 /* MutableReference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MutableReference;Jakt::ids::TypeId const& lhs_id = __jakt_match_value.value;
 {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp54 = rhs;
-if (__jakt_tmp54->__jakt_init_index() == 28 /* MutableReference */){
-Jakt::ids::TypeId const rhs_id = __jakt_tmp54->as.MutableReference.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp53 = rhs;
+if (__jakt_tmp53->__jakt_init_index() == 28 /* MutableReference */){
+Jakt::ids::TypeId const rhs_id = __jakt_tmp53->as.MutableReference.value;
 return lhs_id.equals(rhs_id);
 }
 return false;
@@ -6441,9 +5779,9 @@ return false;
 case 26 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;Jakt::ids::TraitId const& lhs_id = __jakt_match_value.value;
 {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp55 = rhs;
-if (__jakt_tmp55->__jakt_init_index() == 26 /* Trait */){
-Jakt::ids::TraitId const rhs_id = __jakt_tmp55->as.Trait.value;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp54 = rhs;
+if (__jakt_tmp54->__jakt_init_index() == 26 /* Trait */){
+Jakt::ids::TraitId const rhs_id = __jakt_tmp54->as.Trait.value;
 return lhs_id.equals(rhs_id);
 }
 return false;
@@ -6454,11 +5792,11 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::Dynam
 bool const& can_throw = __jakt_match_value.can_throw;
 Jakt::ids::TypeId const& return_type_id = __jakt_match_value.return_type_id;
 {
-NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp56 = rhs;
-if (__jakt_tmp56->__jakt_init_index() == 29 /* Function */){
-JaktInternal::DynamicArray<Jakt::ids::TypeId> const rhs_params = __jakt_tmp56->as.Function.params;
-bool const rhs_can_throw = __jakt_tmp56->as.Function.can_throw;
-Jakt::ids::TypeId const rhs_return_type_id = __jakt_tmp56->as.Function.return_type_id;
+NonnullRefPtr<typename Jakt::types::Type> __jakt_tmp55 = rhs;
+if (__jakt_tmp55->__jakt_init_index() == 29 /* Function */){
+JaktInternal::DynamicArray<Jakt::ids::TypeId> const rhs_params = __jakt_tmp55->as.Function.params;
+bool const rhs_can_throw = __jakt_tmp55->as.Function.can_throw;
+Jakt::ids::TypeId const rhs_return_type_id = __jakt_tmp55->as.Function.return_type_id;
 if ((params.size() == rhs_params.size()) && (return_type_id.equals(rhs_return_type_id) && (can_throw == rhs_can_throw))){
 {
 JaktInternal::Range<size_t> _magic = JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(params.size())};
@@ -6469,7 +5807,7 @@ break;
 }
 size_t i = _magic_value.value();
 {
-if (!params.operator[](i).equals(rhs_params.operator[](i))){
+if (!params[i].equals(rhs_params[i])){
 return false;
 }
 }
@@ -6502,55 +5840,28 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 
 bool Jakt::types::Type::is_builtin() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Void */:case 1 /* Bool */:case 2 /* U8 */:case 3 /* U16 */:case 4 /* U32 */:case 5 /* U64 */:case 6 /* I8 */:case 7 /* I16 */:case 8 /* I32 */:case 9 /* I64 */:case 10 /* F32 */:case 11 /* F64 */:case 12 /* Usize */:case 13 /* JaktString */:case 14 /* CChar */:case 15 /* CInt */:return JaktInternal::ExplicitValue(true);
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 0 /* Void */:case 1 /* Bool */:case 2 /* U8 */:case 3 /* U16 */:case 4 /* U32 */:case 5 /* U64 */:case 6 /* I8 */:case 7 /* I16 */:case 8 /* I32 */:case 9 /* I64 */:case 10 /* F32 */:case 11 /* F64 */:case 12 /* Usize */:case 13 /* JaktString */:case 14 /* CChar */:case 15 /* CInt */:return true;default:return false;}/*switch end*/
+}
 }
 }
 
 bool Jakt::types::Type::is_integer() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* U8 */:case 3 /* U16 */:case 4 /* U32 */:case 5 /* U64 */:case 6 /* I8 */:case 7 /* I16 */:case 8 /* I32 */:case 9 /* I64 */:case 14 /* CChar */:case 15 /* CInt */:case 12 /* Usize */:return JaktInternal::ExplicitValue(true);
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 2 /* U8 */:case 3 /* U16 */:case 4 /* U32 */:case 5 /* U64 */:case 6 /* I8 */:case 7 /* I16 */:case 8 /* I32 */:case 9 /* I64 */:case 14 /* CChar */:case 15 /* CInt */:case 12 /* Usize */:return true;default:return false;}/*switch end*/
+}
 }
 }
 
 bool Jakt::types::Type::is_floating() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 10 /* F32 */:case 11 /* F64 */:return JaktInternal::ExplicitValue(true);
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 10 /* F32 */:case 11 /* F64 */:return true;default:return false;}/*switch end*/
+}
 }
 }
 
@@ -6562,157 +5873,59 @@ return this->is_integer() || this->is_floating();
 
 Jakt::types::BuiltinType Jakt::types::Type::as_builtin_type() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BuiltinType, Jakt::types::BuiltinType>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Void */:return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::Void());
-case 1 /* Bool */:return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::Bool());
-case 2 /* U8 */:return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::U8());
-case 3 /* U16 */:return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::U16());
-case 4 /* U32 */:return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::U32());
-case 5 /* U64 */:return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::U64());
-case 6 /* I8 */:return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::I8());
-case 7 /* I16 */:return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::I16());
-case 8 /* I32 */:return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::I32());
-case 9 /* I64 */:return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::I64());
-case 10 /* F32 */:return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::F32());
-case 11 /* F64 */:return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::F64());
-case 12 /* Usize */:return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::Usize());
-case 13 /* JaktString */:return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::JaktString());
-case 14 /* CChar */:return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::CChar());
-case 15 /* CInt */:return JaktInternal::ExplicitValue(Jakt::types::BuiltinType::CInt());
-default:{
+case 0 /* Void */:return Jakt::types::BuiltinType::Void();case 1 /* Bool */:return Jakt::types::BuiltinType::Bool();case 2 /* U8 */:return Jakt::types::BuiltinType::U8();case 3 /* U16 */:return Jakt::types::BuiltinType::U16();case 4 /* U32 */:return Jakt::types::BuiltinType::U32();case 5 /* U64 */:return Jakt::types::BuiltinType::U64();case 6 /* I8 */:return Jakt::types::BuiltinType::I8();case 7 /* I16 */:return Jakt::types::BuiltinType::I16();case 8 /* I32 */:return Jakt::types::BuiltinType::I32();case 9 /* I64 */:return Jakt::types::BuiltinType::I64();case 10 /* F32 */:return Jakt::types::BuiltinType::F32();case 11 /* F64 */:return Jakt::types::BuiltinType::F64();case 12 /* Usize */:return Jakt::types::BuiltinType::Usize();case 13 /* JaktString */:return Jakt::types::BuiltinType::JaktString();case 14 /* CChar */:return Jakt::types::BuiltinType::CChar();case 15 /* CInt */:return Jakt::types::BuiltinType::CInt();default:{
 warnln(StringView::from_string_literal("Type.as_builtin_type: Not a builtin type: {}"sv),*this);
 Jakt::abort();
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 i64 Jakt::types::Type::get_bits() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<i64, i64>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* U8 */:case 6 /* I8 */:case 14 /* CChar */:return JaktInternal::ExplicitValue(static_cast<i64>(8LL));
-case 3 /* U16 */:case 7 /* I16 */:return JaktInternal::ExplicitValue(static_cast<i64>(16LL));
-case 4 /* U32 */:case 8 /* I32 */:case 15 /* CInt */:return JaktInternal::ExplicitValue(static_cast<i64>(32LL));
-case 5 /* U64 */:case 9 /* I64 */:case 12 /* Usize */:return JaktInternal::ExplicitValue(static_cast<i64>(64LL));
-case 10 /* F32 */:return JaktInternal::ExplicitValue(static_cast<i64>(32LL));
-case 11 /* F64 */:return JaktInternal::ExplicitValue(static_cast<i64>(64LL));
-default:return JaktInternal::ExplicitValue(static_cast<i64>(0LL));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 2 /* U8 */:case 6 /* I8 */:case 14 /* CChar */:return static_cast<i64>(8LL);case 3 /* U16 */:case 7 /* I16 */:return static_cast<i64>(16LL);case 4 /* U32 */:case 8 /* I32 */:case 15 /* CInt */:return static_cast<i64>(32LL);case 5 /* U64 */:case 9 /* I64 */:case 12 /* Usize */:return static_cast<i64>(64LL);case 10 /* F32 */:return static_cast<i64>(32LL);case 11 /* F64 */:return static_cast<i64>(64LL);default:return static_cast<i64>(0LL);}/*switch end*/
+}
 }
 }
 
 bool Jakt::types::Type::is_signed() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 6 /* I8 */:case 7 /* I16 */:case 8 /* I32 */:case 9 /* I64 */:case 14 /* CChar */:case 15 /* CInt */:return JaktInternal::ExplicitValue(true);
-case 2 /* U8 */:case 3 /* U16 */:case 4 /* U32 */:case 5 /* U64 */:case 12 /* Usize */:return JaktInternal::ExplicitValue(false);
-case 10 /* F32 */:case 11 /* F64 */:return JaktInternal::ExplicitValue(true);
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 6 /* I8 */:case 7 /* I16 */:case 8 /* I32 */:case 9 /* I64 */:case 14 /* CChar */:case 15 /* CInt */:return true;case 2 /* U8 */:case 3 /* U16 */:case 4 /* U32 */:case 5 /* U64 */:case 12 /* Usize */:return false;case 10 /* F32 */:case 11 /* F64 */:return true;default:return false;}/*switch end*/
+}
 }
 }
 
 i64 Jakt::types::Type::min() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<i64, i64>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 14 /* CChar */:return JaktInternal::ExplicitValue(-static_cast<i64>(128LL));
-case 15 /* CInt */:return JaktInternal::ExplicitValue(-static_cast<i64>(2147483648LL));
-case 6 /* I8 */:return JaktInternal::ExplicitValue(-static_cast<i64>(128LL));
-case 7 /* I16 */:return JaktInternal::ExplicitValue(-static_cast<i64>(32768LL));
-case 8 /* I32 */:return JaktInternal::ExplicitValue(-static_cast<i64>(2147483648LL));
-case 9 /* I64 */:return JaktInternal::ExplicitValue(JaktInternal::checked_sub((-static_cast<i64>(9223372036854775807LL)),static_cast<i64>(1LL)));
-case 2 /* U8 */:case 3 /* U16 */:case 4 /* U32 */:case 5 /* U64 */:case 12 /* Usize */:return JaktInternal::ExplicitValue(static_cast<i64>(0LL));
-default:return JaktInternal::ExplicitValue(static_cast<i64>(0LL));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 14 /* CChar */:return -static_cast<i64>(128LL);case 15 /* CInt */:return -static_cast<i64>(2147483648LL);case 6 /* I8 */:return -static_cast<i64>(128LL);case 7 /* I16 */:return -static_cast<i64>(32768LL);case 8 /* I32 */:return -static_cast<i64>(2147483648LL);case 9 /* I64 */:return JaktInternal::checked_sub((-static_cast<i64>(9223372036854775807LL)),static_cast<i64>(1LL));case 2 /* U8 */:case 3 /* U16 */:case 4 /* U32 */:case 5 /* U64 */:case 12 /* Usize */:return static_cast<i64>(0LL);default:return static_cast<i64>(0LL);}/*switch end*/
+}
 }
 }
 
 u64 Jakt::types::Type::max() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<u64, u64>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 14 /* CChar */:return JaktInternal::ExplicitValue(static_cast<u64>(127ULL));
-case 15 /* CInt */:return JaktInternal::ExplicitValue(static_cast<u64>(2147483647ULL));
-case 6 /* I8 */:return JaktInternal::ExplicitValue(static_cast<u64>(127ULL));
-case 7 /* I16 */:return JaktInternal::ExplicitValue(static_cast<u64>(32767ULL));
-case 8 /* I32 */:return JaktInternal::ExplicitValue(static_cast<u64>(2147483647ULL));
-case 9 /* I64 */:return JaktInternal::ExplicitValue(static_cast<u64>(9223372036854775807ULL));
-case 2 /* U8 */:return JaktInternal::ExplicitValue(static_cast<u64>(255ULL));
-case 3 /* U16 */:return JaktInternal::ExplicitValue(static_cast<u64>(65535ULL));
-case 4 /* U32 */:return JaktInternal::ExplicitValue(static_cast<u64>(4294967295ULL));
-case 5 /* U64 */:return JaktInternal::ExplicitValue(static_cast<u64>(18446744073709551615ULL));
-case 12 /* Usize */:return JaktInternal::ExplicitValue(static_cast<u64>(18446744073709551615ULL));
-default:return JaktInternal::ExplicitValue(static_cast<u64>(0ULL));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 14 /* CChar */:return static_cast<u64>(127ULL);case 15 /* CInt */:return static_cast<u64>(2147483647ULL);case 6 /* I8 */:return static_cast<u64>(127ULL);case 7 /* I16 */:return static_cast<u64>(32767ULL);case 8 /* I32 */:return static_cast<u64>(2147483647ULL);case 9 /* I64 */:return static_cast<u64>(9223372036854775807ULL);case 2 /* U8 */:return static_cast<u64>(255ULL);case 3 /* U16 */:return static_cast<u64>(65535ULL);case 4 /* U32 */:return static_cast<u64>(4294967295ULL);case 5 /* U64 */:return static_cast<u64>(18446744073709551615ULL);case 12 /* Usize */:return static_cast<u64>(18446744073709551615ULL);default:return static_cast<u64>(0ULL);}/*switch end*/
+}
 }
 }
 
 Jakt::ids::TypeId Jakt::types::Type::flip_signedness() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId, Jakt::ids::TypeId>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 6 /* I8 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::U8()));
-case 7 /* I16 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::U16()));
-case 8 /* I32 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::U32()));
-case 9 /* I64 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::U64()));
-case 2 /* U8 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::I8()));
-case 3 /* U16 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::I16()));
-case 4 /* U32 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::I32()));
-case 5 /* U64 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::I64()));
-default:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::Unknown()));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 6 /* I8 */:return Jakt::types::builtin(Jakt::types::BuiltinType::U8());case 7 /* I16 */:return Jakt::types::builtin(Jakt::types::BuiltinType::U16());case 8 /* I32 */:return Jakt::types::builtin(Jakt::types::BuiltinType::U32());case 9 /* I64 */:return Jakt::types::builtin(Jakt::types::BuiltinType::U64());case 2 /* U8 */:return Jakt::types::builtin(Jakt::types::BuiltinType::I8());case 3 /* U16 */:return Jakt::types::builtin(Jakt::types::BuiltinType::I16());case 4 /* U32 */:return Jakt::types::builtin(Jakt::types::BuiltinType::I32());case 5 /* U64 */:return Jakt::types::builtin(Jakt::types::BuiltinType::I64());default:return Jakt::types::builtin(Jakt::types::BuiltinType::Unknown());}/*switch end*/
+}
 }
 }
 
@@ -6981,22 +6194,19 @@ break;
 }
 ErrorOr<NonnullRefPtr<typename Jakt::types::MaybeResolvedScope>> Jakt::types::MaybeResolvedScope::try_resolve(NonnullRefPtr<Jakt::types::CheckedProgram> const program) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::MaybeResolvedScope>, ErrorOr<NonnullRefPtr<typename Jakt::types::MaybeResolvedScope>>>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Resolved */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Resolved;Jakt::ids::ScopeId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::MaybeResolvedScope::Resolved(id));
-};/*case end*/
+return Jakt::types::MaybeResolvedScope::Resolved(id);};/*case end*/
 case 1 /* Unresolved */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unresolved;NonnullRefPtr<typename Jakt::types::MaybeResolvedScope> const& parent_scope = __jakt_match_value.parent_scope;
 ByteString const& relative_name = __jakt_match_value.relative_name;
 {
 NonnullRefPtr<typename Jakt::types::MaybeResolvedScope> parent = TRY((parent_scope->try_resolve(program)));
-NonnullRefPtr<typename Jakt::types::MaybeResolvedScope> __jakt_tmp57 = parent;
-if (__jakt_tmp57->__jakt_init_index() == 0 /* Resolved */){
-Jakt::ids::ScopeId const parent_scope_id = __jakt_tmp57->as.Resolved.value;
+NonnullRefPtr<typename Jakt::types::MaybeResolvedScope> __jakt_tmp56 = parent;
+if (__jakt_tmp56->__jakt_init_index() == 0 /* Resolved */){
+Jakt::ids::ScopeId const parent_scope_id = __jakt_tmp56->as.Resolved.value;
 Jakt::ids::ScopeId const scope = parent_scope_id;
 JaktInternal::Optional<Jakt::ids::ScopeId> scope_id = JaktInternal::OptionalNone();
 if (!scope_id.has_value()){
@@ -7020,24 +6230,19 @@ scope_id = ns.value().template get<0>();
 if (!scope_id.has_value()){
 JaktInternal::Optional<JaktInternal::DynamicArray<Jakt::ids::FunctionId>> const ids = TRY((program->find_functions_with_name_in_scope(scope,relative_name,false,JaktInternal::OptionalNone())));
 if (ids.has_value()){
-scope_id = program->get_function(ids.value().operator[](static_cast<i64>(0LL)))->function_scope_id;
+scope_id = program->get_function(ids.value()[static_cast<i64>(0LL)])->function_scope_id;
 }
 }
 if (scope_id.has_value()){
 return Jakt::types::MaybeResolvedScope::Resolved(scope_id.value());
 }
 }
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::MaybeResolvedScope>>(Jakt::types::MaybeResolvedScope::Unresolved(parent,relative_name));
+return Jakt::types::MaybeResolvedScope::Unresolved(parent,relative_name);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -7710,600 +6915,322 @@ case 6 /* PartialNeverReturns */:break;
 }
 Jakt::types::BlockControlFlow Jakt::types::BlockControlFlow::unify_with(Jakt::types::BlockControlFlow const second) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* NeverReturns */:return JaktInternal::ExplicitValue(second);
-case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = second;
+case 2 /* NeverReturns */:return second;case 0 /* AlwaysReturns */:{auto&& __jakt_match_variant = second;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysReturns());
-case 1 /* AlwaysTransfersControl */: {
+case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:return Jakt::types::BlockControlFlow::AlwaysReturns();case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break));
-};/*case end*/
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-case 4 /* PartialAlwaysReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysReturns());
-case 5 /* PartialAlwaysTransfersControl */: {
+return Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break);};/*case end*/
+case 3 /* MayReturn */:return Jakt::types::BlockControlFlow::MayReturn();case 4 /* PartialAlwaysReturns */:return Jakt::types::BlockControlFlow::AlwaysReturns();case 5 /* PartialAlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break);};/*case end*/
 case 6 /* PartialNeverReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialNeverReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 1 /* AlwaysTransfersControl */: {
+}case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& lhs = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = second;
+{auto&& __jakt_match_variant = second;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs));
-case 1 /* AlwaysTransfersControl */: {
+case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:return Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs);case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs || might_break));
-};/*case end*/
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs));
-default:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = second;
+return Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs || might_break);};/*case end*/
+case 3 /* MayReturn */:return Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs);default:return Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs);}/*switch end*/
+}};/*case end*/
+case 3 /* MayReturn */:{auto&& __jakt_match_variant = second;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break);};/*case end*/
 case 4 /* PartialAlwaysReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysReturns(might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysReturns(might_break);};/*case end*/
 case 5 /* PartialAlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break);};/*case end*/
 case 6 /* PartialNeverReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialNeverReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialNeverReturns(might_break));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 4 /* PartialAlwaysReturns */: {
+return Jakt::types::BlockControlFlow::PartialNeverReturns(might_break);};/*case end*/
+default:return Jakt::types::BlockControlFlow::MayReturn();}/*switch end*/
+}case 4 /* PartialAlwaysReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysReturns;bool const& lhs = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = second;
+{auto&& __jakt_match_variant = second;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* PartialAlwaysReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysReturns(lhs || might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysReturns(lhs || might_break);};/*case end*/
 case 5 /* PartialAlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(lhs || might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(lhs || might_break);};/*case end*/
 case 6 /* PartialNeverReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialNeverReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(lhs || might_break));
-};/*case end*/
-case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysReturns());
-case 2 /* NeverReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs));
-case 1 /* AlwaysTransfersControl */: {
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(lhs || might_break);};/*case end*/
+case 0 /* AlwaysReturns */:return Jakt::types::BlockControlFlow::AlwaysReturns();case 2 /* NeverReturns */:return Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs);case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs || might_break));
-};/*case end*/
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs || might_break);};/*case end*/
+case 3 /* MayReturn */:return Jakt::types::BlockControlFlow::MayReturn();default: VERIFY_NOT_REACHED();}/*switch end*/
+}};/*case end*/
 case 5 /* PartialAlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysTransfersControl;bool const& lhs = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = second;
+{auto&& __jakt_match_variant = second;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* PartialAlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(lhs || might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(lhs || might_break);};/*case end*/
 case 4 /* PartialAlwaysReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(lhs || might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(lhs || might_break);};/*case end*/
 case 6 /* PartialNeverReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialNeverReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(lhs || might_break));
-};/*case end*/
-case 0 /* AlwaysReturns */:case 2 /* NeverReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs));
-case 1 /* AlwaysTransfersControl */: {
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(lhs || might_break);};/*case end*/
+case 0 /* AlwaysReturns */:case 2 /* NeverReturns */:return Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs);case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs || might_break));
-};/*case end*/
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(lhs));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs || might_break);};/*case end*/
+case 3 /* MayReturn */:return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(lhs);default: VERIFY_NOT_REACHED();}/*switch end*/
+}};/*case end*/
 case 6 /* PartialNeverReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialNeverReturns;bool const& lhs = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = second;
+{auto&& __jakt_match_variant = second;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* PartialNeverReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialNeverReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialNeverReturns(lhs || might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialNeverReturns(lhs || might_break);};/*case end*/
 case 5 /* PartialAlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(lhs || might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(lhs || might_break);};/*case end*/
 case 4 /* PartialAlwaysReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(lhs || might_break));
-};/*case end*/
-case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs));
-case 1 /* AlwaysTransfersControl */: {
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(lhs || might_break);};/*case end*/
+case 0 /* AlwaysReturns */:return Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs);case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs || might_break));
-};/*case end*/
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialNeverReturns(lhs));
-case 2 /* NeverReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::NeverReturns());
+return Jakt::types::BlockControlFlow::AlwaysTransfersControl(lhs || might_break);};/*case end*/
+case 3 /* MayReturn */:return Jakt::types::BlockControlFlow::PartialNeverReturns(lhs);case 2 /* NeverReturns */:return Jakt::types::BlockControlFlow::NeverReturns();default: VERIFY_NOT_REACHED();}/*switch end*/
+}};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 Jakt::types::BlockControlFlow Jakt::types::BlockControlFlow::branch_unify_with(Jakt::types::BlockControlFlow const second) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* NeverReturns */:return JaktInternal::ExplicitValue(second);
-case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = second;
+case 2 /* NeverReturns */:return second;case 0 /* AlwaysReturns */:{auto&& __jakt_match_variant = second;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysReturns());
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-case 1 /* AlwaysTransfersControl */: {
+case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:return Jakt::types::BlockControlFlow::AlwaysReturns();case 3 /* MayReturn */:return Jakt::types::BlockControlFlow::MayReturn();case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break);};/*case end*/
 case 6 /* PartialNeverReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialNeverReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialNeverReturns(might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialNeverReturns(might_break);};/*case end*/
 case 4 /* PartialAlwaysReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysReturns(might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysReturns(might_break);};/*case end*/
 case 5 /* PartialAlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = second;
+}case 3 /* MayReturn */:{auto&& __jakt_match_variant = second;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-case 1 /* AlwaysTransfersControl */: {
+case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:return Jakt::types::BlockControlFlow::MayReturn();case 3 /* MayReturn */:return Jakt::types::BlockControlFlow::MayReturn();case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break);};/*case end*/
 case 6 /* PartialNeverReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialNeverReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialNeverReturns(might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialNeverReturns(might_break);};/*case end*/
 case 4 /* PartialAlwaysReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysReturns(might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysReturns(might_break);};/*case end*/
 case 5 /* PartialAlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-case 6 /* PartialNeverReturns */: {
+}case 6 /* PartialNeverReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialNeverReturns;bool const& this_might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = second;
+{auto&& __jakt_match_variant = second;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialNeverReturns(this_might_break));
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialNeverReturns(this_might_break));
-case 1 /* AlwaysTransfersControl */: {
+case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:return Jakt::types::BlockControlFlow::PartialNeverReturns(this_might_break);case 3 /* MayReturn */:return Jakt::types::BlockControlFlow::PartialNeverReturns(this_might_break);case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break);};/*case end*/
 case 6 /* PartialNeverReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialNeverReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialNeverReturns(might_break || this_might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialNeverReturns(might_break || this_might_break);};/*case end*/
 case 4 /* PartialAlwaysReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysReturns(might_break || this_might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysReturns(might_break || this_might_break);};/*case end*/
 case 5 /* PartialAlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 4 /* PartialAlwaysReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysReturns;bool const& this_might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = second;
+{auto&& __jakt_match_variant = second;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysReturns(this_might_break));
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysReturns(this_might_break));
-case 1 /* AlwaysTransfersControl */: {
+case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:return Jakt::types::BlockControlFlow::PartialAlwaysReturns(this_might_break);case 3 /* MayReturn */:return Jakt::types::BlockControlFlow::PartialAlwaysReturns(this_might_break);case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break);};/*case end*/
 case 6 /* PartialNeverReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialNeverReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysReturns(might_break || this_might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysReturns(might_break || this_might_break);};/*case end*/
 case 4 /* PartialAlwaysReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysReturns(might_break || this_might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysReturns(might_break || this_might_break);};/*case end*/
 case 5 /* PartialAlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 5 /* PartialAlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysTransfersControl;bool const& this_might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = second;
+{auto&& __jakt_match_variant = second;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(this_might_break));
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(this_might_break));
-case 1 /* AlwaysTransfersControl */: {
+case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(this_might_break);case 3 /* MayReturn */:return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(this_might_break);case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break);};/*case end*/
 case 6 /* PartialNeverReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialNeverReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break);};/*case end*/
 case 4 /* PartialAlwaysReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break);};/*case end*/
 case 5 /* PartialAlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& this_might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = second;
+{auto&& __jakt_match_variant = second;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(this_might_break));
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(this_might_break));
-case 1 /* AlwaysTransfersControl */: {
+case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:return Jakt::types::BlockControlFlow::AlwaysTransfersControl(this_might_break);case 3 /* MayReturn */:return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(this_might_break);case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break || this_might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break || this_might_break);};/*case end*/
 case 6 /* PartialNeverReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialNeverReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialNeverReturns(might_break || this_might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialNeverReturns(might_break || this_might_break);};/*case end*/
 case 4 /* PartialAlwaysReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysReturns(might_break || this_might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysReturns(might_break || this_might_break);};/*case end*/
 case 5 /* PartialAlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break || this_might_break);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+}};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 Jakt::types::BlockControlFlow Jakt::types::BlockControlFlow::updated(Jakt::types::BlockControlFlow const second) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* NeverReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::NeverReturns());
-case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysReturns());
-case 1 /* AlwaysTransfersControl */: {
+case 2 /* NeverReturns */:return Jakt::types::BlockControlFlow::NeverReturns();case 0 /* AlwaysReturns */:return Jakt::types::BlockControlFlow::AlwaysReturns();case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break));
-};/*case end*/
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(second);
-case 5 /* PartialAlwaysTransfersControl */:case 4 /* PartialAlwaysReturns */:case 6 /* PartialNeverReturns */:return JaktInternal::ExplicitValue(this->unify_with(second));
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break);};/*case end*/
+case 3 /* MayReturn */:return second;case 5 /* PartialAlwaysTransfersControl */:case 4 /* PartialAlwaysReturns */:case 6 /* PartialNeverReturns */:return this->unify_with(second);default: VERIFY_NOT_REACHED();}/*switch end*/
+}
 }
 }
 
 Jakt::types::BlockControlFlow Jakt::types::BlockControlFlow::partial() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* NeverReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialNeverReturns(false));
-case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysReturns(false));
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-case 1 /* AlwaysTransfersControl */: {
+case 2 /* NeverReturns */:return Jakt::types::BlockControlFlow::PartialNeverReturns(false);case 0 /* AlwaysReturns */:return Jakt::types::BlockControlFlow::PartialAlwaysReturns(false);case 3 /* MayReturn */:return Jakt::types::BlockControlFlow::MayReturn();case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break);};/*case end*/
 case 5 /* PartialAlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysTransfersControl(might_break);};/*case end*/
 case 4 /* PartialAlwaysReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialAlwaysReturns(might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialAlwaysReturns(might_break);};/*case end*/
 case 6 /* PartialNeverReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialNeverReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::PartialNeverReturns(might_break));
-};/*case end*/
+return Jakt::types::BlockControlFlow::PartialNeverReturns(might_break);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 Jakt::types::BlockControlFlow Jakt::types::BlockControlFlow::definitive() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* NeverReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::NeverReturns());
-case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysReturns());
-case 1 /* AlwaysTransfersControl */: {
+case 2 /* NeverReturns */:return Jakt::types::BlockControlFlow::NeverReturns();case 0 /* AlwaysReturns */:return Jakt::types::BlockControlFlow::AlwaysReturns();case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break));
-};/*case end*/
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-default:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break);};/*case end*/
+case 3 /* MayReturn */:return Jakt::types::BlockControlFlow::MayReturn();default:return Jakt::types::BlockControlFlow::MayReturn();}/*switch end*/
+}
 }
 }
 
 bool Jakt::types::BlockControlFlow::always_transfers_control() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* AlwaysReturns */:case 1 /* AlwaysTransfersControl */:return JaktInternal::ExplicitValue(true);
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 0 /* AlwaysReturns */:case 1 /* AlwaysTransfersControl */:return true;default:return false;}/*switch end*/
+}
 }
 }
 
 bool Jakt::types::BlockControlFlow::never_returns() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* NeverReturns */:return JaktInternal::ExplicitValue(true);
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 2 /* NeverReturns */:return true;default:return false;}/*switch end*/
+}
 }
 }
 
 bool Jakt::types::BlockControlFlow::always_returns() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(true);
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 0 /* AlwaysReturns */:return true;default:return false;}/*switch end*/
+}
 }
 }
 
 bool Jakt::types::BlockControlFlow::may_return() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 3 /* MayReturn */:case 4 /* PartialAlwaysReturns */:case 5 /* PartialAlwaysTransfersControl */:case 6 /* PartialNeverReturns */:return JaktInternal::ExplicitValue(true);
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 3 /* MayReturn */:case 4 /* PartialAlwaysReturns */:case 5 /* PartialAlwaysTransfersControl */:case 6 /* PartialNeverReturns */:return true;default:return false;}/*switch end*/
+}
 }
 }
 
 bool Jakt::types::BlockControlFlow::may_break() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* PartialAlwaysReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(might_break);
-};/*case end*/
+return might_break;};/*case end*/
 case 5 /* PartialAlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(might_break);
-};/*case end*/
+return might_break;};/*case end*/
 case 6 /* PartialNeverReturns */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialNeverReturns;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(might_break);
-};/*case end*/
+return might_break;};/*case end*/
 case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(might_break);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return might_break;};/*case end*/
+default:return false;}/*switch end*/
+}
 }
 }
 
 bool Jakt::types::BlockControlFlow::is_reachable() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:case 1 /* AlwaysTransfersControl */:return JaktInternal::ExplicitValue(false);
-default:return JaktInternal::ExplicitValue(true);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+case 2 /* NeverReturns */:case 0 /* AlwaysReturns */:case 1 /* AlwaysTransfersControl */:return false;default:return true;}/*switch end*/
+}
 }
 }
 
@@ -8618,133 +7545,82 @@ break;
 }
 bool Jakt::types::CheckedEnumVariant::equals(Jakt::types::CheckedEnumVariant const other) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Untyped */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Untyped;ByteString const& this_name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = other;
+{auto&& __jakt_match_variant = other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Untyped */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Untyped;ByteString const& other_name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(this_name == other_name);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return this_name == other_name;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
+default:return false;}/*switch end*/
+}
 }
 }
 
 Jakt::ids::EnumId Jakt::types::CheckedEnumVariant::enum_id() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::EnumId, Jakt::ids::EnumId>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Untyped */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Untyped;Jakt::ids::EnumId const& enum_id = __jakt_match_value.enum_id;
-return JaktInternal::ExplicitValue(enum_id);
-};/*case end*/
+return enum_id;};/*case end*/
 case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;Jakt::ids::EnumId const& enum_id = __jakt_match_value.enum_id;
-return JaktInternal::ExplicitValue(enum_id);
-};/*case end*/
+return enum_id;};/*case end*/
 case 2 /* WithValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.WithValue;Jakt::ids::EnumId const& enum_id = __jakt_match_value.enum_id;
-return JaktInternal::ExplicitValue(enum_id);
-};/*case end*/
+return enum_id;};/*case end*/
 case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;Jakt::ids::EnumId const& enum_id = __jakt_match_value.enum_id;
-return JaktInternal::ExplicitValue(enum_id);
-};/*case end*/
+return enum_id;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 Jakt::utility::Span Jakt::types::CheckedEnumVariant::span() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::utility::Span, Jakt::utility::Span>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Untyped */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Untyped;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 2 /* WithValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.WithValue;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 ByteString Jakt::types::CheckedEnumVariant::name() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ByteString>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Untyped */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Untyped;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(name);
-};/*case end*/
+return name;};/*case end*/
 case 1 /* Typed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Typed;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(name);
-};/*case end*/
+return name;};/*case end*/
 case 2 /* WithValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.WithValue;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(name);
-};/*case end*/
+return name;};/*case end*/
 case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(name);
-};/*case end*/
+return name;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -9508,77 +8384,55 @@ break;
 }
 JaktInternal::Optional<Jakt::utility::Span> Jakt::types::CheckedStatement::span() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::utility::Span>, JaktInternal::Optional<Jakt::utility::Span>>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<Jakt::utility::Span>>(span));
-};/*case end*/
+return static_cast<JaktInternal::Optional<Jakt::utility::Span>>(span);};/*case end*/
 case 1 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 2 /* DestructuringAssignment */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DestructuringAssignment;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 3 /* VarDecl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.VarDecl;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 4 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 5 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 6 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 7 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
-case 8 /* Return */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.Return;JaktInternal::Optional<Jakt::utility::Span> const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 9 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 10 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 11 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 12 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 13 /* InlineCpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.InlineCpp;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 14 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;Jakt::utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
+case 8 /* Return */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Return;JaktInternal::Optional<Jakt::utility::Span> const& span = __jakt_match_value.span;
+return span;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -9590,202 +8444,77 @@ return JaktInternal::OptionalNone();
 
 Jakt::types::BlockControlFlow Jakt::types::CheckedStatement::maybe_control_flow(JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const statement,Jakt::types::BlockControlFlow const other_branch) {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow,Jakt::types::BlockControlFlow> {
-auto __jakt_enum_value = (statement.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(statement.value()->control_flow());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(other_branch.partial());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+{auto __jakt_enum_value = statement.has_value();
+if (__jakt_enum_value) {return statement.value()->control_flow();}else if (!__jakt_enum_value) {return other_branch.partial();}VERIFY_NOT_REACHED();
+}
 }
 }
 
 Jakt::types::BlockControlFlow Jakt::types::CheckedStatement::control_flow() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 8 /* Return */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysReturns());
-case 11 /* Throw */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysReturns());
-case 9 /* Break */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(true));
-case 10 /* Continue */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(false));
-case 12 /* Yield */: {
+case 8 /* Return */:return Jakt::types::BlockControlFlow::AlwaysReturns();case 11 /* Throw */:return Jakt::types::BlockControlFlow::AlwaysReturns();case 9 /* Break */:return Jakt::types::BlockControlFlow::AlwaysTransfersControl(true);case 10 /* Continue */:return Jakt::types::BlockControlFlow::AlwaysTransfersControl(false);case 12 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow,Jakt::types::BlockControlFlow> {
-auto __jakt_enum_value = (expr.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(expr.value()->control_flow().updated(Jakt::types::BlockControlFlow::AlwaysTransfersControl(false)));
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(false));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+{auto __jakt_enum_value = expr.has_value();
+if (__jakt_enum_value) {return expr.value()->control_flow().updated(Jakt::types::BlockControlFlow::AlwaysTransfersControl(false));}else if (!__jakt_enum_value) {return Jakt::types::BlockControlFlow::AlwaysTransfersControl(false);}VERIFY_NOT_REACHED();
+}};/*case end*/
 case 4 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& condition = __jakt_match_value.condition;
 Jakt::types::CheckedBlock const& then_block = __jakt_match_value.then_block;
 JaktInternal::Optional<NonnullRefPtr<typename Jakt::types::CheckedStatement>> const& else_statement = __jakt_match_value.else_statement;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = *condition;
+{auto&& __jakt_match_variant = *condition;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Boolean */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boolean;bool const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow,Jakt::types::BlockControlFlow> {
-auto __jakt_enum_value = (val);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(then_block.control_flow);
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow,Jakt::types::BlockControlFlow> {
-auto __jakt_enum_value = (else_statement.has_value());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(else_statement.value()->control_flow());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(then_block.control_flow.branch_unify_with(Jakt::types::CheckedStatement::maybe_control_flow(else_statement,then_block.control_flow)));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+{auto __jakt_enum_value = val;
+if (__jakt_enum_value) {return then_block.control_flow;}else if (!__jakt_enum_value) {{auto __jakt_enum_value = else_statement.has_value();
+if (__jakt_enum_value) {return else_statement.value()->control_flow();}else if (!__jakt_enum_value) {return Jakt::types::BlockControlFlow::MayReturn();}VERIFY_NOT_REACHED();
+}}VERIFY_NOT_REACHED();
+}};/*case end*/
+default:return then_block.control_flow.branch_unify_with(Jakt::types::CheckedStatement::maybe_control_flow(else_statement,then_block.control_flow));}/*switch end*/
+}};/*case end*/
 case 5 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(block.control_flow);
-};/*case end*/
+return block.control_flow;};/*case end*/
 case 7 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& condition = __jakt_match_value.condition;
 Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = *condition;
+{auto&& __jakt_match_variant = *condition;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Boolean */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boolean;bool const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow,Jakt::types::BlockControlFlow> {
-auto __jakt_enum_value = (val);
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = block.control_flow;
+{auto __jakt_enum_value = val;
+if (__jakt_enum_value) {{auto&& __jakt_match_variant = block.control_flow;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysReturns());
-case 2 /* NeverReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::NeverReturns());
-default:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}else {return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+case 0 /* AlwaysReturns */:return Jakt::types::BlockControlFlow::AlwaysReturns();case 2 /* NeverReturns */:return Jakt::types::BlockControlFlow::NeverReturns();default:return Jakt::types::BlockControlFlow::MayReturn();}/*switch end*/
+}}else {return Jakt::types::BlockControlFlow::MayReturn();}}};/*case end*/
+default:return Jakt::types::BlockControlFlow::MayReturn();}/*switch end*/
+}};/*case end*/
 case 6 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = block.control_flow;
+{auto&& __jakt_match_variant = block.control_flow;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* AlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow,Jakt::types::BlockControlFlow> {
-auto __jakt_enum_value = (might_break);
-if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break));
-}else if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-case 2 /* NeverReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::NeverReturns());
-case 0 /* AlwaysReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysReturns());
-case 3 /* MayReturn */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-default:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow,Jakt::types::BlockControlFlow> {
-auto __jakt_enum_value = (block.control_flow.may_break());
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = block.control_flow;
+{auto __jakt_enum_value = might_break;
+if (!__jakt_enum_value) {return Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break);}else if (__jakt_enum_value) {return Jakt::types::BlockControlFlow::MayReturn();}VERIFY_NOT_REACHED();
+}};/*case end*/
+case 2 /* NeverReturns */:return Jakt::types::BlockControlFlow::NeverReturns();case 0 /* AlwaysReturns */:return Jakt::types::BlockControlFlow::AlwaysReturns();case 3 /* MayReturn */:return Jakt::types::BlockControlFlow::MayReturn();default:{auto __jakt_enum_value = block.control_flow.may_break();
+if (__jakt_enum_value) {return Jakt::types::BlockControlFlow::MayReturn();}else if (!__jakt_enum_value) {{auto&& __jakt_match_variant = block.control_flow;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 4 /* PartialAlwaysReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysReturns());
-case 6 /* PartialNeverReturns */:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::NeverReturns());
-case 5 /* PartialAlwaysTransfersControl */: {
+case 4 /* PartialAlwaysReturns */:return Jakt::types::BlockControlFlow::AlwaysReturns();case 6 /* PartialNeverReturns */:return Jakt::types::BlockControlFlow::NeverReturns();case 5 /* PartialAlwaysTransfersControl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PartialAlwaysTransfersControl;bool const& might_break = __jakt_match_value.might_break;
-return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return Jakt::types::BlockControlFlow::AlwaysTransfersControl(might_break);};/*case end*/
+default:return Jakt::types::BlockControlFlow::MayReturn();}/*switch end*/
+}}VERIFY_NOT_REACHED();
+}}/*switch end*/
+}};/*case end*/
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(expr->control_flow());
-};/*case end*/
-default:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return expr->control_flow();};/*case end*/
+default:return Jakt::types::BlockControlFlow::MayReturn();}/*switch end*/
+}
 }
 }
 
@@ -9933,86 +8662,44 @@ case 2 /* Floating */:break;
 bool Jakt::types::NumberConstant::can_fit_number(Jakt::ids::TypeId const type_id,NonnullRefPtr<Jakt::types::CheckedProgram> const program) const {
 {
 NonnullRefPtr<typename Jakt::types::Type> const type_ = program->get_type(type_id);
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Signed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Signed;i64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *type_;
+{auto&& __jakt_match_variant = *type_;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 9 /* I64 */:return JaktInternal::ExplicitValue(true);
-case 5 /* U64 */:case 12 /* Usize */:return JaktInternal::ExplicitValue(value >= static_cast<i64>(0LL));
-default:return JaktInternal::ExplicitValue((program->is_integer(type_id) && (value >= type_->min())) && (value <= infallible_integer_cast<i64>(type_->max())));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+case 9 /* I64 */:return true;case 5 /* U64 */:case 12 /* Usize */:return value >= static_cast<i64>(0LL);default:return (program->is_integer(type_id) && (value >= type_->min())) && (value <= infallible_integer_cast<i64>(type_->max()));}/*switch end*/
+}};/*case end*/
 case 1 /* Unsigned */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsigned;u64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *type_;
+{auto&& __jakt_match_variant = *type_;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 5 /* U64 */:case 12 /* Usize */:return JaktInternal::ExplicitValue(true);
-default:return JaktInternal::ExplicitValue(program->is_integer(type_id) && (value <= type_->max()));
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+case 5 /* U64 */:case 12 /* Usize */:return true;default:return program->is_integer(type_id) && (value <= type_->max());}/*switch end*/
+}};/*case end*/
 case 2 /* Floating */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Floating;f64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *type_;
+{auto&& __jakt_match_variant = *type_;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* F32 */:{
 Jakt::utility::todo(ByteString::from_utf8_without_validation("Implement casting f32 to f64"sv));
 }
-case 11 /* F64 */:return JaktInternal::ExplicitValue(true);
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+case 11 /* F64 */:return true;default:return false;}/*switch end*/
+}};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 size_t Jakt::types::NumberConstant::to_usize() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, size_t>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Signed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Signed;i64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<size_t>(value));
-};/*case end*/
+return infallible_integer_cast<size_t>(value);};/*case end*/
 case 1 /* Unsigned */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsigned;u64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(infallible_integer_cast<size_t>(value));
-};/*case end*/
+return infallible_integer_cast<size_t>(value);};/*case end*/
 case 2 /* Floating */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Floating;f64 const& value = __jakt_match_value.value;
 {
@@ -10020,12 +8707,7 @@ Jakt::utility::panic(ByteString::from_utf8_without_validation("to_usize on a flo
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -10412,58 +9094,40 @@ case 10 /* F64 */:break;
 }
 JaktInternal::Optional<Jakt::types::NumberConstant> Jakt::types::CheckedNumericConstant::number_constant() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::types::NumberConstant>, JaktInternal::Optional<Jakt::types::NumberConstant>>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::NumberConstant::Signed(infallible_integer_cast<i64>(value)));
-};/*case end*/
+return Jakt::types::NumberConstant::Signed(infallible_integer_cast<i64>(value));};/*case end*/
 case 1 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::NumberConstant::Signed(infallible_integer_cast<i64>(value)));
-};/*case end*/
+return Jakt::types::NumberConstant::Signed(infallible_integer_cast<i64>(value));};/*case end*/
 case 2 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::NumberConstant::Signed(infallible_integer_cast<i64>(value)));
-};/*case end*/
+return Jakt::types::NumberConstant::Signed(infallible_integer_cast<i64>(value));};/*case end*/
 case 3 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::NumberConstant::Signed(static_cast<i64>(value)));
-};/*case end*/
+return Jakt::types::NumberConstant::Signed(static_cast<i64>(value));};/*case end*/
 case 4 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::NumberConstant::Unsigned(infallible_integer_cast<u64>(value)));
-};/*case end*/
+return Jakt::types::NumberConstant::Unsigned(infallible_integer_cast<u64>(value));};/*case end*/
 case 5 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::NumberConstant::Unsigned(infallible_integer_cast<u64>(value)));
-};/*case end*/
+return Jakt::types::NumberConstant::Unsigned(infallible_integer_cast<u64>(value));};/*case end*/
 case 6 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::NumberConstant::Unsigned(infallible_integer_cast<u64>(value)));
-};/*case end*/
+return Jakt::types::NumberConstant::Unsigned(infallible_integer_cast<u64>(value));};/*case end*/
 case 7 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::NumberConstant::Unsigned(static_cast<u64>(value)));
-};/*case end*/
+return Jakt::types::NumberConstant::Unsigned(static_cast<u64>(value));};/*case end*/
 case 8 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;u64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::NumberConstant::Unsigned(static_cast<u64>(value)));
-};/*case end*/
+return Jakt::types::NumberConstant::Unsigned(static_cast<u64>(value));};/*case end*/
 case 10 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::NumberConstant::Floating(value));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return Jakt::types::NumberConstant::Floating(value);};/*case end*/
+default:return JaktInternal::OptionalNone();}/*switch end*/
+}
 }
 }
 
@@ -10551,21 +9215,13 @@ break;
 }
 ByteString Jakt::types::StringLiteral::to_string() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ByteString>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Static */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Static;ByteString const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
+return value;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -10715,29 +9371,19 @@ break;
 }
 Jakt::ids::TypeId Jakt::types::CheckedTypeCast::type_id() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId, Jakt::ids::TypeId>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Fallible */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Fallible;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 1 /* Infallible */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Infallible;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 2 /* Identity */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identity;Jakt::ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
@@ -11339,17 +9985,15 @@ JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};
 JaktInternal::PrettyPrint::must_output_indentation(builder);
 builder.appendff("defaults: {}, ", this->common.init_common.defaults);
 JaktInternal::PrettyPrint::must_output_indentation(builder);
+builder.appendff("marker_span: {}, ", this->common.init_common.marker_span);
+JaktInternal::PrettyPrint::must_output_indentation(builder);
 builder.appendff("name: \"{}\", ", that.name);
 JaktInternal::PrettyPrint::must_output_indentation(builder);
 builder.appendff("args: {}, ", that.args);
 JaktInternal::PrettyPrint::must_output_indentation(builder);
 builder.appendff("subject_type_id: {}, ", that.subject_type_id);
 JaktInternal::PrettyPrint::must_output_indentation(builder);
-builder.appendff("index: {}, ", that.index);
-JaktInternal::PrettyPrint::must_output_indentation(builder);
-builder.appendff("scope_id: {}, ", that.scope_id);
-JaktInternal::PrettyPrint::must_output_indentation(builder);
-builder.appendff("marker_span: {}", that.marker_span);
+builder.appendff("index: {}", that.index);
 }
 builder.append(")"sv);
 break;}
@@ -11362,9 +10006,9 @@ JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};
 JaktInternal::PrettyPrint::must_output_indentation(builder);
 builder.appendff("defaults: {}, ", this->common.init_common.defaults);
 JaktInternal::PrettyPrint::must_output_indentation(builder);
-builder.appendff("expression: {}, ", that.expression);
+builder.appendff("marker_span: {}, ", this->common.init_common.marker_span);
 JaktInternal::PrettyPrint::must_output_indentation(builder);
-builder.appendff("marker_span: {}", that.marker_span);
+builder.appendff("expression: {}", that.expression);
 }
 builder.append(")"sv);
 break;}
@@ -11377,11 +10021,11 @@ JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};
 JaktInternal::PrettyPrint::must_output_indentation(builder);
 builder.appendff("defaults: {}, ", this->common.init_common.defaults);
 JaktInternal::PrettyPrint::must_output_indentation(builder);
+builder.appendff("marker_span: {}, ", this->common.init_common.marker_span);
+JaktInternal::PrettyPrint::must_output_indentation(builder);
 builder.appendff("type: {}, ", that.type);
 JaktInternal::PrettyPrint::must_output_indentation(builder);
-builder.appendff("rebind_name: {}, ", that.rebind_name);
-JaktInternal::PrettyPrint::must_output_indentation(builder);
-builder.appendff("marker_span: {}", that.marker_span);
+builder.appendff("rebind_name: {}", that.rebind_name);
 }
 builder.append(")"sv);
 break;}
@@ -11394,55 +10038,55 @@ JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};
 JaktInternal::PrettyPrint::must_output_indentation(builder);
 builder.appendff("defaults: {}, ", this->common.init_common.defaults);
 JaktInternal::PrettyPrint::must_output_indentation(builder);
-builder.appendff("has_arguments: {}, ", that.has_arguments);
+builder.appendff("marker_span: {}, ", this->common.init_common.marker_span);
 JaktInternal::PrettyPrint::must_output_indentation(builder);
-builder.appendff("marker_span: {}", that.marker_span);
+builder.appendff("has_arguments: {}", that.has_arguments);
 }
 builder.append(")"sv);
 break;}
 }
 return builder.to_string();
 }
-[[nodiscard]] CheckedMatchPattern CheckedMatchPattern::EnumVariant(JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> defaults, ByteString name, JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> args, Jakt::ids::TypeId subject_type_id, size_t index, Jakt::ids::ScopeId scope_id, Jakt::utility::Span marker_span){
+[[nodiscard]] CheckedMatchPattern CheckedMatchPattern::EnumVariant(JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> defaults, Jakt::utility::Span marker_span, ByteString name, JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> args, Jakt::ids::TypeId subject_type_id, size_t index){
 CheckedMatchPattern __jakt_uninit_enum;
 __jakt_uninit_enum.__jakt_variant_index = 1;
 new (&__jakt_uninit_enum.common.init_common.defaults) (decltype(defaults))(move(defaults));
+new (&__jakt_uninit_enum.common.init_common.marker_span) (decltype(marker_span))(move(marker_span));
 new (&__jakt_uninit_enum.as.EnumVariant.name) (decltype(name))(move(name));
 new (&__jakt_uninit_enum.as.EnumVariant.args) (decltype(args))(move(args));
 new (&__jakt_uninit_enum.as.EnumVariant.subject_type_id) (decltype(subject_type_id))(move(subject_type_id));
 new (&__jakt_uninit_enum.as.EnumVariant.index) (decltype(index))(move(index));
-new (&__jakt_uninit_enum.as.EnumVariant.scope_id) (decltype(scope_id))(move(scope_id));
-new (&__jakt_uninit_enum.as.EnumVariant.marker_span) (decltype(marker_span))(move(marker_span));
 return __jakt_uninit_enum;
 }
-[[nodiscard]] CheckedMatchPattern CheckedMatchPattern::Expression(JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> defaults, NonnullRefPtr<typename Jakt::types::CheckedExpression> expression, Jakt::utility::Span marker_span){
+[[nodiscard]] CheckedMatchPattern CheckedMatchPattern::Expression(JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> defaults, Jakt::utility::Span marker_span, NonnullRefPtr<typename Jakt::types::CheckedExpression> expression){
 CheckedMatchPattern __jakt_uninit_enum;
 __jakt_uninit_enum.__jakt_variant_index = 2;
 new (&__jakt_uninit_enum.common.init_common.defaults) (decltype(defaults))(move(defaults));
+new (&__jakt_uninit_enum.common.init_common.marker_span) (decltype(marker_span))(move(marker_span));
 new (&__jakt_uninit_enum.as.Expression.expression) (decltype(expression))(move(expression));
-new (&__jakt_uninit_enum.as.Expression.marker_span) (decltype(marker_span))(move(marker_span));
 return __jakt_uninit_enum;
 }
-[[nodiscard]] CheckedMatchPattern CheckedMatchPattern::ClassInstance(JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> defaults, Jakt::ids::TypeId type, JaktInternal::Optional<Jakt::types::ClassInstanceRebind> rebind_name, Jakt::utility::Span marker_span){
+[[nodiscard]] CheckedMatchPattern CheckedMatchPattern::ClassInstance(JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> defaults, Jakt::utility::Span marker_span, Jakt::ids::TypeId type, JaktInternal::Optional<Jakt::types::ClassInstanceRebind> rebind_name){
 CheckedMatchPattern __jakt_uninit_enum;
 __jakt_uninit_enum.__jakt_variant_index = 3;
 new (&__jakt_uninit_enum.common.init_common.defaults) (decltype(defaults))(move(defaults));
+new (&__jakt_uninit_enum.common.init_common.marker_span) (decltype(marker_span))(move(marker_span));
 new (&__jakt_uninit_enum.as.ClassInstance.type) (decltype(type))(move(type));
 new (&__jakt_uninit_enum.as.ClassInstance.rebind_name) (decltype(rebind_name))(move(rebind_name));
-new (&__jakt_uninit_enum.as.ClassInstance.marker_span) (decltype(marker_span))(move(marker_span));
 return __jakt_uninit_enum;
 }
-[[nodiscard]] CheckedMatchPattern CheckedMatchPattern::CatchAll(JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> defaults, bool has_arguments, Jakt::utility::Span marker_span){
+[[nodiscard]] CheckedMatchPattern CheckedMatchPattern::CatchAll(JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> defaults, Jakt::utility::Span marker_span, bool has_arguments){
 CheckedMatchPattern __jakt_uninit_enum;
 __jakt_uninit_enum.__jakt_variant_index = 4;
 new (&__jakt_uninit_enum.common.init_common.defaults) (decltype(defaults))(move(defaults));
+new (&__jakt_uninit_enum.common.init_common.marker_span) (decltype(marker_span))(move(marker_span));
 new (&__jakt_uninit_enum.as.CatchAll.has_arguments) (decltype(has_arguments))(move(has_arguments));
-new (&__jakt_uninit_enum.as.CatchAll.marker_span) (decltype(marker_span))(move(marker_span));
 return __jakt_uninit_enum;
 }
 CheckedMatchPattern& CheckedMatchPattern::operator=(CheckedMatchPattern const &rhs){
 {VERIFY(this->__jakt_variant_index != 0 && rhs.__jakt_variant_index != 0);
 this->common.init_common.defaults = rhs.common.init_common.defaults;
+this->common.init_common.marker_span = rhs.common.init_common.marker_span;
 if (this->__jakt_variant_index != rhs.__jakt_variant_index) {
 this->__jakt_destroy_variant();
 switch (rhs.__jakt_init_index()) {
@@ -11451,21 +10095,16 @@ new (&this->as.EnumVariant.name) (decltype(this->as.EnumVariant.name))(rhs.as.En
 new (&this->as.EnumVariant.args) (decltype(this->as.EnumVariant.args))(rhs.as.EnumVariant.args);
 new (&this->as.EnumVariant.subject_type_id) (decltype(this->as.EnumVariant.subject_type_id))(rhs.as.EnumVariant.subject_type_id);
 new (&this->as.EnumVariant.index) (decltype(this->as.EnumVariant.index))(rhs.as.EnumVariant.index);
-new (&this->as.EnumVariant.scope_id) (decltype(this->as.EnumVariant.scope_id))(rhs.as.EnumVariant.scope_id);
-new (&this->as.EnumVariant.marker_span) (decltype(this->as.EnumVariant.marker_span))(rhs.as.EnumVariant.marker_span);
 break;
 case 1 /* Expression */:
 new (&this->as.Expression.expression) (decltype(this->as.Expression.expression))(rhs.as.Expression.expression);
-new (&this->as.Expression.marker_span) (decltype(this->as.Expression.marker_span))(rhs.as.Expression.marker_span);
 break;
 case 2 /* ClassInstance */:
 new (&this->as.ClassInstance.type) (decltype(this->as.ClassInstance.type))(rhs.as.ClassInstance.type);
 new (&this->as.ClassInstance.rebind_name) (decltype(this->as.ClassInstance.rebind_name))(rhs.as.ClassInstance.rebind_name);
-new (&this->as.ClassInstance.marker_span) (decltype(this->as.ClassInstance.marker_span))(rhs.as.ClassInstance.marker_span);
 break;
 case 3 /* CatchAll */:
 new (&this->as.CatchAll.has_arguments) (decltype(this->as.CatchAll.has_arguments))(rhs.as.CatchAll.has_arguments);
-new (&this->as.CatchAll.marker_span) (decltype(this->as.CatchAll.marker_span))(rhs.as.CatchAll.marker_span);
 break;
 }
 } else {
@@ -11475,21 +10114,16 @@ this->as.EnumVariant.name = rhs.as.EnumVariant.name;
 this->as.EnumVariant.args = rhs.as.EnumVariant.args;
 this->as.EnumVariant.subject_type_id = rhs.as.EnumVariant.subject_type_id;
 this->as.EnumVariant.index = rhs.as.EnumVariant.index;
-this->as.EnumVariant.scope_id = rhs.as.EnumVariant.scope_id;
-this->as.EnumVariant.marker_span = rhs.as.EnumVariant.marker_span;
 break;
 case 1 /* Expression */:
 this->as.Expression.expression = rhs.as.Expression.expression;
-this->as.Expression.marker_span = rhs.as.Expression.marker_span;
 break;
 case 2 /* ClassInstance */:
 this->as.ClassInstance.type = rhs.as.ClassInstance.type;
 this->as.ClassInstance.rebind_name = rhs.as.ClassInstance.rebind_name;
-this->as.ClassInstance.marker_span = rhs.as.ClassInstance.marker_span;
 break;
 case 3 /* CatchAll */:
 this->as.CatchAll.has_arguments = rhs.as.CatchAll.has_arguments;
-this->as.CatchAll.marker_span = rhs.as.CatchAll.marker_span;
 break;
 }
 }
@@ -11499,27 +10133,23 @@ return *this;
 }
 CheckedMatchPattern::CheckedMatchPattern(CheckedMatchPattern const &rhs){VERIFY(rhs.__jakt_variant_index != 0);
 new (&this->common.init_common.defaults) (decltype(this->common.init_common.defaults))(rhs.common.init_common.defaults);
+new (&this->common.init_common.marker_span) (decltype(this->common.init_common.marker_span))(rhs.common.init_common.marker_span);
 switch (rhs.__jakt_init_index()) {
 case 0 /* EnumVariant */:
 new (&this->as.EnumVariant.name) (decltype(this->as.EnumVariant.name))(rhs.as.EnumVariant.name);
 new (&this->as.EnumVariant.args) (decltype(this->as.EnumVariant.args))(rhs.as.EnumVariant.args);
 new (&this->as.EnumVariant.subject_type_id) (decltype(this->as.EnumVariant.subject_type_id))(rhs.as.EnumVariant.subject_type_id);
 new (&this->as.EnumVariant.index) (decltype(this->as.EnumVariant.index))(rhs.as.EnumVariant.index);
-new (&this->as.EnumVariant.scope_id) (decltype(this->as.EnumVariant.scope_id))(rhs.as.EnumVariant.scope_id);
-new (&this->as.EnumVariant.marker_span) (decltype(this->as.EnumVariant.marker_span))(rhs.as.EnumVariant.marker_span);
 break;
 case 1 /* Expression */:
 new (&this->as.Expression.expression) (decltype(this->as.Expression.expression))(rhs.as.Expression.expression);
-new (&this->as.Expression.marker_span) (decltype(this->as.Expression.marker_span))(rhs.as.Expression.marker_span);
 break;
 case 2 /* ClassInstance */:
 new (&this->as.ClassInstance.type) (decltype(this->as.ClassInstance.type))(rhs.as.ClassInstance.type);
 new (&this->as.ClassInstance.rebind_name) (decltype(this->as.ClassInstance.rebind_name))(rhs.as.ClassInstance.rebind_name);
-new (&this->as.ClassInstance.marker_span) (decltype(this->as.ClassInstance.marker_span))(rhs.as.ClassInstance.marker_span);
 break;
 case 3 /* CatchAll */:
 new (&this->as.CatchAll.has_arguments) (decltype(this->as.CatchAll.has_arguments))(rhs.as.CatchAll.has_arguments);
-new (&this->as.CatchAll.marker_span) (decltype(this->as.CatchAll.marker_span))(rhs.as.CatchAll.marker_span);
 break;
 }
 this->__jakt_variant_index = rhs.__jakt_variant_index;
@@ -11527,6 +10157,7 @@ this->__jakt_variant_index = rhs.__jakt_variant_index;
 CheckedMatchPattern& CheckedMatchPattern::operator=(CheckedMatchPattern &&rhs){
 {VERIFY(this->__jakt_variant_index != 0 && rhs.__jakt_variant_index != 0);
 this->common.init_common.defaults = move(rhs.common.init_common.defaults);
+this->common.init_common.marker_span = move(rhs.common.init_common.marker_span);
 if (this->__jakt_variant_index != rhs.__jakt_variant_index) {
 this->__jakt_destroy_variant();
 switch (rhs.__jakt_init_index()) {
@@ -11535,21 +10166,16 @@ new (&this->as.EnumVariant.name) (decltype(this->as.EnumVariant.name))(move(rhs.
 new (&this->as.EnumVariant.args) (decltype(this->as.EnumVariant.args))(move(rhs.as.EnumVariant.args));
 new (&this->as.EnumVariant.subject_type_id) (decltype(this->as.EnumVariant.subject_type_id))(move(rhs.as.EnumVariant.subject_type_id));
 new (&this->as.EnumVariant.index) (decltype(this->as.EnumVariant.index))(move(rhs.as.EnumVariant.index));
-new (&this->as.EnumVariant.scope_id) (decltype(this->as.EnumVariant.scope_id))(move(rhs.as.EnumVariant.scope_id));
-new (&this->as.EnumVariant.marker_span) (decltype(this->as.EnumVariant.marker_span))(move(rhs.as.EnumVariant.marker_span));
 break;
 case 1 /* Expression */:
 new (&this->as.Expression.expression) (decltype(this->as.Expression.expression))(move(rhs.as.Expression.expression));
-new (&this->as.Expression.marker_span) (decltype(this->as.Expression.marker_span))(move(rhs.as.Expression.marker_span));
 break;
 case 2 /* ClassInstance */:
 new (&this->as.ClassInstance.type) (decltype(this->as.ClassInstance.type))(move(rhs.as.ClassInstance.type));
 new (&this->as.ClassInstance.rebind_name) (decltype(this->as.ClassInstance.rebind_name))(move(rhs.as.ClassInstance.rebind_name));
-new (&this->as.ClassInstance.marker_span) (decltype(this->as.ClassInstance.marker_span))(move(rhs.as.ClassInstance.marker_span));
 break;
 case 3 /* CatchAll */:
 new (&this->as.CatchAll.has_arguments) (decltype(this->as.CatchAll.has_arguments))(move(rhs.as.CatchAll.has_arguments));
-new (&this->as.CatchAll.marker_span) (decltype(this->as.CatchAll.marker_span))(move(rhs.as.CatchAll.marker_span));
 break;
 }
 } else {
@@ -11559,21 +10185,16 @@ this->as.EnumVariant.name = move(rhs.as.EnumVariant.name);
 this->as.EnumVariant.args = move(rhs.as.EnumVariant.args);
 this->as.EnumVariant.subject_type_id = move(rhs.as.EnumVariant.subject_type_id);
 this->as.EnumVariant.index = move(rhs.as.EnumVariant.index);
-this->as.EnumVariant.scope_id = move(rhs.as.EnumVariant.scope_id);
-this->as.EnumVariant.marker_span = move(rhs.as.EnumVariant.marker_span);
 break;
 case 1 /* Expression */:
 this->as.Expression.expression = move(rhs.as.Expression.expression);
-this->as.Expression.marker_span = move(rhs.as.Expression.marker_span);
 break;
 case 2 /* ClassInstance */:
 this->as.ClassInstance.type = move(rhs.as.ClassInstance.type);
 this->as.ClassInstance.rebind_name = move(rhs.as.ClassInstance.rebind_name);
-this->as.ClassInstance.marker_span = move(rhs.as.ClassInstance.marker_span);
 break;
 case 3 /* CatchAll */:
 this->as.CatchAll.has_arguments = move(rhs.as.CatchAll.has_arguments);
-this->as.CatchAll.marker_span = move(rhs.as.CatchAll.marker_span);
 break;
 }
 }
@@ -11584,52 +10205,44 @@ return *this;
 CheckedMatchPattern::CheckedMatchPattern(CheckedMatchPattern &&rhs){
 {VERIFY(rhs.__jakt_variant_index != 0);
 new (&this->common.init_common.defaults) (decltype(this->common.init_common.defaults))(move(rhs.common.init_common.defaults));
+new (&this->common.init_common.marker_span) (decltype(this->common.init_common.marker_span))(move(rhs.common.init_common.marker_span));
 switch (rhs.__jakt_init_index()) {
 case 0 /* EnumVariant */:
 new (&this->as.EnumVariant.name) (decltype(this->as.EnumVariant.name))(move(rhs.as.EnumVariant.name));
 new (&this->as.EnumVariant.args) (decltype(this->as.EnumVariant.args))(move(rhs.as.EnumVariant.args));
 new (&this->as.EnumVariant.subject_type_id) (decltype(this->as.EnumVariant.subject_type_id))(move(rhs.as.EnumVariant.subject_type_id));
 new (&this->as.EnumVariant.index) (decltype(this->as.EnumVariant.index))(move(rhs.as.EnumVariant.index));
-new (&this->as.EnumVariant.scope_id) (decltype(this->as.EnumVariant.scope_id))(move(rhs.as.EnumVariant.scope_id));
-new (&this->as.EnumVariant.marker_span) (decltype(this->as.EnumVariant.marker_span))(move(rhs.as.EnumVariant.marker_span));
 break;
 case 1 /* Expression */:
 new (&this->as.Expression.expression) (decltype(this->as.Expression.expression))(move(rhs.as.Expression.expression));
-new (&this->as.Expression.marker_span) (decltype(this->as.Expression.marker_span))(move(rhs.as.Expression.marker_span));
 break;
 case 2 /* ClassInstance */:
 new (&this->as.ClassInstance.type) (decltype(this->as.ClassInstance.type))(move(rhs.as.ClassInstance.type));
 new (&this->as.ClassInstance.rebind_name) (decltype(this->as.ClassInstance.rebind_name))(move(rhs.as.ClassInstance.rebind_name));
-new (&this->as.ClassInstance.marker_span) (decltype(this->as.ClassInstance.marker_span))(move(rhs.as.ClassInstance.marker_span));
 break;
 case 3 /* CatchAll */:
 new (&this->as.CatchAll.has_arguments) (decltype(this->as.CatchAll.has_arguments))(move(rhs.as.CatchAll.has_arguments));
-new (&this->as.CatchAll.marker_span) (decltype(this->as.CatchAll.marker_span))(move(rhs.as.CatchAll.marker_span));
 break;
 }
 this->__jakt_variant_index = rhs.__jakt_variant_index;
 }
 }
 CheckedMatchPattern::~CheckedMatchPattern(){ if (this->__jakt_variant_index == 0) return;
-this->common.init_common.defaults.~DynamicArray();
+this->common.init_common.defaults.~Dictionary();
+this->common.init_common.marker_span.~Span();
 this->__jakt_destroy_variant(); }
 void CheckedMatchPattern::__jakt_destroy_variant() {
 switch (this->__jakt_init_index()) {
 case 0 /* EnumVariant */:this->as.EnumVariant.name.~ByteString();
 this->as.EnumVariant.args.~DynamicArray();
 this->as.EnumVariant.subject_type_id.~TypeId();
-this->as.EnumVariant.scope_id.~ScopeId();
-this->as.EnumVariant.marker_span.~Span();
 break;
 case 1 /* Expression */:this->as.Expression.expression.~NonnullRefPtr();
-this->as.Expression.marker_span.~Span();
 break;
 case 2 /* ClassInstance */:this->as.ClassInstance.type.~TypeId();
 this->as.ClassInstance.rebind_name.~Optional();
-this->as.ClassInstance.marker_span.~Span();
 break;
-case 3 /* CatchAll */:this->as.CatchAll.marker_span.~Span();
-break;
+case 3 /* CatchAll */:break;
 }
 }
 ByteString Jakt::types::CheckedExpression::debug_description() const {
@@ -14210,16 +12823,13 @@ break;
 }
 JaktInternal::Optional<Jakt::types::NumberConstant> Jakt::types::CheckedExpression::to_number_constant(NonnullRefPtr<Jakt::types::CheckedProgram> const program) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::types::NumberConstant>, JaktInternal::Optional<Jakt::types::NumberConstant>>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* NumericConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NumericConstant;Jakt::types::CheckedNumericConstant const& val = __jakt_match_value.val;
 Jakt::utility::Span const& span = __jakt_match_value.span;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(val.number_constant());
-};/*case end*/
+return val.number_constant();};/*case end*/
 case 6 /* UnaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 Jakt::types::CheckedUnaryOperator const& op = __jakt_match_value.op;
@@ -14227,243 +12837,178 @@ Jakt::utility::Span const& span = __jakt_match_value.span;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
 JaktInternal::Optional<Jakt::types::NumberConstant> result = JaktInternal::OptionalNone();
-Jakt::types::CheckedUnaryOperator __jakt_tmp58 = op;
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::types::NumberConstant>>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<Jakt::types::NumberConstant>,JaktInternal::Optional<Jakt::types::NumberConstant>> {
-auto __jakt_enum_value = (__jakt_tmp58.__jakt_init_index() == 11 /* TypeCast */);
+Jakt::types::CheckedUnaryOperator __jakt_tmp57 = op;
+{auto __jakt_enum_value = __jakt_tmp57.__jakt_init_index() == 11 /* TypeCast */;
 if (__jakt_enum_value) {{
-Jakt::types::CheckedTypeCast const cast = __jakt_tmp58.as.TypeCast.value;
+Jakt::types::CheckedTypeCast const cast = __jakt_tmp57.as.TypeCast.value;
 if (!(cast.__jakt_init_index() == 1 /* Infallible */)){
 result = JaktInternal::OptionalNone();
 }
 if ((!program->is_integer(type_id)) && (!program->is_floating(type_id))){
 result = JaktInternal::OptionalNone();
 }
-NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp59 = expr;
-if (__jakt_tmp59->__jakt_init_index() == 1 /* NumericConstant */){
-Jakt::types::CheckedNumericConstant const val = __jakt_tmp59->as.NumericConstant.val;
+NonnullRefPtr<typename Jakt::types::CheckedExpression> __jakt_tmp58 = expr;
+if (__jakt_tmp58->__jakt_init_index() == 1 /* NumericConstant */){
+Jakt::types::CheckedNumericConstant const val = __jakt_tmp58->as.NumericConstant.val;
 result = val.number_constant();
 }
-return JaktInternal::ExplicitValue<JaktInternal::Optional<Jakt::types::NumberConstant>>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 }else {{
 return JaktInternal::OptionalNone();
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return JaktInternal::OptionalNone();}/*switch end*/
+}
 }
 }
 
 Jakt::utility::Span Jakt::types::CheckedExpression::span() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::utility::Span, Jakt::utility::Span>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Boolean */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boolean;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 1 /* NumericConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NumericConstant;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 2 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 3 /* ByteConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ByteConstant;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 4 /* CharacterConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CharacterConstant;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 5 /* CCharacterConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CCharacterConstant;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 6 /* UnaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 7 /* BinaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.BinaryOp;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 8 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 9 /* Range */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Range;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 10 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 11 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 12 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 13 /* IndexedExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedExpression;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 14 /* IndexedDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedDictionary;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 15 /* IndexedTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedTuple;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 16 /* IndexedStruct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedStruct;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 17 /* IndexedCommonEnumMember */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedCommonEnumMember;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 18 /* ComptimeIndex */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ComptimeIndex;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 19 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 20 /* EnumVariantArg */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariantArg;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 21 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 22 /* MethodCall */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MethodCall;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 23 /* NamespacedVar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedVar;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 24 /* Var */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Var;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 25 /* OptionalNone */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalNone;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 26 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 27 /* ForcedUnwrap */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForcedUnwrap;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 28 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 29 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 30 /* DependentFunction */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DependentFunction;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 31 /* Must */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Must;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 32 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 33 /* TryBlock */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TryBlock;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 34 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 case 35 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;Jakt::utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(span);
-};/*case end*/
+return span;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 bool Jakt::types::CheckedExpression::is_mutable(NonnullRefPtr<Jakt::types::CheckedProgram> const program) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Boolean */:case 1 /* NumericConstant */:case 2 /* QuotedString */:case 3 /* ByteConstant */:case 4 /* CharacterConstant */:case 5 /* CCharacterConstant */:return JaktInternal::ExplicitValue(true);
-case 24 /* Var */: {
+case 0 /* Boolean */:case 1 /* NumericConstant */:case 2 /* QuotedString */:case 3 /* ByteConstant */:case 4 /* CharacterConstant */:case 5 /* CCharacterConstant */:return true;case 24 /* Var */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Var;NonnullRefPtr<Jakt::types::CheckedVariable> const& var = __jakt_match_value.var;
-return JaktInternal::ExplicitValue(var->is_mutable);
-};/*case end*/
+return var->is_mutable;};/*case end*/
 case 16 /* IndexedStruct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedStruct;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(expr->is_mutable(program));
-};/*case end*/
+return expr->is_mutable(program);};/*case end*/
 case 13 /* IndexedExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedExpression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(expr->is_mutable(program));
-};/*case end*/
+return expr->is_mutable(program);};/*case end*/
 case 18 /* ComptimeIndex */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ComptimeIndex;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(expr->is_mutable(program));
-};/*case end*/
+return expr->is_mutable(program);};/*case end*/
 case 15 /* IndexedTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedTuple;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(expr->is_mutable(program));
-};/*case end*/
+return expr->is_mutable(program);};/*case end*/
 case 14 /* IndexedDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedDictionary;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(expr->is_mutable(program));
-};/*case end*/
+return expr->is_mutable(program);};/*case end*/
 case 27 /* ForcedUnwrap */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForcedUnwrap;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(expr->is_mutable(program));
-};/*case end*/
+return expr->is_mutable(program);};/*case end*/
 case 10 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedExpression>> const& vals = __jakt_match_value.vals;
 {
@@ -14486,7 +13031,7 @@ break;
 }
 }
 
-return JaktInternal::ExplicitValue<bool>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -14512,7 +13057,7 @@ break;
 }
 }
 
-return JaktInternal::ExplicitValue<bool>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -14542,234 +13087,151 @@ break;
 }
 }
 
-return JaktInternal::ExplicitValue<bool>(result);
+return result;
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 6 /* UnaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
 Jakt::types::CheckedUnaryOperator const& op = __jakt_match_value.op;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = op;
+{auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 5 /* Dereference */:return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *program->get_type(expr->type());
+case 5 /* Dereference */:{auto&& __jakt_match_variant = *program->get_type(expr->type());
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 28 /* MutableReference */:return JaktInternal::ExplicitValue(true);
-case 25 /* RawPtr */:return JaktInternal::ExplicitValue(expr->is_mutable(program));
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+case 28 /* MutableReference */:return true;case 25 /* RawPtr */:return expr->is_mutable(program);default:return false;}/*switch end*/
+}default:return false;}/*switch end*/
+}};/*case end*/
 case 22 /* MethodCall */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MethodCall;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(expr->is_mutable(program));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return expr->is_mutable(program);};/*case end*/
+default:return false;}/*switch end*/
+}
 }
 }
 
 bool Jakt::types::CheckedExpression::can_throw() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::types::CheckedCall const& call = __jakt_match_value.call;
-return JaktInternal::ExplicitValue(call.callee_throws);
-};/*case end*/
+return call.callee_throws;};/*case end*/
 case 22 /* MethodCall */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MethodCall;Jakt::types::CheckedCall const& call = __jakt_match_value.call;
-return JaktInternal::ExplicitValue(call.callee_throws);
-};/*case end*/
+return call.callee_throws;};/*case end*/
 case 2 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;Jakt::types::CheckedStringLiteral const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(val.may_throw);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return val.may_throw;};/*case end*/
+default:return false;}/*switch end*/
+}
 }
 }
 
 Jakt::ids::TypeId Jakt::types::CheckedExpression::type() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId, Jakt::ids::TypeId>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Boolean */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::Bool()));
-case 2 /* QuotedString */: {
+case 0 /* Boolean */:return Jakt::types::builtin(Jakt::types::BuiltinType::Bool());case 2 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;Jakt::types::CheckedStringLiteral const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(val.type_id);
-};/*case end*/
-case 3 /* ByteConstant */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::U8()));
-case 5 /* CCharacterConstant */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::CChar()));
-case 4 /* CharacterConstant */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::U32()));
-case 20 /* EnumVariantArg */: {
+return val.type_id;};/*case end*/
+case 3 /* ByteConstant */:return Jakt::types::builtin(Jakt::types::BuiltinType::U8());case 5 /* CCharacterConstant */:return Jakt::types::builtin(Jakt::types::BuiltinType::CChar());case 4 /* CharacterConstant */:return Jakt::types::builtin(Jakt::types::BuiltinType::U32());case 20 /* EnumVariantArg */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariantArg;Jakt::types::CheckedEnumVariantBinding const& arg = __jakt_match_value.arg;
-return JaktInternal::ExplicitValue(arg.type_id);
-};/*case end*/
+return arg.type_id;};/*case end*/
 case 23 /* NamespacedVar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedVar;NonnullRefPtr<Jakt::types::CheckedVariable> const& var = __jakt_match_value.var;
-return JaktInternal::ExplicitValue(var->type_id);
-};/*case end*/
+return var->type_id;};/*case end*/
 case 24 /* Var */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Var;NonnullRefPtr<Jakt::types::CheckedVariable> const& var = __jakt_match_value.var;
-return JaktInternal::ExplicitValue(var->type_id);
-};/*case end*/
-case 18 /* ComptimeIndex */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::Unknown()));
-case 1 /* NumericConstant */: {
+return var->type_id;};/*case end*/
+case 18 /* ComptimeIndex */:return Jakt::types::builtin(Jakt::types::BuiltinType::Unknown());case 1 /* NumericConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NumericConstant;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 6 /* UnaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 7 /* BinaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.BinaryOp;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 8 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 9 /* Range */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Range;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 10 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 11 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 12 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 13 /* IndexedExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedExpression;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 14 /* IndexedDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedDictionary;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 15 /* IndexedTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedTuple;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 16 /* IndexedStruct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedStruct;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 17 /* IndexedCommonEnumMember */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedCommonEnumMember;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 19 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 21 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 22 /* MethodCall */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MethodCall;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 25 /* OptionalNone */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalNone;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 26 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 27 /* ForcedUnwrap */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForcedUnwrap;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 28 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 29 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 30 /* DependentFunction */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DependentFunction;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 31 /* Must */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Must;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 32 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 33 /* TryBlock */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TryBlock;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 34 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 case 35 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(type_id);
-};/*case end*/
+return type_id;};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 Jakt::types::BlockControlFlow Jakt::types::CheckedExpression::control_flow() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 19 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.expr;
@@ -14788,29 +13250,17 @@ break;
 }
 Jakt::types::CheckedMatchCase case_ = _magic_value.value();
 {
-Jakt::types::BlockControlFlow const case_control_flow = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow, Jakt::types::BlockControlFlow>{
-auto&& __jakt_match_variant = case_.body;
+Jakt::types::BlockControlFlow const case_control_flow = [&]() -> Jakt::types::BlockControlFlow { auto&& __jakt_match_variant = case_.body;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;Jakt::types::CheckedBlock const& block = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(block.control_flow);
-};/*case end*/
+return block.control_flow;};/*case end*/
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename Jakt::types::CheckedExpression> const& expr = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(expr->control_flow());
-};/*case end*/
+return expr->control_flow();};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+ 
+}();
 if (control_flow.has_value()){
 control_flow = control_flow.value().branch_unify_with(case_control_flow);
 }
@@ -14823,70 +13273,40 @@ control_flow = case_control_flow;
 }
 }
 
-return JaktInternal::ExplicitValue<Jakt::types::BlockControlFlow>(control_flow.value_or_lazy_evaluated([&] { return Jakt::types::BlockControlFlow::MayReturn(); }));
+return control_flow.value_or_lazy_evaluated([&] { return Jakt::types::BlockControlFlow::MayReturn(); });
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 22 /* MethodCall */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MethodCall;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow,Jakt::types::BlockControlFlow> {
-auto __jakt_enum_value = (type_id.equals(Jakt::types::never_type_id()));
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::NeverReturns());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+{auto __jakt_enum_value = type_id.equals(Jakt::types::never_type_id());
+if (__jakt_enum_value) {return Jakt::types::BlockControlFlow::NeverReturns();}else if (!__jakt_enum_value) {return Jakt::types::BlockControlFlow::MayReturn();}VERIFY_NOT_REACHED();
+}};/*case end*/
 case 21 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow,Jakt::types::BlockControlFlow> {
-auto __jakt_enum_value = (type_id.equals(Jakt::types::never_type_id()));
-if (__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::NeverReturns());
-}else if (!__jakt_enum_value) {return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-}VERIFY_NOT_REACHED();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+{auto __jakt_enum_value = type_id.equals(Jakt::types::never_type_id());
+if (__jakt_enum_value) {return Jakt::types::BlockControlFlow::NeverReturns();}else if (!__jakt_enum_value) {return Jakt::types::BlockControlFlow::MayReturn();}VERIFY_NOT_REACHED();
+}};/*case end*/
 case 33 /* TryBlock */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TryBlock;NonnullRefPtr<typename Jakt::types::CheckedStatement> const& stmt = __jakt_match_value.stmt;
 Jakt::types::CheckedBlock const& catch_block = __jakt_match_value.catch_block;
 {
-NonnullRefPtr<typename Jakt::types::CheckedStatement> __jakt_tmp60 = stmt;
-return JaktInternal::ExplicitValue<Jakt::types::BlockControlFlow>(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::types::BlockControlFlow,Jakt::types::BlockControlFlow> {
-auto __jakt_enum_value = (__jakt_tmp60->__jakt_init_index() == 5 /* Block */);
+NonnullRefPtr<typename Jakt::types::CheckedStatement> __jakt_tmp59 = stmt;
+{auto __jakt_enum_value = __jakt_tmp59->__jakt_init_index() == 5 /* Block */;
 if (__jakt_enum_value) {{
-Jakt::types::CheckedBlock const block = __jakt_tmp60->as.Block.block;
-return JaktInternal::ExplicitValue<Jakt::types::BlockControlFlow>(block.control_flow.branch_unify_with(catch_block.control_flow));
+Jakt::types::CheckedBlock const block = __jakt_tmp59->as.Block.block;
+return block.control_flow.branch_unify_with(catch_block.control_flow);
 }
 VERIFY_NOT_REACHED();
 }else {{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Try block doesn't have a block"sv));
 }
-}}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
+}}
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
-default:return JaktInternal::ExplicitValue(Jakt::types::BlockControlFlow::MayReturn());
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+default:return Jakt::types::BlockControlFlow::MayReturn();}/*switch end*/
+}
 }
 }
 
@@ -16020,123 +14440,77 @@ break;
 }
 ErrorOr<Jakt::ids::TypeId> Jakt::types::ValueImpl::type_id(NonnullRefPtr<Jakt::types::CheckedProgram>& program) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<Jakt::ids::TypeId, ErrorOr<Jakt::ids::TypeId>>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Void */:return JaktInternal::ExplicitValue(Jakt::types::void_type_id());
-case 1 /* Bool */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::Bool()));
-case 2 /* U8 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::U8()));
-case 3 /* U16 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::U16()));
-case 4 /* U32 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::U32()));
-case 5 /* U64 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::U64()));
-case 6 /* I8 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::I8()));
-case 7 /* I16 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::I16()));
-case 8 /* I32 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::I32()));
-case 9 /* I64 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::I64()));
-case 10 /* F32 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::F32()));
-case 11 /* F64 */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::F64()));
-case 12 /* USize */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::Usize()));
-case 13 /* JaktString */:return JaktInternal::ExplicitValue(TRY((program->find_type_in_scope(program->prelude_scope_id(),ByteString::from_utf8_without_validation("String"sv),false,JaktInternal::OptionalNone()))).value());
-case 14 /* StringView */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::JaktString()));
-case 15 /* CChar */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::CChar()));
-case 16 /* CInt */:return JaktInternal::ExplicitValue(Jakt::types::builtin(Jakt::types::BuiltinType::CInt()));
-case 17 /* Struct */: {
+case 0 /* Void */:return Jakt::types::void_type_id();case 1 /* Bool */:return Jakt::types::builtin(Jakt::types::BuiltinType::Bool());case 2 /* U8 */:return Jakt::types::builtin(Jakt::types::BuiltinType::U8());case 3 /* U16 */:return Jakt::types::builtin(Jakt::types::BuiltinType::U16());case 4 /* U32 */:return Jakt::types::builtin(Jakt::types::BuiltinType::U32());case 5 /* U64 */:return Jakt::types::builtin(Jakt::types::BuiltinType::U64());case 6 /* I8 */:return Jakt::types::builtin(Jakt::types::BuiltinType::I8());case 7 /* I16 */:return Jakt::types::builtin(Jakt::types::BuiltinType::I16());case 8 /* I32 */:return Jakt::types::builtin(Jakt::types::BuiltinType::I32());case 9 /* I64 */:return Jakt::types::builtin(Jakt::types::BuiltinType::I64());case 10 /* F32 */:return Jakt::types::builtin(Jakt::types::BuiltinType::F32());case 11 /* F64 */:return Jakt::types::builtin(Jakt::types::BuiltinType::F64());case 12 /* USize */:return Jakt::types::builtin(Jakt::types::BuiltinType::Usize());case 13 /* JaktString */:return TRY((program->find_type_in_scope(program->prelude_scope_id(),ByteString::from_utf8_without_validation("String"sv),false,JaktInternal::OptionalNone()))).value();case 14 /* StringView */:return Jakt::types::builtin(Jakt::types::BuiltinType::JaktString());case 15 /* CChar */:return Jakt::types::builtin(Jakt::types::BuiltinType::CChar());case 16 /* CInt */:return Jakt::types::builtin(Jakt::types::BuiltinType::CInt());case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;Jakt::ids::StructId const& struct_id = __jakt_match_value.struct_id;
-return JaktInternal::ExplicitValue(program->find_or_add_type_id(Jakt::types::Type::Struct(Jakt::parser::CheckedQualifiers(false),struct_id),struct_id.module,false));
-};/*case end*/
+return program->find_or_add_type_id(Jakt::types::Type::Struct(Jakt::parser::CheckedQualifiers(false),struct_id),struct_id.module,false);};/*case end*/
 case 18 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;Jakt::ids::StructId const& struct_id = __jakt_match_value.struct_id;
-return JaktInternal::ExplicitValue(program->find_or_add_type_id(Jakt::types::Type::Struct(Jakt::parser::CheckedQualifiers(false),struct_id),struct_id.module,false));
-};/*case end*/
+return program->find_or_add_type_id(Jakt::types::Type::Struct(Jakt::parser::CheckedQualifiers(false),struct_id),struct_id.module,false);};/*case end*/
 case 19 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;Jakt::ids::EnumId const& enum_id = __jakt_match_value.enum_id;
-return JaktInternal::ExplicitValue(program->find_or_add_type_id(Jakt::types::Type::Enum(Jakt::parser::CheckedQualifiers(false),enum_id),enum_id.module,false));
-};/*case end*/
+return program->find_or_add_type_id(Jakt::types::Type::Enum(Jakt::parser::CheckedQualifiers(false),enum_id),enum_id.module,false);};/*case end*/
 default:{
 Jakt::utility::panic(ByteString::from_utf8_without_validation("Reflected value type not implemented"sv));
 }
 }/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 NonnullRefPtr<typename Jakt::types::ValueImpl> Jakt::types::ValueImpl::copy() const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename Jakt::types::ValueImpl>, NonnullRefPtr<typename Jakt::types::ValueImpl>>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Void */:return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Void());
-case 1 /* Bool */: {
+case 0 /* Void */:return Jakt::types::ValueImpl::Void();case 1 /* Bool */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Bool;bool const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Bool(x));
-};/*case end*/
+return Jakt::types::ValueImpl::Bool(x);};/*case end*/
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U8(x));
-};/*case end*/
+return Jakt::types::ValueImpl::U8(x);};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U16(x));
-};/*case end*/
+return Jakt::types::ValueImpl::U16(x);};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U32(x));
-};/*case end*/
+return Jakt::types::ValueImpl::U32(x);};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::U64(x));
-};/*case end*/
+return Jakt::types::ValueImpl::U64(x);};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I8(x));
-};/*case end*/
+return Jakt::types::ValueImpl::I8(x);};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I16(x));
-};/*case end*/
+return Jakt::types::ValueImpl::I16(x);};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I32(x));
-};/*case end*/
+return Jakt::types::ValueImpl::I32(x);};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::I64(x));
-};/*case end*/
+return Jakt::types::ValueImpl::I64(x);};/*case end*/
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::F32(x));
-};/*case end*/
+return Jakt::types::ValueImpl::F32(x);};/*case end*/
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::F64(x));
-};/*case end*/
+return Jakt::types::ValueImpl::F64(x);};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::USize(x));
-};/*case end*/
+return Jakt::types::ValueImpl::USize(x);};/*case end*/
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::JaktString(x));
-};/*case end*/
+return Jakt::types::ValueImpl::JaktString(x);};/*case end*/
 case 14 /* StringView */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StringView;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::StringView(x));
-};/*case end*/
+return Jakt::types::ValueImpl::StringView(x);};/*case end*/
 case 15 /* CChar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CChar;char const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::CChar(x));
-};/*case end*/
+return Jakt::types::ValueImpl::CChar(x);};/*case end*/
 case 16 /* CInt */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CInt;int const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::CInt(x));
-};/*case end*/
+return Jakt::types::ValueImpl::CInt(x);};/*case end*/
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
 Jakt::ids::StructId const& struct_id = __jakt_match_value.struct_id;
@@ -16158,7 +14532,7 @@ fields_copy.push(field.copy());
 }
 }
 
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::ValueImpl>>(Jakt::types::ValueImpl::Struct(fields_copy,struct_id,constructor));
+return Jakt::types::ValueImpl::Struct(fields_copy,struct_id,constructor);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16166,8 +14540,7 @@ case 18 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
 Jakt::ids::StructId const& struct_id = __jakt_match_value.struct_id;
 JaktInternal::Optional<Jakt::ids::FunctionId> const& constructor = __jakt_match_value.constructor;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Class(fields,struct_id,constructor));
-};/*case end*/
+return Jakt::types::ValueImpl::Class(fields,struct_id,constructor);};/*case end*/
 case 19 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
 Jakt::ids::EnumId const& enum_id = __jakt_match_value.enum_id;
@@ -16189,7 +14562,7 @@ fields_copy.push(field.copy());
 }
 }
 
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::ValueImpl>>(Jakt::types::ValueImpl::Enum(fields_copy,enum_id,constructor));
+return Jakt::types::ValueImpl::Enum(fields_copy,enum_id,constructor);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16213,7 +14586,7 @@ values_copy.push(value.copy());
 }
 }
 
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::ValueImpl>>(Jakt::types::ValueImpl::JaktArray(values_copy,type_id));
+return Jakt::types::ValueImpl::JaktArray(values_copy,type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16254,7 +14627,7 @@ keys_copy.push(key.copy());
 }
 }
 
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::ValueImpl>>(Jakt::types::ValueImpl::JaktDictionary(keys_copy,values_copy,type_id));
+return Jakt::types::ValueImpl::JaktDictionary(keys_copy,values_copy,type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16278,20 +14651,17 @@ values_copy.push(value.copy());
 }
 }
 
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::ValueImpl>>(Jakt::types::ValueImpl::JaktSet(values_copy,type_id));
+return Jakt::types::ValueImpl::JaktSet(values_copy,type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
 case 23 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;NonnullRefPtr<typename Jakt::types::ValueImpl> const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::RawPtr(value));
-};/*case end*/
+return Jakt::types::ValueImpl::RawPtr(value);};/*case end*/
 case 24 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;Jakt::types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::OptionalSome(value.copy()));
-};/*case end*/
-case 25 /* OptionalNone */:return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::OptionalNone());
-case 26 /* JaktTuple */: {
+return Jakt::types::ValueImpl::OptionalSome(value.copy());};/*case end*/
+case 25 /* OptionalNone */:return Jakt::types::ValueImpl::OptionalNone();case 26 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;JaktInternal::DynamicArray<Jakt::types::Value> const& fields = __jakt_match_value.fields;
 Jakt::ids::TypeId const& type_id = __jakt_match_value.type_id;
 {
@@ -16311,7 +14681,7 @@ values_copy.push(value.copy());
 }
 }
 
-return JaktInternal::ExplicitValue<NonnullRefPtr<typename Jakt::types::ValueImpl>>(Jakt::types::ValueImpl::JaktTuple(values_copy,type_id));
+return Jakt::types::ValueImpl::JaktTuple(values_copy,type_id);
 }
 VERIFY_NOT_REACHED();
 };/*case end*/
@@ -16325,337 +14695,162 @@ Jakt::types::CheckedBlock const& block = __jakt_match_value.block;
 JaktInternal::DynamicArray<Jakt::types::CheckedParameter> const& checked_params = __jakt_match_value.checked_params;
 Jakt::ids::ScopeId const& scope_id = __jakt_match_value.scope_id;
 JaktInternal::Optional<Jakt::ids::FunctionId> const& pseudo_function_id = __jakt_match_value.pseudo_function_id;
-return JaktInternal::ExplicitValue(Jakt::types::ValueImpl::Function(captures,params,return_type_id,type_id,block,can_throw,checked_params,scope_id,pseudo_function_id));
-};/*case end*/
+return Jakt::types::ValueImpl::Function(captures,params,return_type_id,type_id,block,can_throw,checked_params,scope_id,pseudo_function_id);};/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+}
 }
 }
 
 bool Jakt::types::ValueImpl::equals(NonnullRefPtr<typename Jakt::types::ValueImpl> const other) const {
 {
-return ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *this;
+{auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
-case 0 /* Void */:return JaktInternal::ExplicitValue(other->__jakt_init_index() == 0 /* Void */);
-case 1 /* Bool */: {
+case 0 /* Void */:return other->__jakt_init_index() == 0 /* Void */;case 1 /* Bool */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Bool;bool const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *other;
+{auto&& __jakt_match_variant = *other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Bool */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Bool;bool const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x == y);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return x == y;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *other;
+{auto&& __jakt_match_variant = *other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* U8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U8;u8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x == y);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return x == y;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *other;
+{auto&& __jakt_match_variant = *other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* U16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U16;u16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(y == x);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return y == x;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *other;
+{auto&& __jakt_match_variant = *other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* U32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U32;u32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(y == x);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return y == x;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *other;
+{auto&& __jakt_match_variant = *other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* U64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.U64;u64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(y == x);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return y == x;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *other;
+{auto&& __jakt_match_variant = *other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 6 /* I8 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I8;i8 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(y == x);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return y == x;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *other;
+{auto&& __jakt_match_variant = *other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* I16 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I16;i16 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(y == x);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return y == x;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *other;
+{auto&& __jakt_match_variant = *other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* I32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I32;i32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(y == x);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return y == x;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *other;
+{auto&& __jakt_match_variant = *other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* I64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.I64;i64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(y == x);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return y == x;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *other;
+{auto&& __jakt_match_variant = *other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* F32 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F32;f32 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(y == x);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return y == x;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *other;
+{auto&& __jakt_match_variant = *other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* F64 */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.F64;f64 const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(y == x);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return y == x;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *other;
+{auto&& __jakt_match_variant = *other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* USize */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.USize;size_t const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(y == x);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return y == x;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *other;
+{auto&& __jakt_match_variant = *other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(y == x);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return y == x;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 14 /* StringView */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StringView;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *other;
+{auto&& __jakt_match_variant = *other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 14 /* StringView */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StringView;ByteString const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(y == x);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return y == x;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 15 /* CChar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CChar;char const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *other;
+{auto&& __jakt_match_variant = *other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 15 /* CChar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CChar;char const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(y == x);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
+return y == x;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
 case 16 /* CInt */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CInt;int const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
-auto&& __jakt_match_variant = *other;
+{auto&& __jakt_match_variant = *other;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 16 /* CInt */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CInt;int const& y = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(y == x);
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}));
-};/*case end*/
-default:return JaktInternal::ExplicitValue(false);
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+return y == x;};/*case end*/
+default:return false;}/*switch end*/
+}};/*case end*/
+default:return false;}/*switch end*/
+}
 }
 }
 

--- a/bootstrap/stage0/types.h
+++ b/bootstrap/stage0/types.h
@@ -1098,7 +1098,7 @@ public: ByteString name;public: Jakt::utility::Span name_span;public: bool is_mu
 public: ByteString debug_description() const;
 };struct CheckedMatchCase {
   public:
-public: JaktInternal::DynamicArray<Jakt::types::CheckedMatchPattern> patterns;public: Jakt::types::CheckedMatchBody body;public: CheckedMatchCase(JaktInternal::DynamicArray<Jakt::types::CheckedMatchPattern> a_patterns, Jakt::types::CheckedMatchBody a_body);
+public: JaktInternal::DynamicArray<Jakt::types::CheckedMatchPattern> patterns;public: Jakt::types::CheckedMatchBody body;public: JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> bindings;public: CheckedMatchCase(JaktInternal::DynamicArray<Jakt::types::CheckedMatchPattern> a_patterns, Jakt::types::CheckedMatchBody a_body, JaktInternal::Dictionary<ByteString,Jakt::ids::VarId> a_bindings);
 
 public: ByteString debug_description() const;
 };struct CheckedMatchPattern {
@@ -1106,7 +1106,8 @@ u8 __jakt_variant_index = 0;
 union CommonData {
 u8 __jakt_uninit_common;
 struct {
-JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> defaults;
+JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> defaults;
+Jakt::utility::Span marker_span;
 } init_common;
 constexpr CommonData() {}
 ~CommonData() {}
@@ -1118,30 +1119,25 @@ ByteString name;
 JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> args;
 Jakt::ids::TypeId subject_type_id;
 size_t index;
-Jakt::ids::ScopeId scope_id;
-Jakt::utility::Span marker_span;
 } EnumVariant;
 struct {
 NonnullRefPtr<typename Jakt::types::CheckedExpression> expression;
-Jakt::utility::Span marker_span;
 } Expression;
 struct {
 Jakt::ids::TypeId type;
 JaktInternal::Optional<Jakt::types::ClassInstanceRebind> rebind_name;
-Jakt::utility::Span marker_span;
 } ClassInstance;
 struct {
 bool has_arguments;
-Jakt::utility::Span marker_span;
 } CatchAll;
 constexpr VariantData() {}
 ~VariantData() {}
 } as;
 constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ByteString debug_description() const;
-[[nodiscard]] static CheckedMatchPattern EnumVariant(JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> defaults, ByteString name, JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> args, Jakt::ids::TypeId subject_type_id, size_t index, Jakt::ids::ScopeId scope_id, Jakt::utility::Span marker_span);
-[[nodiscard]] static CheckedMatchPattern Expression(JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> defaults, NonnullRefPtr<typename Jakt::types::CheckedExpression> expression, Jakt::utility::Span marker_span);
-[[nodiscard]] static CheckedMatchPattern ClassInstance(JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> defaults, Jakt::ids::TypeId type, JaktInternal::Optional<Jakt::types::ClassInstanceRebind> rebind_name, Jakt::utility::Span marker_span);
-[[nodiscard]] static CheckedMatchPattern CatchAll(JaktInternal::DynamicArray<NonnullRefPtr<typename Jakt::types::CheckedStatement>> defaults, bool has_arguments, Jakt::utility::Span marker_span);
+[[nodiscard]] static CheckedMatchPattern EnumVariant(JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> defaults, Jakt::utility::Span marker_span, ByteString name, JaktInternal::DynamicArray<Jakt::parser::EnumVariantPatternArgument> args, Jakt::ids::TypeId subject_type_id, size_t index);
+[[nodiscard]] static CheckedMatchPattern Expression(JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> defaults, Jakt::utility::Span marker_span, NonnullRefPtr<typename Jakt::types::CheckedExpression> expression);
+[[nodiscard]] static CheckedMatchPattern ClassInstance(JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> defaults, Jakt::utility::Span marker_span, Jakt::ids::TypeId type, JaktInternal::Optional<Jakt::types::ClassInstanceRebind> rebind_name);
+[[nodiscard]] static CheckedMatchPattern CatchAll(JaktInternal::Dictionary<ByteString,NonnullRefPtr<typename Jakt::types::CheckedExpression>> defaults, Jakt::utility::Span marker_span, bool has_arguments);
 ~CheckedMatchPattern();
 CheckedMatchPattern& operator=(CheckedMatchPattern const &);
 CheckedMatchPattern& operator=(CheckedMatchPattern &&);

--- a/bootstrap/stage0/types_specializations.cpp
+++ b/bootstrap/stage0/types_specializations.cpp
@@ -33,26 +33,20 @@ ErrorOr<JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedVariable>>> Jak
 {
 JaktInternal::Optional<NonnullRefPtr<Jakt::types::CheckedVariable>> result = JaktInternal::OptionalNone();
 TRY((this->for_each_scope_accessible_unqualified_from_scope_impl(scope_id,[&callback, &result](Jakt::types::ResolutionMixin mixin, JaktInternal::Optional<ByteString> name_override, bool is_alias) -> ErrorOr<typename Jakt::utility::IterationDecision<bool>> {{
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<typename Jakt::utility::IterationDecision<bool>>> {
-auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer(TRY((callback(mixin,name_override,is_alias))));
-if (__jakt_enum_value.__jakt_init_index() == 1 /* Continue */) {{
-return Jakt::utility::IterationDecision<bool>::Continue();
-}
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value.__jakt_init_index() == 0 /* Break */) {auto& __jakt_match_value = __jakt_enum_value.as.Break;
-auto& value = __jakt_match_value.value;
+{auto&& __jakt_match_variant = TRY((callback(mixin,name_override,is_alias)));
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Break */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Break;NonnullRefPtr<Jakt::types::CheckedVariable> const& value = __jakt_match_value.value;
 {
 result = value;
 return Jakt::utility::IterationDecision<bool>::Break(true);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_208;};/*case end*/
+case 1 /* Continue */:{
+return Jakt::utility::IterationDecision<bool>::Continue();
+}
+goto __jakt_label_208;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_208; __jakt_label_208:;;
 }
 }
 ,ignore_mixin_scopes,root_scope)));
@@ -64,26 +58,20 @@ ErrorOr<JaktInternal::Optional<Jakt::types::Value>> Jakt::types::CheckedProgram:
 {
 JaktInternal::Optional<Jakt::types::Value> result = JaktInternal::OptionalNone();
 TRY((this->for_each_scope_accessible_unqualified_from_scope_impl(scope_id,[&callback, &result](Jakt::types::ResolutionMixin mixin, JaktInternal::Optional<ByteString> name_override, bool is_alias) -> ErrorOr<typename Jakt::utility::IterationDecision<bool>> {{
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<typename Jakt::utility::IterationDecision<bool>>> {
-auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer(TRY((callback(mixin,name_override,is_alias))));
-if (__jakt_enum_value.__jakt_init_index() == 1 /* Continue */) {{
-return Jakt::utility::IterationDecision<bool>::Continue();
-}
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value.__jakt_init_index() == 0 /* Break */) {auto& __jakt_match_value = __jakt_enum_value.as.Break;
-auto& value = __jakt_match_value.value;
+{auto&& __jakt_match_variant = TRY((callback(mixin,name_override,is_alias)));
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Break */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Break;Jakt::types::Value const& value = __jakt_match_value.value;
 {
 result = value;
 return Jakt::utility::IterationDecision<bool>::Break(true);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_209;};/*case end*/
+case 1 /* Continue */:{
+return Jakt::utility::IterationDecision<bool>::Continue();
+}
+goto __jakt_label_209;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_209; __jakt_label_209:;;
 }
 }
 ,ignore_mixin_scopes,root_scope)));
@@ -95,26 +83,20 @@ ErrorOr<JaktInternal::Optional<JaktInternal::Tuple<Jakt::ids::TypeId,Jakt::ids::
 {
 JaktInternal::Optional<JaktInternal::Tuple<Jakt::ids::TypeId,Jakt::ids::ScopeId>> result = JaktInternal::OptionalNone();
 TRY((this->for_each_scope_accessible_unqualified_from_scope_impl(scope_id,[&callback, &result](Jakt::types::ResolutionMixin mixin, JaktInternal::Optional<ByteString> name_override, bool is_alias) -> ErrorOr<typename Jakt::utility::IterationDecision<bool>> {{
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<typename Jakt::utility::IterationDecision<bool>>> {
-auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer(TRY((callback(mixin,name_override,is_alias))));
-if (__jakt_enum_value.__jakt_init_index() == 1 /* Continue */) {{
-return Jakt::utility::IterationDecision<bool>::Continue();
-}
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value.__jakt_init_index() == 0 /* Break */) {auto& __jakt_match_value = __jakt_enum_value.as.Break;
-auto& value = __jakt_match_value.value;
+{auto&& __jakt_match_variant = TRY((callback(mixin,name_override,is_alias)));
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Break */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Break;JaktInternal::Tuple<Jakt::ids::TypeId,Jakt::ids::ScopeId> const& value = __jakt_match_value.value;
 {
 result = value;
 return Jakt::utility::IterationDecision<bool>::Break(true);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_210;};/*case end*/
+case 1 /* Continue */:{
+return Jakt::utility::IterationDecision<bool>::Continue();
+}
+goto __jakt_label_210;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_210; __jakt_label_210:;;
 }
 }
 ,ignore_mixin_scopes,root_scope)));
@@ -126,26 +108,20 @@ ErrorOr<JaktInternal::Optional<Jakt::ids::EnumId>> Jakt::types::CheckedProgram::
 {
 JaktInternal::Optional<Jakt::ids::EnumId> result = JaktInternal::OptionalNone();
 TRY((this->for_each_scope_accessible_unqualified_from_scope_impl(scope_id,[&callback, &result](Jakt::types::ResolutionMixin mixin, JaktInternal::Optional<ByteString> name_override, bool is_alias) -> ErrorOr<typename Jakt::utility::IterationDecision<bool>> {{
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<typename Jakt::utility::IterationDecision<bool>>> {
-auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer(TRY((callback(mixin,name_override,is_alias))));
-if (__jakt_enum_value.__jakt_init_index() == 1 /* Continue */) {{
-return Jakt::utility::IterationDecision<bool>::Continue();
-}
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value.__jakt_init_index() == 0 /* Break */) {auto& __jakt_match_value = __jakt_enum_value.as.Break;
-auto& value = __jakt_match_value.value;
+{auto&& __jakt_match_variant = TRY((callback(mixin,name_override,is_alias)));
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Break */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Break;Jakt::ids::EnumId const& value = __jakt_match_value.value;
 {
 result = value;
 return Jakt::utility::IterationDecision<bool>::Break(true);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_211;};/*case end*/
+case 1 /* Continue */:{
+return Jakt::utility::IterationDecision<bool>::Continue();
+}
+goto __jakt_label_211;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_211; __jakt_label_211:;;
 }
 }
 ,ignore_mixin_scopes,root_scope)));
@@ -157,26 +133,20 @@ ErrorOr<JaktInternal::Optional<Jakt::ids::TraitId>> Jakt::types::CheckedProgram:
 {
 JaktInternal::Optional<Jakt::ids::TraitId> result = JaktInternal::OptionalNone();
 TRY((this->for_each_scope_accessible_unqualified_from_scope_impl(scope_id,[&callback, &result](Jakt::types::ResolutionMixin mixin, JaktInternal::Optional<ByteString> name_override, bool is_alias) -> ErrorOr<typename Jakt::utility::IterationDecision<bool>> {{
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<typename Jakt::utility::IterationDecision<bool>>> {
-auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer(TRY((callback(mixin,name_override,is_alias))));
-if (__jakt_enum_value.__jakt_init_index() == 1 /* Continue */) {{
-return Jakt::utility::IterationDecision<bool>::Continue();
-}
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value.__jakt_init_index() == 0 /* Break */) {auto& __jakt_match_value = __jakt_enum_value.as.Break;
-auto& value = __jakt_match_value.value;
+{auto&& __jakt_match_variant = TRY((callback(mixin,name_override,is_alias)));
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Break */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Break;Jakt::ids::TraitId const& value = __jakt_match_value.value;
 {
 result = value;
 return Jakt::utility::IterationDecision<bool>::Break(true);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_212;};/*case end*/
+case 1 /* Continue */:{
+return Jakt::utility::IterationDecision<bool>::Continue();
+}
+goto __jakt_label_212;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_212; __jakt_label_212:;;
 }
 }
 ,ignore_mixin_scopes,root_scope)));
@@ -188,26 +158,20 @@ ErrorOr<JaktInternal::Optional<Jakt::ids::StructId>> Jakt::types::CheckedProgram
 {
 JaktInternal::Optional<Jakt::ids::StructId> result = JaktInternal::OptionalNone();
 TRY((this->for_each_scope_accessible_unqualified_from_scope_impl(scope_id,[&callback, &result](Jakt::types::ResolutionMixin mixin, JaktInternal::Optional<ByteString> name_override, bool is_alias) -> ErrorOr<typename Jakt::utility::IterationDecision<bool>> {{
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<typename Jakt::utility::IterationDecision<bool>>> {
-auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer(TRY((callback(mixin,name_override,is_alias))));
-if (__jakt_enum_value.__jakt_init_index() == 1 /* Continue */) {{
-return Jakt::utility::IterationDecision<bool>::Continue();
-}
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value.__jakt_init_index() == 0 /* Break */) {auto& __jakt_match_value = __jakt_enum_value.as.Break;
-auto& value = __jakt_match_value.value;
+{auto&& __jakt_match_variant = TRY((callback(mixin,name_override,is_alias)));
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Break */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Break;Jakt::ids::StructId const& value = __jakt_match_value.value;
 {
 result = value;
 return Jakt::utility::IterationDecision<bool>::Break(true);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_213;};/*case end*/
+case 1 /* Continue */:{
+return Jakt::utility::IterationDecision<bool>::Continue();
+}
+goto __jakt_label_213;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_213; __jakt_label_213:;;
 }
 }
 ,ignore_mixin_scopes,root_scope)));
@@ -219,26 +183,20 @@ ErrorOr<JaktInternal::Optional<bool>> Jakt::types::CheckedProgram::for_each_scop
 {
 JaktInternal::Optional<bool> result = JaktInternal::OptionalNone();
 TRY((this->for_each_scope_accessible_unqualified_from_scope_impl(scope_id,[&callback, &result](Jakt::types::ResolutionMixin mixin, JaktInternal::Optional<ByteString> name_override, bool is_alias) -> ErrorOr<typename Jakt::utility::IterationDecision<bool>> {{
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<typename Jakt::utility::IterationDecision<bool>>> {
-auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer(TRY((callback(mixin,name_override,is_alias))));
-if (__jakt_enum_value.__jakt_init_index() == 1 /* Continue */) {{
-return Jakt::utility::IterationDecision<bool>::Continue();
-}
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value.__jakt_init_index() == 0 /* Break */) {auto& __jakt_match_value = __jakt_enum_value.as.Break;
-auto& value = __jakt_match_value.value;
+{auto&& __jakt_match_variant = TRY((callback(mixin,name_override,is_alias)));
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Break */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Break;bool const& value = __jakt_match_value.value;
 {
 result = value;
 return Jakt::utility::IterationDecision<bool>::Break(true);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_214;};/*case end*/
+case 1 /* Continue */:{
+return Jakt::utility::IterationDecision<bool>::Continue();
+}
+goto __jakt_label_214;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_214; __jakt_label_214:;;
 }
 }
 ,ignore_mixin_scopes,root_scope)));
@@ -250,26 +208,20 @@ ErrorOr<JaktInternal::Optional<JaktInternal::Tuple<Jakt::ids::ScopeId,bool>>> Ja
 {
 JaktInternal::Optional<JaktInternal::Tuple<Jakt::ids::ScopeId,bool>> result = JaktInternal::OptionalNone();
 TRY((this->for_each_scope_accessible_unqualified_from_scope_impl(scope_id,[&callback, &result](Jakt::types::ResolutionMixin mixin, JaktInternal::Optional<ByteString> name_override, bool is_alias) -> ErrorOr<typename Jakt::utility::IterationDecision<bool>> {{
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<typename Jakt::utility::IterationDecision<bool>>> {
-auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer(TRY((callback(mixin,name_override,is_alias))));
-if (__jakt_enum_value.__jakt_init_index() == 1 /* Continue */) {{
-return Jakt::utility::IterationDecision<bool>::Continue();
-}
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value.__jakt_init_index() == 0 /* Break */) {auto& __jakt_match_value = __jakt_enum_value.as.Break;
-auto& value = __jakt_match_value.value;
+{auto&& __jakt_match_variant = TRY((callback(mixin,name_override,is_alias)));
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Break */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Break;JaktInternal::Tuple<Jakt::ids::ScopeId,bool> const& value = __jakt_match_value.value;
 {
 result = value;
 return Jakt::utility::IterationDecision<bool>::Break(true);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_215;};/*case end*/
+case 1 /* Continue */:{
+return Jakt::utility::IterationDecision<bool>::Continue();
+}
+goto __jakt_label_215;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_215; __jakt_label_215:;;
 }
 }
 ,ignore_mixin_scopes,root_scope)));
@@ -281,26 +233,20 @@ ErrorOr<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Ja
 {
 JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::ids::FunctionId>,Jakt::ids::ScopeId>> result = JaktInternal::OptionalNone();
 TRY((this->for_each_scope_accessible_unqualified_from_scope_impl(scope_id,[&callback, &result](Jakt::types::ResolutionMixin mixin, JaktInternal::Optional<ByteString> name_override, bool is_alias) -> ErrorOr<typename Jakt::utility::IterationDecision<bool>> {{
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<typename Jakt::utility::IterationDecision<bool>>> {
-auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer(TRY((callback(mixin,name_override,is_alias))));
-if (__jakt_enum_value.__jakt_init_index() == 1 /* Continue */) {{
-return Jakt::utility::IterationDecision<bool>::Continue();
-}
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value.__jakt_init_index() == 0 /* Break */) {auto& __jakt_match_value = __jakt_enum_value.as.Break;
-auto& value = __jakt_match_value.value;
+{auto&& __jakt_match_variant = TRY((callback(mixin,name_override,is_alias)));
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 0 /* Break */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Break;JaktInternal::Tuple<JaktInternal::DynamicArray<Jakt::ids::FunctionId>,Jakt::ids::ScopeId> const& value = __jakt_match_value.value;
 {
 result = value;
 return Jakt::utility::IterationDecision<bool>::Break(true);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
+goto __jakt_label_216;};/*case end*/
+case 1 /* Continue */:{
+return Jakt::utility::IterationDecision<bool>::Continue();
+}
+goto __jakt_label_216;default: VERIFY_NOT_REACHED();}/*switch end*/
+}goto __jakt_label_216; __jakt_label_216:;;
 }
 }
 ,ignore_mixin_scopes,root_scope)));

--- a/bootstrap/stage0/utility.cpp
+++ b/bootstrap/stage0/utility.cpp
@@ -149,35 +149,20 @@ break;
 }
 u32 cp = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ByteString> {
-auto __jakt_enum_value = (cp);
+{auto __jakt_enum_value = cp;
 if (__jakt_enum_value == infallible_integer_cast<u32>(static_cast<u8>(u8'"'))) {{
 builder.append(StringView::from_string_literal("\\\""sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == infallible_integer_cast<u32>(static_cast<u8>(u8'\\'))) {{
+goto __jakt_label_0;}else if (__jakt_enum_value == infallible_integer_cast<u32>(static_cast<u8>(u8'\\'))) {{
 builder.append(StringView::from_string_literal("\\\\"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == infallible_integer_cast<u32>(static_cast<u8>(u8'\n'))) {{
+goto __jakt_label_0;}else if (__jakt_enum_value == infallible_integer_cast<u32>(static_cast<u8>(u8'\n'))) {{
 builder.append(StringView::from_string_literal("\\n"sv));
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_0;}else {{
 builder.append_code_point(cp);
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_0;}}goto __jakt_label_0; __jakt_label_0:;;
 }
 
 }
@@ -200,9 +185,7 @@ break;
 }
 u32 cp = _magic_value.value();
 {
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ByteString> {
-auto __jakt_enum_value = (cp);
+{auto __jakt_enum_value = cp;
 if (__jakt_enum_value == infallible_integer_cast<u32>(static_cast<u8>(u8'\\'))) {{
 if (in_escape){
 builder.append(static_cast<u8>(u8'\\'));
@@ -213,13 +196,11 @@ in_escape = true;
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-}else if ((__jakt_enum_value == infallible_integer_cast<u32>(static_cast<u8>(u8'"')))||(__jakt_enum_value == infallible_integer_cast<u32>(static_cast<u8>(u8'\'')))) {{
+goto __jakt_label_1;}else if ((__jakt_enum_value == infallible_integer_cast<u32>(static_cast<u8>(u8'"')))||(__jakt_enum_value == infallible_integer_cast<u32>(static_cast<u8>(u8'\'')))) {{
 builder.append_code_point(cp);
 in_escape = false;
 }
-return JaktInternal::ExplicitValue<void>();
-}else if (__jakt_enum_value == infallible_integer_cast<u32>(static_cast<u8>(u8'n'))) {{
+goto __jakt_label_1;}else if (__jakt_enum_value == infallible_integer_cast<u32>(static_cast<u8>(u8'n'))) {{
 if (in_escape){
 builder.append(static_cast<u8>(u8'\n'));
 in_escape = false;
@@ -229,22 +210,11 @@ builder.append_code_point(cp);
 }
 
 }
-return JaktInternal::ExplicitValue<void>();
-}else {{
+goto __jakt_label_1;}else {{
 builder.append_code_point(cp);
 in_escape = false;
 }
-return JaktInternal::ExplicitValue<void>();
-}return JaktInternal::ExplicitValue<void>();
-}());
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
+goto __jakt_label_1;}}goto __jakt_label_1; __jakt_label_1:;;
 }
 
 }

--- a/selfhost/cpp_import/clang.jakt
+++ b/selfhost/cpp_import/clang.jakt
@@ -26,9 +26,9 @@ import cpp_import::clang_c {
     clang_EvalResult_getAsDouble, clang_EvalResult_getAsInt, clang_EvalResult_getAsLongLong
     clang_EvalResult_getAsStr, clang_EvalResult_getAsUnsigned, clang_EvalResult_getKind
     clang_EvalResult_isUnsignedInt, clang_Type_getNamedType, clang_Type_getNumTemplateArguments
-    clang_Type_getSizeOf, clang_Type_getTemplateArgumentAsType, clang_createIndex, clang_createTranslationUnit
-    clang_disposeIndex, clang_disposeString, clang_disposeTokens, clang_disposeTranslationUnit, clang_equalCursors
-    clang_getArgType, clang_getArrayElementType, clang_getArraySize, clang_getCString, clang_getCanonicalCursor
+    clang_Type_getSizeOf, clang_Type_getTemplateArgumentAsType, clang_createIndex, clang_disposeIndex
+    clang_disposeString, clang_disposeTokens, clang_disposeTranslationUnit, clang_equalCursors, clang_getArgType
+    clang_getArrayElementType, clang_getArraySize, clang_getCString, clang_getCanonicalCursor
     clang_getCanonicalType, clang_getCursorDefinition, clang_getCursorExtent, clang_getCursorKind
     clang_getCursorKindSpelling, clang_getCursorLocation, clang_getCursorPrettyPrinted
     clang_getCursorPrintingPolicy, clang_getCursorResultType, clang_getCursorSemanticParent, clang_getCursorSpelling
@@ -1405,7 +1405,7 @@ class CppImportProcessor {
                 )
             }
             else => {
-                if .debug_print { 
+                if .debug_print {
                     let k = clang_getCursorKind(cursor)
                     let v = clang_getCursorKindSpelling(k)
                     eprintln("Unsupported template cursor kind: {}", string_from(v))
@@ -2451,82 +2451,63 @@ class CppImportProcessor {
             end: 0
         )
 
-        // Check if a PCH exists for this file
         mut tu = CXTranslationUnit()
 
-        let path_separator_string = format("{:c}", get_path_separator())
-        let pch_file_path = program.compiler.binary_dir.join(
-            filename.replace(replace: path_separator_string, with: "_")
-        ).replace_extension("pch")
-
-        if pch_file_path.exists() {
-            // Parse the TU from the PCH
-            tu = clang_createTranslationUnit(index: .index, file_name: pch_file_path.to_string().c_string())
+        mut includes = program.compiler.include_paths[..].to_array()
+        if clang_runtime_dir.has_value() {
+            includes.push(clang_runtime_dir!)
         }
 
-        if tu == CXTranslationUnit() {
-            mut includes = program.compiler.include_paths[..].to_array()
-            if clang_runtime_dir.has_value() {
-                includes.push(clang_runtime_dir!)
-            }
+        mut args_storage = [""; 3 + includes.size() + defines.size()]
+        if is_c {
+            args_storage[0] = "-xc"
+            args_storage[1] = "-std=c11"
+        } else {
+            args_storage[0] = "-xc++-header"
+            args_storage[1] = "-std=c++23"
+        }
+        args_storage[2] = format("--target={}", program.compiler.target_triple ?? Target::active().name())
 
-            mut args_storage = [""; 3 + includes.size() + defines.size()]
-            if is_c {
-                args_storage[0] = "-xc"
-                args_storage[1] = "-std=c11"
-            } else {
-                args_storage[0] = "-xc++-header"
-                args_storage[1] = "-std=c++23"
-            }
-            args_storage[2] = format("--target={}", program.compiler.target_triple ?? Target::active().name())
+        for i in 0..includes.size() {
+            args_storage[i + 2] = format("-I{}", includes[i])
+        }
 
-            for i in 0..includes.size() {
-                args_storage[i + 2] = format("-I{}", includes[i])
-            }
+        mut defines_it = defines.iterator()
+        for i in 0..defines.size() {
+            let (key, value) = defines_it.next()!
+            args_storage[i + 2 + includes.size()] = format("-D{}={}", key, value)
+        }
 
-            mut defines_it = defines.iterator()
-            for i in 0..defines.size() {
-                let (key, value) = defines_it.next()!
-                args_storage[i + 2 + includes.size()] = format("-D{}={}", key, value)
-            }
+        mut args = allocate<raw c_char>(count: args_storage.size())
+        let r = bitcast<raw c_char>(args)
+        defer free(r)
 
-            mut args = allocate<raw c_char>(count: args_storage.size())
-            let r = bitcast<raw c_char>(args)
-            defer free(r)
+        for i in 0..args_storage.size() {
+            unsafe { cpp { "args[i] = const_cast<char*>(args_storage[i].characters());" } }
+        }
 
-            for i in 0..args_storage.size() {
-                unsafe { cpp { "args[i] = const_cast<char*>(args_storage[i].characters());" } }
-            }
-
-            let err = clang_parseTranslationUnit2(
-                index: .index
-                source_filename: filename.c_string()
-                command_line_args: args
-                num_command_line_args: args_storage.size() as! c_int
-                unsaved_files: null<raw CXUnsavedFile>()
-                num_unsaved_files: 0
-                options: (
-                    CXTranslationUnit_Flags::CXTranslationUnit_SkipFunctionBodies as! c_int |
-                    CXTranslationUnit_Flags::CXTranslationUnit_DetailedPreprocessingRecord as! c_int
-                )
-                out_tu: &raw tu
+        let err = clang_parseTranslationUnit2(
+            index: .index
+            source_filename: filename.c_string()
+            command_line_args: args
+            num_command_line_args: args_storage.size() as! c_int
+            unsaved_files: null<raw CXUnsavedFile>()
+            num_unsaved_files: 0
+            options: (
+                CXTranslationUnit_Flags::CXTranslationUnit_SkipFunctionBodies as! c_int |
+                CXTranslationUnit_Flags::CXTranslationUnit_DetailedPreprocessingRecord as! c_int
             )
-            if not (err is CXError_Success) {
-                eprintln("Error: {}", match err {
-                    CXError_Failure => "Failure"
-                    CXError_Crashed => "Crashed"
-                    CXError_InvalidArguments => "InvalidArguments"
-                    CXError_ASTReadError => "ASTReadError"
-                    else => "Unknown"
-                })
-                throw Error::from_string_literal(CppImportErrors::path_not_found())
-            }
-
-            clang_saveTranslationUnit(
-                tu
-                file_name: pch_file_path.to_string().c_string()
-                options: 0
-            )
+            out_tu: &raw tu
+        )
+        if not (err is CXError_Success) {
+            eprintln("Error: {}", match err {
+                CXError_Failure => "Failure"
+                CXError_Crashed => "Crashed"
+                CXError_InvalidArguments => "InvalidArguments"
+                CXError_ASTReadError => "ASTReadError"
+                else => "Unknown"
+            })
+            throw Error::from_string_literal(CppImportErrors::path_not_found())
         }
 
         let cursor = clang_getTranslationUnitCursor(tu)

--- a/selfhost/ids.jakt
+++ b/selfhost/ids.jakt
@@ -40,7 +40,7 @@ struct StructId implements(Hashable, Equal<StructId>) {
 
     [[inline(make_available)]]
     fn hash(this) -> u32 {
-        return pair_int_hash(.id.hash(), .module.hash())
+        return pair_int_hash(.id as! u32, .module.id as! u32)
     }
 }
 
@@ -51,6 +51,11 @@ struct EnumId {
     [[inline(make_available)]]
     fn equals(this, anon rhs: EnumId) -> bool {
         return this.module.id == rhs.module.id and this.id == rhs.id
+    }
+
+    [[inline(make_available)]]
+    fn hash(this) -> u32 {
+        return pair_int_hash(.id as! u32, .module.id as! u32)
     }
 }
 
@@ -67,7 +72,9 @@ struct TypeId implements(Hashable, Equal<TypeId>) {
     }
 
     [[inline(make_available)]]
-    fn hash(this) -> u32 => .id.pair_hash_with(&.module)
+    fn hash(this) -> u32 {
+        return pair_int_hash(.id as! u32, .module.id as! u32)
+    }
 }
 
 struct TraitId {
@@ -77,6 +84,11 @@ struct TraitId {
     [[inline(make_available)]]
     fn equals(this, anon other: TraitId) -> bool {
         return this.module.id == other.module.id and this.id == other.id
+    }
+
+    [[inline(make_available)]]
+    fn hash(this) -> u32 {
+        return pair_int_hash(.id as! u32, .module.id as! u32)
     }
 }
 

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -1340,17 +1340,24 @@ class Interpreter {
     }
 
     public fn find_or_add_type_id(mut this, anon type: Type) -> TypeId {
-
-        for module in .program.modules {
-            for id in 0..module.types.size() {
-                if module.types[id].equals(type) {
-                    return TypeId(module: module.id, id)
+        let type_hash = type.hash()
+        for index in 0...program.modules.size() {
+            let module = &.program.modules[index]
+            let types = &module.types
+            if module.type_skip_list.get(type_hash) is Some(head) {
+                mut current = head
+                while true {
+                    let other = &types[current.id]
+                    if other.type.equals(type) {
+                        return current
+                    }
+                    guard other.next_with_same_hash.has_value() else { break }
+                    current = other.next_with_same_hash!
                 }
             }
         }
 
-        .program.modules[0].types.push(type)
-
+        .program.modules[0].add_type(type)
         return TypeId(module: ModuleId(id: 0), id: .program.modules[0].types.size() - 1)
     }
 

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1530,12 +1530,14 @@ struct ParsedTypeQualifiers {
     is_immutable: bool = false
 }
 
-struct CheckedQualifiers implements(Equal<CheckedQualifiers>) {
+struct CheckedQualifiers implements(Equal<CheckedQualifiers>, Hashable) {
     is_immutable: bool = false
 
     fn equals(this, anon other: CheckedQualifiers) -> bool {
         return .is_immutable == other.is_immutable
     }
+
+    fn hash(this) -> u32 => .is_immutable.hash()
 }
 
 boxed enum ParsedType {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -384,32 +384,34 @@ struct Typechecker {
     fn create_module(mut this, name: String, is_root: bool, path: String? = None) -> ModuleId {
         let new_id = .program.modules.size()
         let module_id = ModuleId(id: new_id)
-        let module = Module(
+        mut module = Module(
             id: module_id,
             name: name,
-            types: [ // FIXME: use general builtin types array
-                Type::Void,
-                Type::Bool,
-                Type::U8,
-                Type::U16,
-                Type::U32,
-                Type::U64,
-                Type::I8,
-                Type::I16,
-                Type::I32,
-                Type::I64,
-                Type::F32,
-                Type::F64,
-                Type::Usize,
-                Type::JaktString,
-                Type::CChar,
-                Type::CInt,
-                Type::Unknown,
-                Type::Never
-            ],
+            types: [],
             resolved_import_path: path ?? .compiler.current_file_path()!.to_string(),
             is_root: is_root,
         )
+        for type in [
+            Type::Void
+            Type::Bool
+            Type::U8
+            Type::U16
+            Type::U32
+            Type::U64
+            Type::I8
+            Type::I16
+            Type::I32
+            Type::I64
+            Type::F32
+            Type::F64
+            Type::Usize
+            Type::JaktString
+            Type::CChar
+            Type::CInt
+            Type::Unknown
+            Type::Never
+        ] { module.add_type(type) }
+
         .program.modules.push(module)
 
         return module_id
@@ -2515,7 +2517,8 @@ struct Typechecker {
 
             mut trait_implementations: [TypeId] = []
             mut parameter = CheckedGenericParameter::make(parameter_type_id, span: gen_parameter.span)
-            module.types.push(Type::TypeVariable(name: gen_parameter.name, trait_implementations, is_value: gen_parameter.is_value))
+            let type = Type::TypeVariable(name: gen_parameter.name, trait_implementations, is_value: gen_parameter.is_value)
+            module.add_type(type)
 
             if gen_parameter.requires_list.has_value() {
                 .fill_trait_requirements(
@@ -2616,7 +2619,8 @@ struct Typechecker {
         let module_id = .current_module_id
         let enum_id = EnumId(module: .current_module_id, id: enum_index + module_enum_len)
         mut module = .current_module()
-        module.types.push(Type::Enum(enum_id))
+        let type = Type::Enum(enum_id)
+        module.add_type(type)
 
         let enum_type_id = TypeId(module: module_id, id: .current_module().types.size() - 1)
         .add_type_to_scope(scope_id, type_name: parsed_record.name, type_id: enum_type_id, span: parsed_record.name_span)
@@ -2727,7 +2731,8 @@ struct Typechecker {
             mut checked_param = CheckedGenericParameter::make(parameter_type_id, span: gen_parameter.span)
 
             mut trait_implementations: [TypeId] = []
-            module.types.push(Type::TypeVariable(name: gen_parameter.name, trait_implementations, is_value: gen_parameter.is_value))
+            let type = Type::TypeVariable(name: gen_parameter.name, trait_implementations, is_value: gen_parameter.is_value)
+            module.add_type(type)
 
             if gen_parameter.requires_list.has_value() {
                 .fill_trait_requirements(
@@ -2833,9 +2838,8 @@ struct Typechecker {
                 mut parameter = FunctionGenericParameter::parameter(type_var_type_id, span: generic_parameter.span)
 
                 mut trait_implementations: [TypeId] = []
-                module.types.push(
-                    Type::TypeVariable(name: generic_parameter.name, trait_implementations, is_value: generic_parameter.is_value)
-                )
+                let type = Type::TypeVariable(name: generic_parameter.name, trait_implementations, is_value: generic_parameter.is_value)
+                module.add_type(type)
 
                 if generic_parameter.requires_list.has_value() {
                     .fill_trait_requirements(
@@ -3243,7 +3247,8 @@ struct Typechecker {
 
             mut parameter = CheckedGenericParameter::make(parameter_type_id, span: gen_parameter.span)
             mut trait_implementations: [TypeId] = []
-            module.types.push(Type::TypeVariable(name: gen_parameter.name, trait_implementations, is_value: gen_parameter.is_value))
+            let type = Type::TypeVariable(name: gen_parameter.name, trait_implementations, is_value: gen_parameter.is_value)
+            module.add_type(type)
 
             if gen_parameter.requires_list.has_value() {
                 .fill_trait_requirements(
@@ -3357,7 +3362,8 @@ struct Typechecker {
         let module_id = .current_module_id
         let struct_id = StructId(module: .current_module_id, id: struct_index + module_struct_len)
         mut module = .current_module()
-        module.types.push(Type::Struct(struct_id))
+        let type = Type::Struct(struct_id)
+        module.add_type(type)
 
         let struct_type_id = TypeId(module: module_id, id: .current_module().types.size() - 1)
         .add_type_to_scope(scope_id, type_name: parsed_record.name, type_id: struct_type_id, span: parsed_record.name_span)
@@ -4437,9 +4443,9 @@ struct Typechecker {
             if base_definition {
                 mut parameter = FunctionGenericParameter::parameter(type_var_type_id, span: generic_parameter.span)
                 mut trait_implementations: [TypeId] = []
-                current_module.types.push(
-                    Type::TypeVariable(name: generic_parameter.name, trait_implementations, is_value: generic_parameter.is_value)
-                )
+                let type = Type::TypeVariable(name: generic_parameter.name, trait_implementations, is_value: generic_parameter.is_value)
+                current_module.add_type(type)
+
                 if generic_parameter.requires_list.has_value() {
                     .fill_trait_requirements(
                         names: generic_parameter.requires_list!,

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -7,7 +7,7 @@ import parser {
 }
 import utility { FileId, IterationDecision, Queue, Span, join, panic, todo }
 import compiler { Compiler }
-import ids { EnumId, FunctionId, ModuleId, ScopeId, StructId, TraitId, TypeId, VarId }
+import ids { EnumId, FunctionId, ModuleId, ScopeId, StructId, TraitId, TypeId, VarId, pair_int_hash }
 
 enum StructOrEnumId {
     Struct(StructId)
@@ -288,6 +288,61 @@ boxed enum Type {
     Function(params: [TypeId], can_throw: bool, return_type_id: TypeId, pseudo_function_id: FunctionId)
     Self
     Const(Value)
+
+    fn hash(this) -> u32 => match this {
+        Void => 0
+        Bool => 1
+        U8 => 2
+        U16 => 3
+        U32 => 4
+        U64 => 5
+        I8 => 6
+        I16 => 7
+        I32 => 8
+        I64 => 9
+        F32 => 10
+        F64 => 11
+        Usize => 12
+        JaktString => 13
+        CChar => 14
+        CInt => 15
+        Unknown => 16
+        Never => 17
+        TypeVariable(name, is_value) => pair_int_hash(pair_int_hash(name.hash(), is_value.hash()), 18)
+        Dependent(namespace_type, name, args) => {
+            mut hash = pair_int_hash(namespace_type.hash(), name.hash())
+            for arg in args {
+                hash = pair_int_hash(hash, arg.hash())
+            }
+            yield pair_int_hash(hash, 19)
+        }
+        GenericTraitInstance(id, args) default(code: u32 = 20)
+        | GenericEnumInstance(id, args) default(code: u32 = 21)
+        | GenericInstance(id, args) default(code: u32 = 22)
+        => {
+            mut hash = pair_int_hash(id.hash(), args.size().hash())
+            for arg in args {
+                hash = pair_int_hash(hash, arg.hash())
+            }
+            yield pair_int_hash(hash, code)
+        }
+        Struct(id) default(code: u32 = 23)
+        | Enum(id) default(code: u32 = 24)
+        | RawPtr(id) default(code: u32 = 25)
+        | Trait(id) default(code: u32 = 26)
+        | Reference(id) default(code: u32 = 27)
+        | MutableReference(id) default(code: u32 = 28)
+        => pair_int_hash(id.hash(), code)
+        Function(params, can_throw, return_type_id) => {
+            mut hash = pair_int_hash(params.size().hash(), can_throw.hash())
+            for param in params {
+                hash = pair_int_hash(hash, param.hash())
+            }
+            yield pair_int_hash(pair_int_hash(hash, return_type_id.hash()), 29)
+        }
+        Self => 30
+        Const => 31
+    }
 
     fn generic_parameters(this, program: CheckedProgram) -> [CheckedGenericParameter]? => match this {
         Struct(id) | GenericInstance(id) => Some(program.get_struct(id).generic_parameters)
@@ -708,10 +763,18 @@ struct ResolvedForallChunk {
     public generated_scopes: [ScopeId]
 }
 
+struct TypeWithSkipList {
+    type: Type
+    hash: u32
+    next_with_same_hash: TypeId? = None
+}
+
 class Module {
     public id: ModuleId
     public name: String
-    public types: [Type]
+    public types: [TypeWithSkipList]
+    // hash -> TypeId (skip list head)
+    public type_skip_list: [u32:TypeId] = [:]
     public resolved_import_path: String
     public is_root: bool
 
@@ -726,12 +789,31 @@ class Module {
 
     public fn is_prelude(this) -> bool => .id.id == 0
 
+    public fn add_type(mut this, anon type: Type) {
+        let hash = type.hash()
+        let type_with_skip_list = TypeWithSkipList(type: type, hash: hash)
+        let expecte_type_id = TypeId(module: .id, id: .types.size())
+        if .type_skip_list.get(hash) is Some(head) {
+            mut last = head
+            while true {
+                let next = .types[last.id].next_with_same_hash
+                if not next.has_value() { break }
+                last = next!
+            }
+            .types[last.id].next_with_same_hash = expecte_type_id
+        } else {
+            .type_skip_list.set(hash, expecte_type_id)
+        }
+        .types.push(type_with_skip_list)
+    }
+
     public fn new_type_variable(mut this, implemented_traits: [TypeId]? = None) -> TypeId {
         let new_id = .types.size()
 
         let empty_implementation: [TypeId] = []
         let trait_implementations = implemented_traits ?? empty_implementation
-        .types.push(Type::TypeVariable(name: format("T{}", new_id), trait_implementations))
+        let type = Type::TypeVariable(name: format("T{}", new_id), trait_implementations)
+        .add_type(type)
 
         return TypeId(module: .id, id: new_id)
     }
@@ -1884,32 +1966,33 @@ class CheckedProgram {
     public fn create_module(mut this, name: String, is_root: bool, path: String? = None) -> ModuleId {
         let new_id = .modules.size()
         let module_id = ModuleId(id: new_id)
-        let module = Module(
+        mut module = Module(
             id: module_id,
             name: name,
-            types: [ // FIXME: use general builtin types array
-                Type::Void,
-                Type::Bool,
-                Type::U8,
-                Type::U16,
-                Type::U32,
-                Type::U64,
-                Type::I8,
-                Type::I16,
-                Type::I32,
-                Type::I64,
-                Type::F32,
-                Type::F64,
-                Type::Usize,
-                Type::JaktString,
-                Type::CChar,
-                Type::CInt,
-                Type::Unknown,
-                Type::Never
-            ],
+            types: [],
             resolved_import_path: path ?? .compiler.current_file_path()!.to_string(),
             is_root: is_root,
         )
+        for type in [
+            Type::Void
+            Type::Bool
+            Type::U8
+            Type::U16
+            Type::U32
+            Type::U64
+            Type::I8
+            Type::I16
+            Type::I32
+            Type::I64
+            Type::F32
+            Type::F64
+            Type::Usize
+            Type::JaktString
+            Type::CChar
+            Type::CInt
+            Type::Unknown
+            Type::Never
+        ] { module.add_type(type) }
         .modules.push(module)
 
         return module_id
@@ -2074,7 +2157,7 @@ class CheckedProgram {
     public fn get_module(this, anon id: ModuleId) -> Module => .modules[id.id]
     public fn get_function(this, anon id: FunctionId) -> CheckedFunction => .modules[id.module.id].functions[id.id]
     public fn get_variable(this, anon id: VarId) -> CheckedVariable => .modules[id.module.id].variables[id.id]
-    public fn get_type(this, anon id: TypeId) -> Type => .modules[id.module.id].types[id.id]
+    public fn get_type(this, anon id: TypeId) -> Type => .modules[id.module.id].types[id.id].type
     public fn get_enum(this, anon id: EnumId) -> CheckedEnum => .modules[id.module.id].enums[id.id]
     public fn get_struct(this, anon id: StructId) -> CheckedStruct => .modules[id.module.id].structures[id.id]
     public fn get_scope(this, anon id: ScopeId) -> Scope => .modules[id.module_id.id].scopes[id.id]
@@ -2941,24 +3024,27 @@ class CheckedProgram {
     }
 
     public fn find_or_add_type_id(mut this, anon type: Type, module_id: ModuleId, only_in_current_module: bool = false) -> TypeId {
-        if only_in_current_module {
-            let types = &.get_module(module_id).types
-            for id in 0..types.size() {
-                if types[id].equals(type) {
-                    return TypeId(module: module_id, id)
-                }
-            }
-        } else {
-            for module in .modules {
-                for id in 0..module.types.size() {
-                    if module.types[id].equals(type) {
-                        return TypeId(module: module.id, id)
+        let type_hash = type.hash()
+        mut modules_to_search = module_id.id..(module_id.id + 1)
+        if not only_in_current_module { modules_to_search = 0...modules.size() }
+
+        for index in modules_to_search {
+            let module = &.modules[index]
+            let types = &module.types
+            if module.type_skip_list.get(type_hash) is Some(head) {
+                mut current = head
+                while true {
+                    let other = &types[current.id]
+                    if other.type.equals(type) {
+                        return current
                     }
+                    guard other.next_with_same_hash.has_value() else { break }
+                    current = other.next_with_same_hash!
                 }
             }
         }
 
-        .modules[module_id.id].types.push(type)
+        .modules[module_id.id].add_type(type)
 
         return TypeId(module: module_id, id: .modules[module_id.id].types.size() - 1)
     }


### PR DESCRIPTION
This speeds up find_or_add_type_id() using one major observation and
two observations:
  - A type does not change significantly once it's created
  - The type can have a more lax hash that ignores large parts of the
    type
  - There aren't that many types with the same lax hash actually

In this commit, the type list in a module gains a skiplist where each
"lane" is reserved for a specific hash; this list grows linearly with
the number of unique hashes, as each entry tracks its own next-in-list
object.

Overall, this is a ~40% performance increase when typechecking the
compiler, and a ~11% increase when typechecking all the tests in the
repository.