### PR TITLE
editors/sublime: Migrate ST package to LspPlugin API

### DIFF
--- a/editors/sublime/lsp-client/plugin.py
+++ b/editors/sublime/lsp-client/plugin.py
@@ -1,15 +1,23 @@
-import os
-from lsp_utils import NpmClientHandler
+from pathlib import Path
+from LSP.plugin import LspPlugin, OnPreStartContext
+from lsp_utils import NodeManager
+from sublime_lib import ResourcePath
 
 def plugin_loaded():
-    LspYaktPlugin.setup()
+    LspYaktPlugin.register()
 
 def plugin_unloaded():
-    LspYaktPlugin.cleanup()
+    LspYaktPlugin.unregister()
 
-class LspYaktPlugin(NpmClientHandler):
-    package_name = __package__
-    server_directory = 'server'
-    server_binary_path = os.path.join(
-        server_directory, 'src/server.js'
-    )
+
+class LspYaktPlugin(LspPlugin):
+    @classmethod
+    def on_pre_start_async(cls, context: OnPreStartContext) -> None:
+        package_name = cls.plugin_storage_path.name
+        NodeManager.on_pre_start_async(
+            context,
+            cls.plugin_storage_path,
+            ResourcePath('Packages', package_name, 'server'),
+            Path('src', 'server.js'),
+            node_version_requirement='>=18',
+        )


### PR DESCRIPTION
Migrate to [LspPlugin API](https://lsp.sublimetext.io/migrating_to_lsp_plugin/).

There is a plan to remove `NpmClientHandler` so this migration should prevent the package from breaking in the future.

I have not tested those changes so please do before merging.