### PR TITLE
everywhere: Allow descructuring assignments

### DIFF
--- a/samples/tuples/destructuring_assignment.jakt
+++ b/samples/tuples/destructuring_assignment.jakt
@@ -1,11 +1,42 @@
 /// Expect:
-/// - output: "1 hello\n"
+/// - output: "1 hello\n2 world\n1 2 3\n7 8 9\n10 11 12 13\n"
 
 fn foo() throws -> (i64, String) {
     return (1, "hello")
 }
 
+fn bar() throws -> (i64, String) {
+    return (2, "world")
+}
+
 fn main() {
-    let (x1, x2) = foo()
-    println("{} {}", x1, x2)
+    mut a1 = 0
+    mut a2 = ""
+    (a1, a2) = foo()
+    println("{} {}", a1, a2)
+
+    (a1, a2) = bar()
+    println("{} {}", a1, a2)
+
+    let nested_tuple = (1, (2, 3))
+    mut b = 0
+    mut c = 0
+    mut d = 0
+    (b, (c, d)) = nested_tuple
+    println("{} {} {}", b, c, d)
+
+    let left_nested = ((7, 8), 9)
+    mut h = 0
+    mut i = 0
+    mut j = 0
+    ((h, i), j) = left_nested
+    println("{} {} {}", h, i, j)
+
+    let deep_nested = (10, (11, (12, 13)))
+    mut n = 0
+    mut o = 0
+    mut p = 0
+    mut q = 0
+    (n, (o, (p, q))) = deep_nested
+    println("{} {} {} {}", n, o, p, q)
 }

