### PR TITLE
runtime: Detect symlinked directories in DirectoryIterator

### DIFF
--- a/runtime/jaktlib/platform/posix_fs.jakt
+++ b/runtime/jaktlib/platform/posix_fs.jakt
@@ -92,14 +92,21 @@ class DirectoryIterator implements(ThrowingIterable<(Path, bool)>) {
 
         mut builder = StringBuilder::create()
         mut is_directory = false
+        let dir_handle = .dir_fd
 
         unsafe {
             builder.append_c_string((*file).d_name)
 
             // FIXME: Extern constant support
             cpp {
-                "if ((*file).d_type == DT_DIR)"
-                "is_directory = true;"
+                "struct stat st;"
+                "if ((*file).d_type == DT_DIR) {"
+                "    is_directory = true;"
+                "} else if (((*file).d_type == DT_LNK || (*file).d_type == DT_UNKNOWN)"
+                "           && fstatat(dirfd(dir_handle), (*file).d_name, &st, 0) == 0"
+                "           && S_ISDIR(st.st_mode)) {"
+                "    is_directory = true;"
+                "}"
             }
         }
 


### PR DESCRIPTION
DirectoryIterator::next() only sets `is_directory` when `dirent.d_type == DT_DIR`. For entries whose `d_type` is `DT_LNK` (a symlink pointing at a directory) or `DT_UNKNOWN` (returned by file systems that don't populate `d_type`), a directory is misclassified as a regular file.

This breaks `install()` in selfhost/main.jakt: it takes the file-copy path for such an entry, opens it, and `read()`s it, which fails with `EISDIR`.

It reproduces during a normal SerenityOS toolchain build. runtime/CMakeLists.txt populates runtime/AK by symlinking every entry of SerenityOS' AK/ directory, so the AK/Math subdirectory becomes a symlink-to-directory. Environment: Linux (Fedora 44), reproduced via `Meta/serenity.sh build`.

Note: this surfaced after commit d4c79a3 : file(COPY ...) -> create_symlink. Alternatively reverting to copying AK would also resolve it. Glad to take whichever direction you'd prefer.