### PR TITLE
cmake: Precompile `runtime/lib.h`

### DIFF
--- a/cmake/jakt-executable.cmake
+++ b/cmake/jakt-executable.cmake
@@ -153,6 +153,7 @@ function(add_jakt_executable executable)
   endforeach()
 
   add_jakt_compiler_flags("${executable}")
+  target_precompile_headers("${executable}" PRIVATE "${runtime_path}/lib.h")
 
   target_include_directories("${executable}" BEFORE PRIVATE "$<BUILD_INTERFACE:${runtime_path}>")
   foreach(path IN LISTS JAKT_EXECUTABLE_INCLUDES)


### PR DESCRIPTION
It is a big header included in all C++ files generated by Jakt, so when
profiling a C++ build it takes nearly 40% of the time for frontend
analysis.

Although it would be nice to configure it in `runtime/lib.h`, I could
not get it to work with the same line, so it'd be appreciated.

This is the low hanging fruit of more steps we could take towards making
the build share more code. Automatically deciding on where to put PCH
files sounds interesting but introduces a burden on configuring via
cmake. Another solution I can think of is C++ modules, although that is
going to need more iteration.

Below are the summaries from `ClangBuildAnalyzer`, before and after:
[summary-after.txt](https://github.com/user-attachments/files/20772918/summary-after.txt)
[summary-before.txt](https://github.com/user-attachments/files/20772920/summary-before.txt)