--- a/samples/tuples/destructuring_declaration.jakt
+++ b/samples/tuples/destructuring_declaration.jakt
@@ -1,0 +1,28 @@
+/// Expect:
+/// - output: "1 hello\n1 2 3\n7 8 9\n10 11 12 13\n"
+
+fn foo() throws -> (i64, String) {
+    return (1, "hello")
+}
+
+fn main() {
+    let (x1, x2) = foo()
+    println("{} {}", x1, x2)
+
+    // NOTE: Nested destructuring directly in a single let is not yet supported.
+    // You must destructure one level at a time, as shown below.
+    // (e.g. `let ((a, b), c) = ((1, 2), 3)` will fail today.)
+
+    let (b, nested_right) = (1, (2, 3))
+    let (c, d) = nested_right
+    println("{} {} {}", b, c, d)
+
+    let (nested_left, j) = ((7, 8), 9)
+    let (h, i) = nested_left
+    println("{} {} {}", h, i, j)
+
+    let (n, nested_mid) = (10, (11, (12, 13)))
+    let (o, nested_inner) = nested_mid
+    let (p, q) = nested_inner
+    println("{} {} {} {}", n, o, p, q)
+}

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -4923,7 +4923,7 @@ struct CodeGenerator {
             Garbage => {
                 panic("Garbage statement in codegen")
             }
-            DestructuringAssignment(vars, var_decl) => {
+            DestructuringDeclaration(vars, var_decl) => {
                 .codegen_statement(statement: var_decl, &mut output)
 
                 for v in vars {
@@ -5961,7 +5961,7 @@ fn has_control_flow(anon stmt: CheckedStatement, include_loop_control_flow: bool
     Expression(expr) => has_control_flow(expr, include_loop_control_flow)
     // throw is not considered control flow because it uses the return value to forward errors, which is declared by the surrounding IIFE.
     Defer | Throw | Yield | Garbage => false
-    DestructuringAssignment(var_decl) => has_control_flow(var_decl, include_loop_control_flow)
+    DestructuringDeclaration(var_decl) => has_control_flow(var_decl, include_loop_control_flow)
     VarDecl(init) => has_control_flow(init, include_loop_control_flow)
     If(condition, then_block, else_statement) => has_control_flow(condition, include_loop_control_flow) or has_control_flow(then_block, include_loop_control_flow) or has_control_flow(else_statement, include_loop_control_flow)
     Block(block) => has_control_flow(block, include_loop_control_flow)

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -621,7 +621,7 @@ fn find_span_in_statement(program: CheckedProgram, statement: CheckedStatement, 
             }
             yield find_span_in_block(program, block, span)
         }
-        DestructuringAssignment(vars, var_decl) => {
+        DestructuringDeclaration(vars, var_decl) => {
             for var in vars {
                 let found = find_span_in_statement(program, statement: var, span)
                 if found.has_value() {

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -1052,7 +1052,7 @@ class Interpreter {
     ) throws -> CheckedStatement => match statement {
         Expression(expr, span) => CheckedStatement::Expression(expr: .perform_final_interpretation_expr_pass(expr, scope, function_id), span)
         Defer(statement, span) => CheckedStatement::Defer(statement: .perform_final_interpretation_pass(statement, scope, function_id), span)
-        DestructuringAssignment(vars, var_decl, span) => CheckedStatement::DestructuringAssignment(vars: vars, var_decl: .perform_final_interpretation_pass(statement: var_decl, scope, function_id), span)
+        DestructuringDeclaration(vars, var_decl, span) => CheckedStatement::DestructuringDeclaration(vars: vars, var_decl: .perform_final_interpretation_pass(statement: var_decl, scope, function_id), span)
         VarDecl(var_id, init, span) => CheckedStatement::VarDecl(var_id, init: .perform_final_interpretation_expr_pass(expr: init, scope, function_id), span)
         If(condition, then_block, else_statement, span) => {
             let new_condition = .perform_final_interpretation_expr_pass(expr: condition, scope, function_id)
@@ -3694,7 +3694,7 @@ class Interpreter {
             Defer(statement) => {
                 scope.defer_statement(statement)
             }
-            DestructuringAssignment(vars, var_decl) => {
+            DestructuringDeclaration(vars, var_decl) => {
                 guard var_decl is VarDecl(var_id, init) else {
                     panic("expected vardecl")
                 }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -593,7 +593,7 @@ boxed enum ParsedStatement {
     Expression(expr: ParsedExpression, span: Span)
     Defer(statement: ParsedStatement, span: Span)
     UnsafeBlock(block: ParsedBlock, span: Span)
-    DestructuringAssignment(vars: [ParsedVarDecl], var_decl: ParsedStatement, span: Span)
+    DestructuringDeclaration(vars: [ParsedVarDecl], var_decl: ParsedStatement, span: Span)
     VarDecl(var: ParsedVarDecl, init: ParsedExpression, span: Span)
     If(condition: ParsedExpression, then_block: ParsedBlock, else_statement: ParsedStatement?, span: Span)
     Block(block: ParsedBlock, span: Span)
@@ -626,8 +626,8 @@ boxed enum ParsedStatement {
             VarDecl(var: rhs_var, init: rhs_init) => lhs_var.equals(rhs_var) and lhs_init.equals(rhs_init)
             else => false
         }
-        DestructuringAssignment(vars: lhs_vars, var_decl: lhs_var_decl) => match rhs_statement {
-            DestructuringAssignment(vars: rhs_vars, var_decl: rhs_var_decl) => {
+        DestructuringDeclaration(vars: lhs_vars, var_decl: lhs_var_decl) => match rhs_statement {
+            DestructuringDeclaration(vars: rhs_vars, var_decl: rhs_var_decl) => {
                 if lhs_vars.size() != rhs_vars.size() {
                     return false
                 }
@@ -4851,7 +4851,7 @@ struct Parser {
 
                 if is_destructuring_assingment {
                     let old_return_statement = return_statement
-                    return_statement = ParsedStatement::DestructuringAssignment(vars, var_decl: old_return_statement, span: merge_spans(start, .previous().span()))
+                    return_statement = ParsedStatement::DestructuringDeclaration(vars, var_decl: old_return_statement, span: merge_spans(start, .previous().span()))
                 }
                 yield return_statement
             }
@@ -4983,7 +4983,7 @@ struct Parser {
             )
             let init = ParsedExpression::Var(name: iterator_name, span: merge_spans(start_span, .previous().span()))
             let var_decl = ParsedStatement::VarDecl(var: tuple_var_decl, init, span: merge_spans(start_span, .previous().span()))
-            let destructured_vars_stmt = ParsedStatement::DestructuringAssignment(vars: destructured_var_decls, var_decl, span: merge_spans(start_span, .previous().span()))
+            let destructured_vars_stmt = ParsedStatement::DestructuringDeclaration(vars: destructured_var_decls, var_decl, span: merge_spans(start_span, .previous().span()))
             mut block_stmts: [ParsedStatement] = []
             block_stmts.push(destructured_vars_stmt)
             block_stmts.push_values(&block.stmts)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -6743,7 +6743,7 @@ struct Typechecker {
         Continue(span) => .typecheck_continue(span)
         Break(span) => .typecheck_break(span)
         VarDecl(var, init, span) => .typecheck_and_register_var_decl(var, init, scope_id, safety_mode, span)
-        DestructuringAssignment(vars, var_decl, span) => .typecheck_destructuring_assignment(vars, var_decl, scope_id, safety_mode, span)
+        DestructuringDeclaration(vars, var_decl, span) => .typecheck_destructuring_declaration(vars, var_decl, scope_id, safety_mode, span)
         If(condition, then_block, else_statement, span) => .typecheck_if(condition, then_block, else_statement, scope_id, safety_mode, span)
         Garbage(span) => CheckedStatement::Garbage(span)
         For(iterator_name, name_span, is_destructuring, range, block, span) => .typecheck_for(iterator_name, name_span, is_destructuring, range, block, scope_id, safety_mode, span)
@@ -7257,7 +7257,7 @@ struct Typechecker {
         return CheckedStatement::If(condition: checked_condition, then_block: checked_block, else_statement: checked_else, span)
     }
 
-    fn typecheck_destructuring_assignment(mut this, vars: [ParsedVarDecl], var_decl: ParsedStatement, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
+    fn typecheck_destructuring_declaration(mut this, vars: [ParsedVarDecl], var_decl: ParsedStatement, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
         mut var_decls: [CheckedStatement] = []
         let checked_tuple_var_decl = .typecheck_statement(statement: var_decl, scope_id, safety_mode)
         mut expr_type_id: TypeId = unknown_type_id()

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -6730,7 +6730,15 @@ struct Typechecker {
     }
 
     fn typecheck_statement(mut this, anon statement: ParsedStatement, scope_id: ScopeId, safety_mode: SafetyMode, type_hint: TypeHint? = None) throws -> CheckedStatement => match statement {
-        Expression(expr, span) => CheckedStatement::Expression(expr: .typecheck_expression(expr, scope_id, safety_mode, type_hint: None), span)
+        Expression(expr, span) => {
+            // Detect tuple assignment expressed as a BinaryOp with Assign and a tuple on the LHS,
+            // and handle it via the tuple-assignment path.
+            if expr is BinaryOp(lhs, op, rhs) and op is Assign and lhs is JaktTuple(values) {
+                return .typecheck_tuple_assignment(lhs_values: values, rhs, scope_id, safety_mode, span)
+            }
+
+            yield CheckedStatement::Expression(expr: .typecheck_expression(expr, scope_id, safety_mode, type_hint: None), span)
+        }
         UnsafeBlock(block, span) => CheckedStatement::Block(block: .typecheck_block(block, parent_scope_id: scope_id, safety_mode: SafetyMode::Unsafe), span)
         Yield(expr, span) => .typecheck_yield(expr, span, scope_id, safety_mode, type_hint)
         Return(expr, span) => .typecheck_return(expr, span, scope_id, safety_mode)
@@ -7292,7 +7300,153 @@ struct Typechecker {
             .error("Tuple inner types sould have same size as tuple members", span)
         }
 
-        return CheckedStatement::DestructuringAssignment(vars: var_decls, var_decl: checked_tuple_var_decl, span)
+        return CheckedStatement::DestructuringDeclaration(vars: var_decls, var_decl: checked_tuple_var_decl, span)
+    }
+
+    fn typecheck_tuple_element_assignment(
+        mut this
+        lhs: ParsedExpression
+        rhs: ParsedExpression
+        scope_id: ScopeId
+        safety_mode: SafetyMode
+    ) throws -> [CheckedStatement] {
+        match lhs {
+            // Simple variable assignment
+            Var => {
+                let assign_stmt = ParsedStatement::Expression(
+                    expr: ParsedExpression::BinaryOp(
+                        lhs,
+                        op: BinaryOperator::Assign,
+                        rhs,
+                        span: lhs.span()
+                    )
+                    span: lhs.span()
+                )
+                let checked_assign = .typecheck_statement(assign_stmt, scope_id, safety_mode)
+                return [checked_assign]
+            }
+
+            // Nested tuple assignment - handle recursively
+            JaktTuple(values) => {
+                // Create a temporary variable for the nested tuple RHS
+                let nested_tmp_name = format("__jakt_nested_tuple_tmp{}", .temp_var_count)
+                .temp_var_count++
+
+                let nested_tmp_decl = ParsedVarDecl(
+                    name: nested_tmp_name,
+                    parsed_type: ParsedType::Empty,
+                    is_mutable: false,
+                    inlay_span: None,
+                    span: lhs.span()
+                )
+
+                let nested_var_decl_stmt = ParsedStatement::VarDecl(var: nested_tmp_decl, init: rhs, span: lhs.span())
+                let checked_nested_tmp_decl = .typecheck_statement(nested_var_decl_stmt, scope_id, safety_mode)
+
+                mut nested_assignments: [CheckedStatement] = []
+                nested_assignments.push(checked_nested_tmp_decl)
+
+                // Recursively handle each element in the nested tuple
+                for i in 0..values.size() {
+                    let nested_lhs = values[i]
+                    let nested_rhs = ParsedExpression::IndexedTuple(
+                        expr: ParsedExpression::Var(name: nested_tmp_name, span: lhs.span()),
+                        index: i,
+                        is_optional: false,
+                        span: nested_lhs.span()
+                    )
+
+                    let nested_element_assignments = .typecheck_tuple_element_assignment(
+                        lhs: nested_lhs,
+                        rhs: nested_rhs,
+                        scope_id,
+                        safety_mode
+                    )
+                    nested_assignments.push_values(&nested_element_assignments)
+                }
+
+                return nested_assignments
+            }
+
+            // Other expressions - not allowed in tuple destructuring
+            else => {
+                .error("Left-hand side of tuple assignment must be variables or nested tuples", lhs.span())
+                return []
+            }
+        }
+    }
+
+    fn typecheck_tuple_assignment(
+        mut this
+        lhs_values: [ParsedExpression]
+        rhs: ParsedExpression
+        scope_id: ScopeId
+        safety_mode: SafetyMode
+        span: Span
+    ) throws -> CheckedStatement {
+        // Create a fresh temporary to hold the RHS so we evaluate it once.
+        let tmp_name = format("__jakt_tuple_assign_tmp{}", .temp_var_count)
+        .temp_var_count++
+
+        let tmp_decl = ParsedVarDecl(
+            name: tmp_name
+            parsed_type: ParsedType::Empty
+            // temporary mutability is not required; keep it immutable
+            is_mutable: false
+            inlay_span: None
+            span
+        )
+
+        let var_decl_stmt = ParsedStatement::VarDecl(var: tmp_decl, init: rhs, span)
+        let checked_tmp_decl = .typecheck_statement(var_decl_stmt, scope_id, safety_mode)
+
+        // Inspect the type of RHS to ensure it is a tuple and get element types/arity.
+        mut expr_type_id: TypeId = unknown_type_id()
+        if checked_tmp_decl is VarDecl(var_id, init) {
+            expr_type_id = init.type()
+        } else {
+            .error("Internal error: tuple assignment temp is not a VarDecl", span)
+        }
+
+        let tuple_type = .get_type(expr_type_id)
+        mut element_count = 0uz
+        match tuple_type {
+            GenericInstance(id, args) => {
+                // Confirm it's a Tuple<T...>
+                if .get_struct(id).name == "Tuple" {
+                    element_count = args.size()
+                }
+            }
+            else => {}
+        }
+
+        if element_count == 0 or lhs_values.size() != element_count {
+            .error("Tuple assignment arity mismatch", span)
+        }
+
+        // Build assignment statements: lhs_i = tmp[i]
+        mut assignments: [CheckedStatement] = []
+        for i in 0..lhs_values.size() {
+            let lhs_i = lhs_values[i]
+
+            // Create RHS expression for accessing tuple element
+            let rhs_access = ParsedExpression::IndexedTuple(
+                expr: ParsedExpression::Var(name: tmp_name, span)
+                index: i
+                is_optional: false
+                span: lhs_i.span()
+            )
+
+            let nested_assignment = .typecheck_tuple_element_assignment(
+                lhs: lhs_i,
+                rhs: rhs_access,
+                scope_id,
+                safety_mode
+            )
+            assignments.push_values(&nested_assignment)
+        }
+
+        return CheckedStatement::DestructuringDeclaration(vars: assignments, var_decl: checked_tmp_decl, span)
     }
 
     fn interpreter(mut this) -> Interpreter => Interpreter::create(

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -7311,7 +7311,6 @@ struct Typechecker {
         safety_mode: SafetyMode
     ) throws -> [CheckedStatement] {
         match lhs {
-            // Simple variable assignment
             Var => {
                 let assign_stmt = ParsedStatement::Expression(
                     expr: ParsedExpression::BinaryOp(
@@ -7325,11 +7324,50 @@ struct Typechecker {
                 let checked_assign = .typecheck_statement(assign_stmt, scope_id, safety_mode)
                 return [checked_assign]
             }
-
-            // Nested tuple assignment - handle recursively
             JaktTuple(values) => {
-                // Create a temporary variable for the nested tuple RHS
-                let nested_tmp_name = format("__jakt_nested_tuple_tmp{}", .temp_var_count)
+                // Optimization: If all elements are simple variables, we can
+                // avoid introducing an intermediate temporary and directly index
+                // into the parent tuple expression (chaining IndexedTuple expressions).
+                mut no_nesting = true
+                for v in values {
+                    match v {
+                        Var => {},
+                        else => {
+                            no_nesting = false
+                            break
+                        }
+                    }
+                }
+
+                if no_nesting {
+                    mut direct_assignments: [CheckedStatement] = []
+                    for i in 0..values.size() {
+                        let nested_lhs = values[i]
+                        let nested_rhs = ParsedExpression::IndexedTuple(
+                            expr: rhs,
+                            index: i,
+                            is_optional: false,
+                            span: nested_lhs.span()
+                        )
+
+                        // Build assignment: nested_lhs = rhs.get<i>()
+                        let assign_stmt = ParsedStatement::Expression(
+                            expr: ParsedExpression::BinaryOp(
+                                lhs: nested_lhs,
+                                op: BinaryOperator::Assign,
+                                rhs: nested_rhs,
+                                span: nested_lhs.span()
+                            )
+                            span: nested_lhs.span()
+                        )
+                        let checked_assign = .typecheck_statement(assign_stmt, scope_id, safety_mode)
+                        direct_assignments.push(checked_assign)
+                    }
+                    return direct_assignments
+                }
+
+                // else: introduce an intermediate temporary for the nested tuple RHS
+                let nested_tmp_name = format("__jakt_tuple_assign_tmp{}", .temp_var_count)
                 .temp_var_count++
 
                 let nested_tmp_decl = ParsedVarDecl(
@@ -7367,8 +7405,6 @@ struct Typechecker {
 
                 return nested_assignments
             }
-
-            // Other expressions - not allowed in tuple destructuring
             else => {
                 .error("Left-hand side of tuple assignment must be variables or nested tuples", lhs.span())
                 return []

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -1481,7 +1481,7 @@ struct CheckedEnumVariantBinding {
 boxed enum CheckedStatement {
     Expression(expr: CheckedExpression, span: Span)
     Defer(statement: CheckedStatement, span: Span)
-    DestructuringAssignment(vars: [CheckedStatement], var_decl: CheckedStatement, span: Span)
+    DestructuringDeclaration(vars: [CheckedStatement], var_decl: CheckedStatement, span: Span)
     VarDecl(var_id: VarId, init: CheckedExpression, span: Span)
     If(condition: CheckedExpression, then_block: CheckedBlock, else_statement: CheckedStatement?, span: Span)
     Block(block: CheckedBlock, span: Span)

--- a/tests/typechecker/tuple_assignment_struct_fields_invalid.jakt
+++ b/tests/typechecker/tuple_assignment_struct_fields_invalid.jakt
@@ -1,0 +1,12 @@
+/// Expect:
+/// - error: "Left-hand side of tuple assignment must be variables or nested tuples"
+
+struct Point {
+    x: i64
+    y: i64
+}
+
+fn main() {
+    mut point = Point(x: 0, y: 0)
+    (point.x, point.y) = (10, 20)
+}


### PR DESCRIPTION
Currently we allow descructuring declarations for example:
```
let (x, y) = (1, 2)
```
This extends so that we can do destrucuting assignments for example:
```
mut x = 0
mut y = 0
(x, y) = (1, 2)
```
Additionally we can do nested destructuring for example:
```
mut x = 0
mut y = 0
mut z = 0
(x, (y, z)) = (1, (2, 3))
```
Will add this for declaration destructuring as part of a separate PR.

Note: This is similar to an older PR: https://github.com/SerenityOS/jakt/pull/1161
The main difference being that it specifically only allows `Var` or `JaktTuple` for nesting on the LHS. Also the earlier PR had fairly significant parser changes but this version handles it within the typechecker without introducing parsing changes.