### PR TITLE
runtime: Null-terminate posix exec arguments

### DIFF
--- a/runtime/jaktlib/platform/posix_process.jakt
+++ b/runtime/jaktlib/platform/posix_process.jakt
@@ -43,6 +43,11 @@ fn start_background_process(anon args: [String]) throws -> Process {
             }
         }
     }
+    unsafe {
+        cpp {
+            "call_args[i] = nullptr;"
+        }
+    }
 
     let pid = fork()
     if pid == -1i32 {


### PR DESCRIPTION
Jakt uses `start_background_process()` to invoke external tools while building support libraries, including the target archiver used by cross builds. On POSIX, `execvp()` requires argv to end with a null pointer. The runtime allocated space for that terminator but did not write it, leaving the final argv slot uninitialized.

If `execvp()` reads past the intended argument list, process spawning can fail or pass garbage arguments to the tool being launched. I ran into this failure during jakt support library generation for SerenityOS aarch64 builds.

Write the null terminator explicitly before fork/exec so the child process sees the exact argument vector Jakt constructed.