### PR TITLE
compiler: Use --assume-main-file-path as relative path for imports

### DIFF
--- a/selfhost/compiler.jakt
+++ b/selfhost/compiler.jakt
@@ -187,10 +187,7 @@ class Compiler {
     }
 
     public fn find_in_search_paths(this, anon path: Path, relative_import: bool = false, parent_path_count: usize = 0) throws -> Path? {
-        let current_file_path = match relative_import {
-            true => .current_file_path()
-            false => .assume_main_file_path ?? .current_file_path()
-        }
+        let current_file_path = .assume_main_file_path ?? .current_file_path()
         if current_file_path.has_value() {
             mut candidate_path = current_file_path!.absolute().parent()
             if relative_import and parent_path_count > 0 {


### PR DESCRIPTION
This PR fixes an issue with IDE integration where the compiler would use the relative path of the temporary file for imports, rather than the main file path specified.